### PR TITLE
fix(shared): mask email domain and TLD to prevent handle-to-email leak (HYPER-259)

### DIFF
--- a/.changeset/mask-email-domain-tld.md
+++ b/.changeset/mask-email-domain-tld.md
@@ -1,0 +1,19 @@
+---
+'epds': patch
+---
+
+Mask every segment of email addresses on recovery and account-login
+pages, including the domain and TLD (HYPER-259).
+
+**Affects:** End users
+
+Previously, the partially-masked email shown on the recovery and
+account-login pages left the entire domain visible (e.g.
+`jo***@gmail.com`), making the user's email address much easier to
+guess for anyone who entered a known handle on the login flow. Each
+dot-separated segment of both local part and domain is now masked
+independently, revealing only the final character of each segment
+(e.g. `persons.address@gmail.com` → `***s.***s@***l.***m`). Hiding the
+domain is important: leaving a common domain visible would make
+popular providers trivially identifiable, which in turn makes the
+local part much more guessable.

--- a/packages/shared/src/__tests__/html.test.ts
+++ b/packages/shared/src/__tests__/html.test.ts
@@ -35,24 +35,35 @@ describe('escapeHtml', () => {
 })
 
 describe('maskEmail', () => {
-  it('masks a normal email', () => {
-    expect(maskEmail('john@example.com')).toBe('j***n@example.com')
-  })
-
-  it('masks a short local part (2 chars)', () => {
-    expect(maskEmail('ab@example.com')).toBe('a***@example.com')
-  })
-
-  it('masks a single char local part', () => {
-    expect(maskEmail('a@example.com')).toBe('a***@example.com')
-  })
-
-  it('returns invalid email unchanged', () => {
-    expect(maskEmail('not-an-email')).toBe('not-an-email')
-  })
-
-  it('handles long local parts', () => {
-    expect(maskEmail('longusername@test.com')).toBe('l***e@test.com')
+  it.each([
+    [
+      'masks every segment including the TLD',
+      'john@example.com',
+      '***n@***e.***m',
+    ],
+    [
+      'masks each dot-separated segment of the local part independently',
+      'persons.address@gmail.com',
+      '***s.***s@***l.***m',
+    ],
+    ['masks a short local part (2 chars)', 'ab@example.com', '***b@***e.***m'],
+    ['masks a single char local part', 'a@example.com', '***@***e.***m'],
+    ['masks a single char domain segment', 'user@a.co', '***r@***.***o'],
+    [
+      'handles long local parts without leaking length',
+      'longusername@test.com',
+      '***e@***t.***m',
+    ],
+    ['handles multi-level TLDs', 'alice@example.co.uk', '***e@***e.***o.***k'],
+    ['returns invalid email unchanged (no @)', 'not-an-email', 'not-an-email'],
+    [
+      'returns invalid email unchanged (empty local)',
+      '@example.com',
+      '@example.com',
+    ],
+    ['returns invalid email unchanged (empty domain)', 'user@', 'user@'],
+  ])('%s', (_desc, input, expected) => {
+    expect(maskEmail(input)).toBe(expected)
   })
 })
 

--- a/packages/shared/src/html.ts
+++ b/packages/shared/src/html.ts
@@ -6,11 +6,33 @@ export function escapeHtml(s: string): string {
     .replace(/"/g, '&quot;')
 }
 
+/**
+ * Mask an email so that knowing a user's handle does not let an observer
+ * recover (or easily guess) their email address. Both the local part and the
+ * domain — including the TLD — are masked. Dot-separated segments are masked
+ * independently so that segment boundaries are preserved but lengths and
+ * characters are not revealed.
+ *
+ * Each segment is replaced with `***` followed by its final character (or
+ * just `***` if the segment is a single character). Revealing the TLD (e.g.
+ * `.com`) would otherwise make popular providers like `gmail.com` trivially
+ * identifiable, which in turn makes the local part much more guessable.
+ *
+ * Example: `persons.address@gmail.com` → `***s.***s@***l.***m`
+ */
 export function maskEmail(email: string): string {
-  const [local, domain] = email.split('@')
-  if (!local || !domain) return email
-  if (local.length <= 2) return local[0] + '***@' + domain
-  return local[0] + '***' + local[local.length - 1] + '@' + domain
+  const atIndex = email.lastIndexOf('@')
+  if (atIndex <= 0 || atIndex === email.length - 1) return email
+  const local = email.slice(0, atIndex)
+  const domain = email.slice(atIndex + 1)
+  return maskDottedSegments(local) + '@' + maskDottedSegments(domain)
+}
+
+function maskDottedSegments(s: string): string {
+  return s
+    .split('.')
+    .map((seg) => (seg.length <= 1 ? '***' : '***' + seg.slice(-1)))
+    .join('.')
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes [HYPER-259](https://linear.app/hypercerts/issue/HYPER-259/email-discoverable-from-handle): on the OTP login flow, entering a known handle rendered a partially-masked email that leaked enough information for an observer to recover (or trivially guess) the user's real email address.

The previous `maskEmail()` left the entire domain — including the TLD — visible. Leaving a common TLD visible makes popular providers trivially identifiable, which in turn makes the local part much more guessable.

## Changes

- `packages/shared/src/html.ts` — rewrote `maskEmail()` to mask every dot-separated segment of **both** the local part and the domain (including the TLD) independently. Each segment is replaced with `***` followed by its final character (or just `***` for single-char segments). Dots and `@` are preserved.
- `packages/shared/src/__tests__/html.test.ts` — updated existing tests and added cases for multi-level TLDs, multi-segment local parts, single-char segments, and invalid-email edge cases.

### Example transformations (synthetic inputs)

| Input | Before | After |
| --- | --- | --- |
| `user@example.com` | `u***r@example.com` | `***r@***e.***m` |
| `local.part@provider.tld` | `l***t@provider.tld` | `***l.***t@***r.***d` |
| `alice@example.co.uk` | `a***e@example.co.uk` | `***e@***e.***o.***k` |

## Test plan

- [x] `pnpm vitest run packages/shared/src/__tests__/html.test.ts` — 32 passed
- [ ] Manually verify the masked email rendered on the OTP login page (`account-login.ts`) and the recovery flow (`recovery.ts`) looks reasonable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email masking now consistently masks both local and domain/TLD parts by masking each dot-separated segment and revealing only the final character of each segment; inputs missing a valid separator or with empty local/domain are returned unchanged.

* **Tests**
  * Unit tests expanded to cover multi-segment locals/domains, single-character segments, short or empty local/domain cases, multi-level TLDs, and invalid emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->