### PR TITLE
feat: restyle login page to match Bluesky OAuth UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,8 +205,16 @@ import { AuthServiceContext } from './context.js'
 
 - Use `bd` (beads) for all task tracking — **not** TodoWrite or markdown files.
 - `bd ready` — show available work; `bd create` — new issue; `bd close` — done.
-- `bd export -o .beads/issues.jsonl` to export issues (commit this file).
 - Do **not** use `bd sync` (obsolete).
+- The beads database uses **dolt** as its backend. `.beads/backup/` (normalised
+  JSONL per table) is tracked in git — **not** `.beads/issues.jsonl` (legacy
+  denormalised export, no longer the source of truth).
+- During rebases/merges, **never** resolve `.beads/` conflicts manually or with
+  `merge=ours`. The `merge=beads` driver must be registered; if it isn't,
+  the merge will fail — fix the driver registration rather than working around it.
+- **TODO**: verify whether `merge=beads` is still the right strategy for
+  `.beads/backup/*.jsonl` now that dolt is the backend, or whether conflicts
+  there should simply never happen (dolt is source of truth).
 
 ## Key Gotchas
 

--- a/packages/auth-service/src/better-auth.ts
+++ b/packages/auth-service/src/better-auth.ts
@@ -22,8 +22,6 @@ import { ensurePdsUrl } from './lib/pds-url.js'
 
 export type BetterAuthInstance = ReturnType<typeof createBetterAuth>
 
