### PR TITLE
fix: use Taplo directive for schema in railway.toml files

### DIFF
--- a/packages/auth-service/railway.toml
+++ b/packages/auth-service/railway.toml
@@ -1,4 +1,4 @@
-$schema = "https://railway.com/railway.schema.json"
+#:schema https://railway.com/railway.schema.json
 
 [build]
 builder = "DOCKERFILE"

--- a/packages/demo/railway.toml
+++ b/packages/demo/railway.toml
@@ -1,4 +1,4 @@
-$schema = "https://railway.com/railway.schema.json"
+#:schema https://railway.com/railway.schema.json
 
 [build]
 builder = "DOCKERFILE"

--- a/packages/pds-core/railway.toml
+++ b/packages/pds-core/railway.toml
@@ -1,4 +1,4 @@
-$schema = "https://railway.com/railway.schema.json"
+#:schema https://railway.com/railway.schema.json
 
 [build]
 builder = "DOCKERFILE"


### PR DESCRIPTION
## Problem

Railway's TOML parser rejects `$schema` as a bare key:

```
Failed to parse TOML file packages/auth-service/railway.toml:
(1, 1): parsing error: keys cannot contain $ character
```

The `$` character is not valid in bare TOML keys per the TOML spec. The `$schema` convention is a JSON thing — it doesn't work in TOML.

## Fix

Replace the bare `$schema` key with the `#:schema` Taplo directive comment in all three `railway.toml` files. This provides the same editor schema validation (autocompletion, linting) via Taplo-compatible editors without breaking the TOML parser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration schema references across multiple packages for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->