### PR TITLE
fix(auth): widen handle picker for long PDS domain names

### DIFF
--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -564,8 +564,8 @@ const SETTINGS_CSS = `
   .session-agent { display: block; font-size: 13px; color: #333; }
   .session-date { display: block; font-size: 12px; color: #999; }
   .info { color: #666; font-size: 14px; line-height: 1.5; margin-bottom: 12px; }
-  .inline-form { display: flex; gap: 8px; margin-top: 12px; }
-  .inline-form input[type="email"] { flex: 1; padding: 8px 12px; border: 1px solid #ddd; border-radius: 6px; font-size: 14px; }
+  .inline-form { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+  .inline-form input[type="text"], .inline-form input[type="email"] { flex: 1; padding: 8px 12px; border: 1px solid #ddd; border-radius: 6px; font-size: 14px; min-width: 120px; }
   .btn-primary-sm { padding: 8px 16px; background: #0f1828; color: white; border: none; border-radius: 6px; font-size: 14px; cursor: pointer; white-space: nowrap; }
   .btn-primary-sm:hover { background: #1a2a40; }
   .btn-secondary { color: #0f1828; background: none; border: none; font-size: 14px; cursor: pointer; text-decoration: underline; }
@@ -573,7 +573,7 @@ const SETTINGS_CSS = `
   .btn-danger:hover { background: #c82333; }
   .btn-danger-sm { padding: 4px 12px; background: none; color: #dc3545; border: 1px solid #dc3545; border-radius: 4px; font-size: 12px; cursor: pointer; }
   .btn-danger-sm:hover { background: #dc3545; color: white; }
-  .handle-suffix { font-size: 14px; color: #666; white-space: nowrap; align-self: center; }
+  .handle-suffix { font-size: 14px; color: #666; white-space: nowrap; align-self: center; overflow: hidden; text-overflow: ellipsis; }
   .danger-zone { border-color: #f5c6cb; }
   .danger-zone h2 { color: #dc3545; }
   details summary { list-style: none; }

--- a/packages/auth-service/src/routes/choose-handle.ts
+++ b/packages/auth-service/src/routes/choose-handle.ts
@@ -428,15 +428,21 @@ function renderChooseHandlePage(
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
-    .container { background: white; border-radius: 12px; padding: 40px; max-width: 420px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+    .container { background: white; border-radius: 12px; padding: 40px; max-width: max(420px, min(90vw, 600px)); width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
     h1 { font-size: 24px; margin-bottom: 8px; color: #111; }
     .subtitle { color: #666; margin-bottom: 24px; font-size: 15px; line-height: 1.5; }
     .field { margin-bottom: 16px; }
     .field label { display: block; font-size: 14px; font-weight: 500; color: #333; margin-bottom: 6px; }
     .handle-row { display: flex; align-items: center; gap: 0; border: 1px solid #ddd; border-radius: 8px; overflow: hidden; background: white; }
     .handle-row:focus-within { border-color: #0f1828; }
-    .handle-row input { flex: 1; padding: 10px 12px; border: none; font-size: 16px; outline: none; background: transparent; min-width: 0; }
-    .handle-suffix { padding: 10px 12px; background: #f8f9fa; color: #555; font-size: 15px; white-space: nowrap; border-left: 1px solid #ddd; }
+    .handle-row input { flex: 1; padding: 10px 12px; border: none; font-size: 16px; outline: none; background: transparent; min-width: 120px; }
+    .handle-suffix { padding: 10px 12px; background: #f8f9fa; color: #555; font-size: 15px; white-space: nowrap; border-left: 1px solid #ddd; overflow: hidden; text-overflow: ellipsis; }
+    @media (max-width: 480px) {
+      .container { padding: 24px; }
+      .handle-row { flex-wrap: wrap; }
+      .handle-row input { min-width: 100%; border-bottom: 1px solid #ddd; }
+      .handle-suffix { width: 100%; border-left: none; }
+    }
     .status { min-height: 20px; font-size: 14px; margin-top: 6px; }
     .status.available { color: #28a745; }
     .status.taken { color: #dc3545; }


### PR DESCRIPTION
## Summary

- The handle picker dialog container was fixed at `max-width: 420px`, which causes the text input to be crushed to near-zero width when the PDS domain suffix is long (e.g. Railway auto-generated domains like `certified-apppds-core-pr-base.up.railway.app`)
- The container now grows up to 600px when needed via `max(420px, min(90vw, 600px))`
- The handle input has `min-width: 120px` to guarantee a usable typing area
- On narrow screens (≤480px), the input and domain suffix stack vertically
- Same fixes applied to the account-settings handle change form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved form layout with better wrapping and input field sizing for account settings.
  * Enhanced handle picker responsiveness with mobile-friendly adjustments to spacing and layout.
  * Added text truncation for long handle suffixes across both account settings and handle selection pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->