-export type BetterAuthInstance = ReturnType<typeof createBetterAuth>
-
 const logger = createLogger('auth:better-auth')
 
 const AUTH_FLOW_COOKIE = 'epds_auth_flow'

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -217,7 +217,7 @@ function renderLoginPage(opts: {
   const b = opts.branding
   const appName = b.client_name || opts.clientName || 'Certified'
   const logoHtml = b.logo_uri
-    ? `<img src="${escapeHtml(b.logo_uri)}" alt="${escapeHtml(appName)}" class="client-logo" aria-hidden="true">`
+    ? `<img src="${escapeHtml(b.logo_uri)}" alt="${escapeHtml(appName)}" class="client-logo">`
     : ''
 
   const inputProps = buildOtpInputProps(opts.otpLength, opts.otpCharset)
@@ -791,8 +791,13 @@ function renderLoginPage(opts: {
                   </svg>
                 </span>
                 <input type="text" id="code" name="code" class="input-field otp-input" required
-                       maxlength="8" pattern="[0-9]{8}" inputmode="numeric"
-                       autocomplete="one-time-code" placeholder="00000000" ${opts.initialStep === 'otp' ? 'autofocus' : ''}>
+                       maxlength="${opts.otpLength}"
+                       pattern="${inputProps.pattern}"
+                       inputmode="${inputProps.inputmode}"
+                       autocomplete="one-time-code"
+                       autocapitalize="${inputProps.autocapitalize}"
+                       placeholder="${inputProps.placeholder}"
+                       ${opts.initialStep === 'otp' ? 'autofocus' : ''}>
               </div>
             </div>
           </div>

--- a/packages/auth-service/src/routes/recovery.ts
+++ b/packages/auth-service/src/routes/recovery.ts
@@ -35,6 +35,7 @@ export function createRecoveryRouter(
 
   router.get('/auth/recover', (req: Request, res: Response) => {
     const requestUri = req.query.request_uri as string | undefined
+    const clientId = req.query.client_id as string | undefined
 
     if (!requestUri) {
       res.status(400).send(renderError('Missing request_uri parameter'))
@@ -44,6 +45,7 @@ export function createRecoveryRouter(
     res.type('html').send(
       renderRecoveryForm({
         requestUri,
+        clientId,
         csrfToken: res.locals.csrfToken,
       }),
     )
@@ -52,11 +54,13 @@ export function createRecoveryRouter(
   router.post('/auth/recover', async (req: Request, res: Response) => {
     const email = ((req.body.email as string) || '').trim().toLowerCase()
     const requestUri = req.body.request_uri as string
+    const clientId = (req.body.client_id as string | undefined) || undefined
 
     if (!email || !requestUri) {
       res.status(400).send(
         renderRecoveryForm({
           requestUri: requestUri || '',
+          clientId,
           csrfToken: res.locals.csrfToken,
           error: 'Email and request URI are required.',
         }),
@@ -68,6 +72,7 @@ export function createRecoveryRouter(
       res.status(400).send(
         renderRecoveryForm({
           requestUri,
+          clientId,
           csrfToken: res.locals.csrfToken,
           error: 'Please enter a valid email address.',
         }),
@@ -111,6 +116,7 @@ export function createRecoveryRouter(
             email,
             csrfToken: res.locals.csrfToken,
             requestUri,
+            clientId,
             otpLength,
             otpCharset,
           }),
@@ -122,6 +128,7 @@ export function createRecoveryRouter(
             email,
             csrfToken: res.locals.csrfToken,
             requestUri,
+            clientId,
             error: 'Failed to send code. Please try again.',
             otpLength,
             otpCharset,
@@ -135,6 +142,7 @@ export function createRecoveryRouter(
           email,
           csrfToken: res.locals.csrfToken,
           requestUri,
+          clientId,
           otpLength,
           otpCharset,
         }),
@@ -201,12 +209,16 @@ export function createRecoveryRouter(
   return router
 }
 
-function renderRecoveryForm(opts: {
+export function renderRecoveryForm(opts: {
   requestUri: string
   csrfToken: string
+  clientId?: string
   error?: string
 }): string {
   const encodedUri = encodeURIComponent(opts.requestUri)
+  const clientIdParam = opts.clientId
+    ? `&client_id=${encodeURIComponent(opts.clientId)}`
+    : ''
   const errorHtml = opts.error
     ? `<div class="admonition error" role="alert">
         <span class="admonition-icon" aria-hidden="true">
@@ -239,6 +251,7 @@ function renderRecoveryForm(opts: {
       <form method="POST" action="/auth/recover">
         <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
         <input type="hidden" name="request_uri" value="${escapeHtml(opts.requestUri)}">
+        ${opts.clientId ? `<input type="hidden" name="client_id" value="${escapeHtml(opts.clientId)}">` : ''}
         <div class="field">
           <label class="field-label" for="email">Backup email address</label>
           <div class="input-container">
@@ -254,7 +267,7 @@ function renderRecoveryForm(opts: {
           </div>
         </div>
         <div class="form-actions">
-          <a href="/oauth/authorize?request_uri=${encodedUri}" class="link-btn">Back to sign in</a>
+          <a href="/oauth/authorize?request_uri=${encodedUri}${clientIdParam}" class="link-btn">Back to sign in</a>
           <button type="submit" class="btn-primary">Send Recovery Code</button>
         </div>
       </form>
@@ -264,16 +277,20 @@ function renderRecoveryForm(opts: {
 </html>`
 }
 
-function renderOtpForm(opts: {
+export function renderOtpForm(opts: {
   email: string
   csrfToken: string
   requestUri: string
   otpLength: number
   otpCharset: 'numeric' | 'alphanumeric'
+  clientId?: string
   error?: string
 }): string {
   const maskedEmail = maskEmail(opts.email)
   const encodedUri = encodeURIComponent(opts.requestUri)
+  const clientIdParam = opts.clientId
+    ? `&client_id=${encodeURIComponent(opts.clientId)}`
+    : ''
   const inputProps = buildOtpInputProps(opts.otpLength, opts.otpCharset)
   const errorHtml = opts.error
     ? `<div class="admonition error" role="alert">
@@ -330,13 +347,13 @@ function renderOtpForm(opts: {
         </div>
         <div class="form-actions">
           <div class="otp-links">
-            <a href="/oauth/authorize?request_uri=${encodedUri}" class="link-btn">Back to sign in</a>
+            <a href="/oauth/authorize?request_uri=${encodedUri}${clientIdParam}" class="link-btn">Back to sign in</a>
             <span class="otp-links-dot">·</span>
-            <form method="POST" action="/auth/recover" class="inline-form">
+             <form method="POST" action="/auth/recover" class="inline-form">
               <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
               <input type="hidden" name="request_uri" value="${escapeHtml(opts.requestUri)}">
               <input type="hidden" name="email" value="${escapeHtml(opts.email)}">
-              <button type="submit" class="link-btn">Resend Code</button>
+              <button type="submit" class="link-btn" formnovalidate>Resend Code</button>
             </form>
           </div>
           <button type="submit" class="btn-primary">Verify</button>


### PR DESCRIPTION
## Summary
- Restyle the auth-service login page (`GET /oauth/authorize`) from a basic centered-card layout to the Bluesky `@atproto/oauth-provider-ui` split-panel design
- CSS custom property token system with 15-stop contrast scale and automatic dark mode support
- atproto-style input components (InputContainer pattern with icons and focus rings), admonition error/success messages

## Changes
**Single file changed:** `packages/auth-service/src/routes/login-page.ts` (only `renderLoginPage()` — route handler untouched)

### Layout
- Split-panel: left title panel with "Sign in with Certified" branding, right form panel
- Responsive: stacks vertically on mobile (<768px), side-by-side on desktop
- Title panel content right-aligned on desktop, text left-aligned within

### Branding
- "Sign in with Certified" as plain `<h1>` text (no static SVG/PNG assets)
- Logo conditional on `b.logo_uri` from OAuth client metadata (no hardcoded `/static/` references)
- Subtitle: "Sign in for the interop using Certified"

### Bug fixes included
- Recovery link now passes actual PAR `request_uri` instead of `pdsPublicUrl`
- Dark mode placeholder uses CSS token (`var(--color-text-light)`) instead of hardcoded gray
- `min-width: 100%` instead of `100vw` (fixes horizontal scrollbar on Windows/Linux)
- Conditional `autofocus` — email input on email step, OTP input on OTP step

### What's preserved
- All existing functionality: email OTP flow, social login, recovery link, login_hint auto-send
- Route handler logic unchanged
- `renderLoginPage` signature unchanged (only `requestUri` added for recovery link fix)
<img width="1819" height="882" alt="login page" src="https://github.com/user-attachments/assets/af90227d-cf8d-4b45-a91e-898684f251ad" />
<img width="1847" height="939" alt="recovery page" src="https://github.com/user-attachments/assets/2a20dfda-9c27-4f6d-8391-4a0d4d3fb025" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-panel login and recovery pages with left branding panel
  * Request URI preserved through the client flow
  * Improved OTP flow: client-side handling, resend disabled during auto-send, and clearer success states

* **Style**
  * Overhauled layout, spacing and centralized CSS token theming (responsive, dark/light)
  * Updated button labels/capitalization and icon/image ARIA attributes

* **Bug Fixes**
  * Unified, accessible error/admonition banners and consistent form behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->