### PR TITLE
fix: disable buttons once approve/deny clicked on consent

### DIFF
--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -71,6 +71,8 @@ jobs:
           E2E_MAILPIT_URL: ${{ steps.urls.outputs.mailpit_url }}
           E2E_MAILPIT_USER: ${{ secrets.E2E_MAILPIT_USER }}
           E2E_MAILPIT_PASS: ${{ secrets.E2E_MAILPIT_PASS }}
+          OTP_LENGTH: '6'
+          OTP_CHARSET: 'numeric'
           E2E_HEADLESS: 'true'
         run: pnpm test:e2e:headless
 

--- a/packages/auth-service/src/routes/consent.ts
+++ b/packages/auth-service/src/routes/consent.ts
@@ -87,6 +87,7 @@ export function createConsentRouter(ctx: AuthServiceContext): Router {
     )
   })
 
+  // if the user double clicks confirm then bug occurs
   router.post('/auth/consent', (req: Request, res: Response) => {
     const flowId = req.body.flow_id as string | undefined
     const action = req.body.action as string
@@ -241,7 +242,7 @@ function renderConsent(opts: {
       </ul>
     </div>
 
-    <form method="POST" action="/auth/consent">
+    <form method="POST" action="/auth/consent" onsubmit="this.querySelectorAll('button').forEach(button => button.disabled = true)">
       <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
       ${hiddenFields}
       <div class="actions">


### PR DESCRIPTION
Bug: Double-clicking "Approve" or "Deny" on the consent form submitted two POST requests to /auth/consent. The first POST successfully read the auth_flow row and then immediately deleted it. By the time the second POST arrived (milliseconds later), the row was gone — causing getAuthFlow to return undefined and the user to see "Authentication session expired. Please try again."

Fix: Added onsubmit="this.querySelectorAll('button').forEach(b => b.disabled = true)" to the consent form. The moment either button is clicked, both buttons are disabled in the browser before the form submits, making it physically impossible to send a second POST.

<img width="1024" height="635" alt="swappy-20260406-124334" src="https://github.com/user-attachments/assets/86515454-ec44-4735-b4f2-68df47b45259" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consent form now disables form buttons on submission to prevent duplicate submissions and improve reliability and user experience.

* **Tests**
  * End-to-end test environment updated with OTP configuration (length and charset) to better mirror production OTP behavior during CI test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->