### PR TITLE
fix: correct login_hint placement in epds-login skill

### DIFF
--- a/.agents/skills/epds-login/SKILL.md
+++ b/.agents/skills/epds-login/SKILL.md
@@ -20,9 +20,16 @@ The reference implementation is `packages/demo` in the [ePDS repository](https:/
 |                         | Flow 1                | Flow 2           |
 | ----------------------- | --------------------- | ---------------- |
 | **App collects email?** | Yes                   | No               |
-| **PAR includes**        | `login_hint=<email>`  | Nothing extra    |
+| **PAR includes**        | Nothing extra         | Nothing extra    |
 | **Auth server shows**   | OTP input directly    | Email form first |
 | **Redirect includes**   | `&login_hint=<email>` | Nothing extra    |
+
+> **Important:** `login_hint` must **never** go in the PAR body when the value is an
+> email address. The PDS core (AT Protocol layer) validates `login_hint` as an ATProto
+> identity (handle like `user.bsky.social` or DID like `did:plc:…`) and rejects email
+> addresses with `Invalid login_hint`. Put `login_hint` only on the **auth redirect URL**
+> — that request goes to the ePDS auth service (Better Auth layer), which accepts emails
+> and uses them to skip the email-collection step.
 
 ## Quick Start
 
@@ -65,7 +72,6 @@ const parBody = new URLSearchParams({
   state,
   code_challenge: codeChallenge,
   code_challenge_method: 'S256',
-  ...(email ? { login_hint: email } : {}), // Flow 1 only
 })
 
 // PAR always requires a DPoP nonce retry — handle it:
@@ -170,14 +176,15 @@ const { sub: userDid } = await tokenRes.json()
 
 ## Common Pitfalls
 
-| Pitfall                        | Fix                                                                            |
-| ------------------------------ | ------------------------------------------------------------------------------ |
-| Flash of email form            | Include `login_hint` in **both** PAR body **and** the auth redirect URL        |
-| `auth_failed` immediately      | Check Caddy logs — likely a DNS/upstream name mismatch                         |
-| DPoP rejected                  | Always implement the nonce retry loop (ePDS always demands a nonce)            |
-| `Cannot find package` in tests | Run `pnpm build` before `pnpm test` — vitest needs `dist/`                     |
-| Token exchange fails           | Restore the DPoP key pair from the session cookie, don't generate a new one    |
-| Double OTP email               | Normal on duplicate GET — `otpAlreadySent` flag suppresses auto-send on reload |
+| Pitfall                        | Fix                                                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Flash of email form            | Include `login_hint` on the **auth redirect URL only** (never in the PAR body)                 |
+| `Invalid login_hint` from PAR  | Remove `login_hint` from the PAR body — PDS core only accepts ATProto handles/DIDs, not emails |
+| `auth_failed` immediately      | Check Caddy logs — likely a DNS/upstream name mismatch                                         |
+| DPoP rejected                  | Always implement the nonce retry loop (ePDS always demands a nonce)                            |
+| `Cannot find package` in tests | Run `pnpm build` before `pnpm test` — vitest needs `dist/`                                     |
+| Token exchange fails           | Restore the DPoP key pair from the session cookie, don't generate a new one                    |
+| Double OTP email               | Normal on duplicate GET — `otpAlreadySent` flag suppresses auto-send on reload                 |
 
 ## Handles
 

--- a/.agents/skills/epds-login/references/flows.md
+++ b/.agents/skills/epds-login/references/flows.md
@@ -19,10 +19,15 @@ and your callback receives an authorization code to exchange for tokens.
 
 1. User enters their email in your app and clicks "Sign in"
 2. Your login handler:
+
    a. Generates a DPoP key pair and PKCE verifier (see [dpop-pkce.md](dpop-pkce.md))
-   b. POSTs to `/oauth/par` with `login_hint=<email>` (see code below)
+
+   b. POSTs to `/oauth/par`
+
    c. Stores DPoP private key, code verifier, and state in a signed session cookie
+
    d. Redirects the browser to `/oauth/authorize?...&login_hint=<email>`
+
 3. The auth server sees the email, immediately sends the OTP, and shows the user
    the code entry screen (no email form shown)
 4. User reads OTP from email and submits it
@@ -60,7 +65,6 @@ export async function handleLogin(email: string) {
     state,
     code_challenge: codeChallenge,
     code_challenge_method: 'S256',
-    login_hint: email, // Flow 1: include the email
   })
 
   // ePDS always requires a nonce on the first attempt — retry automatically
