### PR TITLE
fix: use filtered pnpm install for Vercel demo build

### DIFF
--- a/packages/demo/vercel.json
+++ b/packages/demo/vercel.json
@@ -1,0 +1,3 @@
+{
+  "installCommand": "pnpm install --filter @certified-app/demo..."
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` to `packages/demo/` with a filtered install command: `pnpm install --filter @certified-app/demo...`
- The monorepo-wide `pnpm install` was pulling in `better-sqlite3`, which fails to compile its native addon on Vercel's Node 24 (V8 API incompatibility)
- The demo package has zero workspace dependencies, so filtering to only its deps avoids the native build entirely

## Root cause

Vercel upgraded to Node 24, and `better-sqlite3`'s C++ bindings use a `v8::Object::Get()` signature that was removed. Since the demo doesn't need `better-sqlite3` at all, the fix is to not install it rather than pin Node versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for the demo application to ensure proper build and installation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->