### PR TITLE
fix: honour PORT env var for Railway healthcheck compatibility

### DIFF
--- a/packages/auth-service/.env.example
+++ b/packages/auth-service/.env.example
@@ -40,6 +40,13 @@ PDS_ADMIN_PASSWORD=
 
 # Subdomain for the auth UI (must be a subdomain of PDS_HOSTNAME)
 AUTH_HOSTNAME=auth.pds.example
+
+# Port the auth service listens on.
+# AUTH_PORT is the service-specific variable.  PORT is used by Railway
+# for healthchecks; when AUTH_PORT is unset, the code falls back to
+# PORT automatically.  Both are set here so the file works for Docker
+# (needs AUTH_PORT) and Railway paste-in (needs PORT).
+PORT=3001
 AUTH_PORT=3001
 
 # Auth service secrets (generate with: openssl rand -hex 32)

--- a/packages/auth-service/src/__tests__/resolve-port.test.ts
+++ b/packages/auth-service/src/__tests__/resolve-port.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests for resolveAuthPort().
+ *
+ * Verifies the AUTH_PORT > PORT > default priority chain without
+ * touching process.env directly.
+ */
+import { describe, it, expect } from 'vitest'
+import { resolveAuthPort } from '../lib/resolve-port.js'
+
+describe('resolveAuthPort', () => {
+  it('returns AUTH_PORT when set', () => {
+    expect(resolveAuthPort({ AUTH_PORT: '4000', PORT: '5000' })).toBe(4000)
+  })
+
+  it('falls back to PORT when AUTH_PORT is unset', () => {
+    expect(resolveAuthPort({ PORT: '8080' })).toBe(8080)
+  })
+
+  it('falls back to 3001 when neither AUTH_PORT nor PORT is set', () => {
+    expect(resolveAuthPort({})).toBe(3001)
+  })
+
+  it('returns 3001 when AUTH_PORT is empty string', () => {
+    expect(resolveAuthPort({ AUTH_PORT: '' })).toBe(3001)
+  })
+
+  it('returns PORT value when AUTH_PORT is empty string', () => {
+    expect(resolveAuthPort({ AUTH_PORT: '', PORT: '9000' })).toBe(9000)
+  })
+
+  it('parses port as integer (ignores decimals)', () => {
+    expect(resolveAuthPort({ AUTH_PORT: '3001.9' })).toBe(3001)
+  })
+})

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -16,6 +16,7 @@ import { createAccountLoginRouter } from './routes/account-login.js'
 import { createAccountSettingsRouter } from './routes/account-settings.js'
 import { createCompleteRouter } from './routes/complete.js'
 import { createChooseHandleRouter } from './routes/choose-handle.js'
+import { resolveAuthPort } from './lib/resolve-port.js'
 
 const logger = createLogger('auth-service')
 