@@ -109,10 +113,6 @@ export async function handleLogin(email: string) {
 }
 ```
 
-> **Important:** Pass `login_hint` in both the PAR body _and_ the redirect URL.
-> Missing it from the redirect URL causes a flash of the email form before the
-> OTP screen appears.
-
 ---
 
 ## Flow 2 — Auth server collects the email
@@ -134,7 +134,7 @@ export async function handleLogin(email: string) {
 
 ### Login handler code
 
-Same as Flow 1 but omit `login_hint` from the PAR body and the redirect URL:
+Same as Flow 1 except `login_hint` is not added to the redirect URL. Flow 1 sends `login_hint` only on the redirect URL (not in the PAR body); Flow 2 omits `login_hint` from both the PAR body and the redirect URL:
 
 ```typescript
 const parBody = new URLSearchParams({
@@ -244,7 +244,7 @@ sequenceDiagram
     participant Inbox as User's Inbox
 
     User->>App: Enters email, clicks Sign in
-    App->>PDS: POST /oauth/par (with email)
+    App->>PDS: POST /oauth/par
     PDS-->>App: { request_uri }
     App-->>User: Redirect to /oauth/authorize?...&login_hint=email
 

--- a/packages/demo/src/__tests__/oauth-login-flow2.test.ts
+++ b/packages/demo/src/__tests__/oauth-login-flow2.test.ts
@@ -40,7 +40,10 @@ vi.mock('next/server', () => {
     cookies: MockCookies
     _url: string
 
-    constructor(body: string | null, init?: { status?: number; headers?: Record<string, string> }) {
+    constructor(
+      body: string | null,
+      init?: { status?: number; headers?: Record<string, string> },
+    ) {
       this.status = init?.status ?? 200
       this.headers = new MockHeaders()
       this.cookies = new MockCookies()
@@ -102,7 +105,7 @@ describe('OAuth login route (Flow 2)', () => {
       headers: new Headers(),
     })
 
-    const resp = await GET(makeRequest()) as unknown as {
+    const resp = (await GET(makeRequest())) as unknown as {
       status: number
       _url: string
       cookies: { entries(): Iterable<[string, { value: string }]> }
@@ -123,14 +126,16 @@ describe('OAuth login route (Flow 2)', () => {
 
   it('PAR body has no login_hint in Flow 2', async () => {
     let capturedBody = ''
-    global.fetch = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
-      if (init?.body) capturedBody = init.body as string
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(MOCK_PAR_RESPONSE),
-        headers: new Headers(),
+    global.fetch = vi
+      .fn()
+      .mockImplementation((_url: string, init?: RequestInit) => {
+        if (init?.body) capturedBody = init.body as string
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_PAR_RESPONSE),
+          headers: new Headers(),
+        })
       })
-    })
 
     await GET(makeRequest())
 
@@ -157,7 +162,7 @@ describe('OAuth login route (Flow 2)', () => {
       })
     })
 
-    const resp = await GET(makeRequest()) as unknown as {
+    const resp = (await GET(makeRequest())) as unknown as {
       status: number
       _url: string
     }
@@ -170,9 +175,12 @@ describe('OAuth login route (Flow 2)', () => {
   })
 
   it('returns 429 when rate limited', async () => {
-    vi.mocked(checkRateLimit).mockReturnValue({ allowed: false, retryAfter: 60 })
+    vi.mocked(checkRateLimit).mockReturnValue({
+      allowed: false,
+      retryAfter: 60,
+    })
 
-    const resp = await GET(makeRequest()) as unknown as {
+    const resp = (await GET(makeRequest())) as unknown as {
       status: number
       headers: { get(k: string): string | null }
     }
@@ -188,8 +196,10 @@ describe('OAuth login route (Flow 2)', () => {
       headers: new Headers(),
     })
 
-    const resp = await GET(makeRequest()) as unknown as {
-      cookies: { get(name: string): { value: string; options: unknown } | undefined }
+    const resp = (await GET(makeRequest())) as unknown as {
+      cookies: {
+        get(name: string): { value: string; options: unknown } | undefined
+      }
     }
 
     const cookie = resp.cookies.get(OAUTH_COOKIE)

--- a/packages/demo/src/__tests__/validation.test.ts
+++ b/packages/demo/src/__tests__/validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { validateEmail, validateHandle, sanitizeForLog } from '../lib/validation'
+import {
+  validateEmail,
+  validateHandle,
+  sanitizeForLog,
+} from '../lib/validation'
 
 describe('validateEmail', () => {
   it('accepts valid emails', () => {


### PR DESCRIPTION
## Summary

- `login_hint` must go on the **auth redirect URL only**, never in the PAR body
- PDS core validates `login_hint` as an ATProto identity (handle/DID) and rejects email addresses
- Updated flow table, code examples, pitfalls, and sequence diagrams in `SKILL.md` and `references/flows.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified ePDS login flows: login_hint must be placed on the auth redirect URL only, and must not be included in the PAR request body.
  * Updated guidance, examples and sequence diagrams for both flows (immediate OTP flow and server-collected email flow).
  * Consolidated pitfalls and added explicit warning about email/handle placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->