### PR TITLE
fix: require consent on account creation

### DIFF
--- a/packages/auth-service/src/routes/complete.ts
+++ b/packages/auth-service/src/routes/complete.ts
@@ -93,8 +93,7 @@ export function createCompleteRouter(
     const isNewAccount = !did
 
     const clientId = flow.clientId ?? ''
-    const needsConsent =
-      !isNewAccount && clientId && !ctx.db.hasClientLogin(email, clientId)
+    const needsConsent = clientId && !ctx.db.hasClientLogin(email, clientId)
 
     if (needsConsent) {
       // Step 5a: Redirect to consent screen, passing flow_id so consent can

--- a/packages/pds-core/src/index.ts
+++ b/packages/pds-core/src/index.ts
@@ -65,7 +65,6 @@ async function main() {
     const requestUri = req.query.request_uri as string
     const email = ((req.query.email as string) || '').toLowerCase()
     const approved = req.query.approved === '1'
-    const _isNewAccount = req.query.new_account === '1'
     const ts = req.query.ts as string
     const sig = req.query.sig as string
 


### PR DESCRIPTION
Previously the condition to show the consent page was `if !newAccount` but this doesnt make sense since its still good to display what perms the app is asking.

Also the stock pds also displays the consent page even if theyre creating a new account

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified consent requirement logic for client authentication flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->