@@ -119,7 +120,7 @@ export function createAuthService(config: AuthServiceConfig): {
 async function main() {
   const config: AuthServiceConfig = {
     hostname: process.env.AUTH_HOSTNAME || 'auth.localhost',
-    port: parseInt(process.env.AUTH_PORT || '3001', 10),
+    port: resolveAuthPort(),
     sessionSecret:
       process.env.AUTH_SESSION_SECRET || 'dev-session-secret-change-me',
     csrfSecret: process.env.AUTH_CSRF_SECRET || 'dev-csrf-secret-change-me',

--- a/packages/auth-service/src/lib/resolve-port.ts
+++ b/packages/auth-service/src/lib/resolve-port.ts
@@ -1,0 +1,9 @@
+/**
+ * Resolves the port the auth-service should listen on.
+ *
+ * Priority: AUTH_PORT > PORT > default (3001).
+ * PORT is the variable Railway injects for healthcheck probing.
+ */
+export function resolveAuthPort(env: NodeJS.ProcessEnv = process.env): number {
+  return parseInt(env.AUTH_PORT || env.PORT || '3001', 10)
+}

--- a/packages/pds-core/.env.example
+++ b/packages/pds-core/.env.example
@@ -39,6 +39,12 @@ AUTH_HOSTNAME=auth.pds.example
 
 # -- PDS-core only --
 
+# Port the PDS listens on.
+# PDS_PORT is read by @atproto/pds.  PORT is used by Railway for
+# healthchecks; when PDS_PORT is unset, the code copies PORT into it
+# automatically.  Both are set here so the file works for Docker
+# (needs PDS_PORT) and Railway paste-in (needs PORT).
+PORT=3000
 PDS_PORT=3000
 PDS_DATA_DIRECTORY=/data
 

--- a/packages/pds-core/src/__tests__/resolve-port.test.ts
+++ b/packages/pds-core/src/__tests__/resolve-port.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests for applyPdsPortFallback().
+ *
+ * Verifies the PORT → PDS_PORT fallback logic without mutating process.env
+ * directly — the helper accepts an env object for testability.
+ */
+import { describe, it, expect } from 'vitest'
+import { applyPdsPortFallback } from '../lib/resolve-port.js'
+
+describe('applyPdsPortFallback', () => {
+  it('copies PORT to PDS_PORT when PDS_PORT is unset', () => {
+    const env: NodeJS.ProcessEnv = { PORT: '8080' }
+    applyPdsPortFallback(env)
+    expect(env.PDS_PORT).toBe('8080')
+  })
+
+  it('does not overwrite PDS_PORT when it is already set', () => {
+    const env: NodeJS.ProcessEnv = { PDS_PORT: '3000', PORT: '8080' }
+    applyPdsPortFallback(env)
+    expect(env.PDS_PORT).toBe('3000')
+  })
+
+  it('does nothing when neither PDS_PORT nor PORT is set', () => {
+    const env: NodeJS.ProcessEnv = {}
+    applyPdsPortFallback(env)
+    expect(env.PDS_PORT).toBeUndefined()
+  })
+
+  it('does nothing when PORT is unset even if PDS_PORT is unset', () => {
+    const env: NodeJS.ProcessEnv = { OTHER: 'value' }
+    applyPdsPortFallback(env)
+    expect(env.PDS_PORT).toBeUndefined()
+  })
+})

--- a/packages/pds-core/src/index.ts
+++ b/packages/pds-core/src/index.ts
@@ -16,6 +16,12 @@
 import * as dotenv from 'dotenv'
 dotenv.config()
 
+// @atproto/pds reads PDS_PORT, not PORT.  On Railway the platform injects
+// PORT and uses it for healthchecks, so fall back to PORT when PDS_PORT is
+// not explicitly set.  This must happen before readEnv().
+import { applyPdsPortFallback } from './lib/resolve-port.js'
+applyPdsPortFallback()
+
 import type * as http from 'node:http'
 import { randomBytes, timingSafeEqual, createHash } from 'node:crypto'
 import { PDS, envToCfg, envToSecrets, readEnv } from '@atproto/pds'

--- a/packages/pds-core/src/lib/resolve-port.ts
+++ b/packages/pds-core/src/lib/resolve-port.ts
@@ -1,0 +1,17 @@
+/**
+ * Applies Railway PORT fallback for @atproto/pds.
+ *
+ * @atproto/pds reads PDS_PORT, not PORT. Railway injects PORT and uses it
+ * to probe healthchecks, so we copy PORT → PDS_PORT when PDS_PORT is not
+ * explicitly set. This must be called before readEnv().
+ *
+ * Accepts an env object so the behaviour can be tested without mutating
+ * process.env directly.
+ */
+export function applyPdsPortFallback(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (!env.PDS_PORT && env.PORT) {
+    env.PDS_PORT = env.PORT
+  }
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -98,6 +98,22 @@ inject_derived_vars() {
   if var_belongs PDS_EMAIL_SMTP_URL && [ -n "$smtp_url" ]; then
     set_env_var PDS_EMAIL_SMTP_URL "$smtp_url" "$target"
   fi
+
+  # PORT — Railway uses this for healthchecks.  Derive from the service-
+  # specific port variable in the top-level .env so the per-package .env
+  # has the right value for Railway paste-in.
+  if var_belongs PORT; then
+    # pds-core uses PDS_PORT, auth-service uses AUTH_PORT
+    local port_val=""
+    if [[ "$target" == *pds-core* ]]; then
+      port_val=$(read_env_var PDS_PORT .env)
+    elif [[ "$target" == *auth-service* ]]; then
+      port_val=$(read_env_var AUTH_PORT .env)
+    fi
+    if [ -n "$port_val" ]; then
+      set_env_var PORT "$port_val" "$target"
+    fi
+  fi
 }
 
 # ── Interactive prompts ──


### PR DESCRIPTION
## Summary

Railway injects a `PORT` environment variable and uses it to probe healthchecks. Both pds-core and auth-service were ignoring `PORT` in favour of their own service-specific variables (`PDS_PORT`, `AUTH_PORT`), causing healthchecks to fail with "service unavailable" on new Railway environments (the app listens on one port, Railway probes a different one).

## Changes

- **pds-core**: copies `PORT` into `PDS_PORT` before `readEnv()` when `PDS_PORT` is not explicitly set, so `@atproto/pds` picks up the Railway-injected port
- **auth-service**: port resolution now reads `AUTH_PORT || PORT || '3001'` (was `AUTH_PORT || '3001'`)
- **`.env.example` files**: add `PORT` alongside the service-specific variable with comments explaining the relationship — both are set so the files work for Docker (needs `PDS_PORT`/`AUTH_PORT`) and Railway paste-in (needs `PORT`)
- **`setup.sh`**: `inject_derived_vars()` now writes `PORT` into each per-package `.env`, derived from `PDS_PORT` (for pds-core) or `AUTH_PORT` (for auth-service) in the top-level `.env`

## Context

The dev environment on Railway was forked from staging. Both pds-core and auth-service failed healthchecks because Railway probes the port specified by `$PORT`, but the services listen on `PDS_PORT=3000` / `AUTH_PORT=3001`. The staging environment happened to work because `PORT` was manually set there. This fix makes the services honour `PORT` as a fallback so new environments work out of the box.