### PR TITLE
[HYPER-293] fix(pds-core): rewrite sec-fetch-site: same-site on /oauth/authorize

### DIFF
--- a/.changeset/consent-upstream-oauth-ui.md
+++ b/.changeset/consent-upstream-oauth-ui.md
@@ -29,7 +29,7 @@ the actual request. Clients that only need scopes the user has
 already approved will now be auto-approved instead of being shown a
 redundant consent screen.
 
-**Operators:** On upgrade, the `client_logins` table is dropped by
-migration v8. Consent state now lives in the upstream provider's
-`authorizedClients` tracking, so nothing else needs to move. No
-configuration changes are required.
+**Operators:** No configuration changes are required. Consent state
+now lives in the upstream provider's `authorizedClients` tracking. The
+`client_logins` table is no longer used but is left in place (not
+dropped) to avoid breaking rollbacks in case they were ever needed.

--- a/.changeset/sec-fetch-site-same-site-fix.md
+++ b/.changeset/sec-fetch-site-same-site-fix.md
@@ -1,0 +1,39 @@
+---
+'ePDS': patch
+---
+
+Sign-in no longer fails when the login service and your data server share a domain name.
+
+**Affects:** Operators
+
+**Operators:** The upstream `@atproto/oauth-provider` rejects `sec-fetch-site: same-site`
+on `GET /oauth/authorize`. This caused a `400 Forbidden sec-fetch-site header` error on
+deployments where the auth service and PDS share a registrable domain (e.g.
+`auth.epds1.test.certified.app` and `epds1.test.certified.app`). Browsers send `same-site`
+on the 303 redirect chain from the auth subdomain to the PDS, and the upstream code does
+not allow it.
+
+pds-core now includes middleware that rewrites `sec-fetch-site: same-site` to `same-origin`
+on `GET /oauth/authorize` when the request originates from the trusted auth subdomain. No
+configuration changes are needed.
+
+Additionally, DB migration v9 (which previously dropped the `client_logins` table) is now a
+no-op. The table is no longer used but is kept in place to avoid breaking emergency rollbacks
+to older code that still references it.
+
+This bug was missed by the comprehensive E2E test suite due to an
+unfortunate combination of quirks:
+
+1. The upstream ATProto PDS does not support `sec-fetch-site: same-site`, marked as a
+   [`@TODO`](https://github.com/bluesky-social/atproto/blob/2a9221d244a0821490458785d70d100a6943ea91/packages/oauth/oauth-provider/src/router/create-authorization-page-middleware.ts#L75-L77)
+   in the source. Stock ATProto never encounters `same-site` because the PDS serves its own
+   login UI on the same origin.
+2. Railway does not allow any control over generated domains for PR preview environments.
+   Each service gets a flat `*.up.railway.app` subdomain, and `up.railway.app` is on the
+   Public Suffix List — so cross-service requests are `cross-site` (allowed), never
+   `same-site`. This creates a small but ultimately significant difference in DNS topology
+   from Certified infrastructure where all services share a registrable domain.
+3. The deliberate introduction (in PR #21) of a double redirect from
+   `auth-service/auth/complete` to `pds-core/oauth/epds-callback` to
+   `pds-core/oauth/authorize`, which sends the browser through a cross-origin hop on the
+   same site — the exact pattern the upstream validation rejects.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 **/node_modules
 **/dist
+**/tsconfig.tsbuildinfo
 data
 *.sqlite
 *.sqlite-wal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,9 @@ import { AuthServiceContext } from './context.js'
 - SQLite via `better-sqlite3`. All DB access goes through `EpdsDb`
   (`packages/shared/src/db.ts`).
 - Schema changes use versioned migrations in `runMigrations()`.
+- **Never drop tables or columns in migrations.** Destructive schema changes
+  break emergency rollbacks — rolled-back code still references the dropped
+  schema and crashes. Leave unused tables/columns in place; they're harmless.
 - Do **not** directly read or modify `@atproto/pds` database tables — use
   `pds.ctx.accountManager.*` methods.
 

--- a/docs/design/pds-white-boxing.md
+++ b/docs/design/pds-white-boxing.md
@@ -21,7 +21,7 @@ Methods used:
 
 - `.get(requestUri, deviceId?)` — fetches a pending authorization request.
   Also has an **undocumented side effect** of resetting the `expiresAt`
-  sliding window (see item 7 below). Used in the `/oauth/epds-callback`
+  sliding window (see item 8 below). Used in the `/oauth/epds-callback`
   handler and the `/_internal/ping-request` keepalive.
 - `.setAuthorized(requestUri, client, account, deviceId, deviceMetadata)` —
   marks a request as authorized and issues an authorization code. Used in the
@@ -91,9 +91,37 @@ stop working, serving stock metadata instead of pointing
 `authorization_endpoint` at the auth service subdomain. OAuth clients would
 be sent to the wrong URL.
 
+### 5. `sec-fetch-site` validation on `/oauth/authorize`
+
+**File:** `packages/pds-core/src/lib/sec-fetch-site-rewrite.ts`,
+`packages/pds-core/src/index.ts`
+
+The upstream `@atproto/oauth-provider` validates the `sec-fetch-site` request
+header on `GET /oauth/authorize` and allows `same-origin`, `cross-site`, and
+`none` — but rejects `same-site`. There is a
+[`@TODO`](https://github.com/bluesky-social/atproto/blob/2a9221d244a0821490458785d70d100a6943ea91/packages/oauth/oauth-provider/src/router/create-authorization-page-middleware.ts#L75-L77)
+in the upstream source acknowledging this gap.
+
+ePDS puts the auth service on a subdomain of the PDS (e.g.
+`auth.pds.example` / `pds.example`). When the browser follows the 303
+redirect chain from auth → PDS `/oauth/epds-callback` → PDS
+`/oauth/authorize`, it sends `sec-fetch-site: same-site` because the chain
+crosses origins within the same registrable domain.
+
+pds-core works around this by injecting middleware (via the same
+`_router.stack` manipulation as item 4) that rewrites `same-site` →
+`same-origin` before the request reaches the upstream validation.
+
+**Breakage scenario:** If the upstream validation logic moves to a different
+layer (e.g., a lower-level HTTP handler that runs before Express middleware),
+or if additional endpoints gain the same validation, the middleware workaround
+would need updating. Also at risk if the upstream `@TODO` is resolved by
+adding `same-site` to the allowed list — the middleware would become a no-op
+(harmless but unnecessary).
+
 ## High Risk (individual features break)
 
-### 5. `pds.ctx.accountManager` methods
+### 6. `pds.ctx.accountManager` methods
 
 **File:** `packages/pds-core/src/index.ts` (multiple internal endpoints)
 
@@ -109,7 +137,7 @@ Methods accessed on the PDS-level account manager:
 `provider.accountManager` (OAuth-provider-level, manages OAuth sessions).
 The code assumes these are kept in sync by the upstream PDS.
 
-### 6. `provider.deviceManager.load()`
+### 7. `provider.deviceManager.load()`
 
 **File:** `packages/pds-core/src/index.ts`
 
@@ -124,7 +152,7 @@ Assumes `deviceManager.load()` accepts raw Node.js request/response objects
 and returns `{ deviceId, deviceMetadata }`. The double cast
 (`as unknown as http.IncomingMessage`) strips Express-specific properties.
 
-### 7. PAR inactivity timeout assumption
+### 8. PAR inactivity timeout assumption
 
 **Files:** `packages/pds-core/src/index.ts`, `packages/auth-service/src/routes/choose-handle.ts`
 
@@ -141,7 +169,7 @@ more than the timeout duration.
 The right fix is to upstream a public keepalive/refresh API on
 `@atproto/oauth-provider`.
 
-### 8. OAuth consent tracking (consent-skip path)
+### 9. OAuth consent tracking (consent-skip path)
 
 **File:** `packages/pds-core/src/index.ts`
 
@@ -162,7 +190,7 @@ uses several provider internals to issue an authorization code directly:
 The normal (non-skip) consent path delegates to the stock `/oauth/authorize`
 endpoint and does not use these internals.
 
-### 9. `provider.metadata`
+### 10. `provider.metadata`
 
 **File:** `packages/pds-core/src/index.ts`
 
@@ -175,7 +203,7 @@ metadata fields.
 
 ## Moderate Risk (public APIs, less likely to break)
 
-### 10. `@atproto/syntax` exports
+### 11. `@atproto/syntax` exports
 
 **File:** `packages/shared/src/handle.ts`
 
@@ -190,7 +218,7 @@ These are public exports. Risk is mainly from validation rule changes in
 major version bumps (e.g., allowing/disallowing characters that ePDS's
 product constraints assume).
 
-### 11. `HandleUnavailableError`
+### 12. `HandleUnavailableError`
 
 **File:** `packages/pds-core/src/index.ts`
 
@@ -202,7 +230,7 @@ Public export, used in `catch` blocks to detect handle collisions. Could
 break if the error class is renamed or if `createAccount()` starts throwing
 a different error type.
 
-### 12. XRPC admin endpoints
+### 13. XRPC admin endpoints
 
 **File:** `packages/auth-service/src/routes/account-settings.ts`
 
@@ -212,7 +240,7 @@ endpoints with stable schemas, lowest risk of breakage.
 
 ## Dead Code / Contradictions
 
-### 13. `auto-provision.ts` — passwordless createAccount
+### 14. `auto-provision.ts` — passwordless createAccount
 
 **File:** `packages/auth-service/src/lib/auto-provision.ts`
 

--- a/e2e/cucumber.mjs
+++ b/e2e/cucumber.mjs
@@ -4,6 +4,7 @@ export default {
     'features/automatic-account-creation.feature',
     'features/consent-screen.feature',
     'features/account-settings.feature',
+    'features/security.feature',
   ],
   import: ['e2e/step-definitions/**/*.ts', 'e2e/support/**/*.ts'],
   format: ['pretty', 'html:reports/e2e.html', 'junit:reports/e2e.junit.xml'],

--- a/e2e/step-definitions/sec-fetch-site.steps.ts
+++ b/e2e/step-definitions/sec-fetch-site.steps.ts
@@ -20,7 +20,7 @@ import type { EpdsWorld } from '../support/world.js'
 import { testEnv } from '../support/env.js'
 
 When(
-  'a GET request is sent to the PDS \\/oauth\\/authorize with sec-fetch-site {string}',
+  String.raw`a GET request is sent to the PDS \/oauth\/authorize with sec-fetch-site {string}`,
   async function (this: EpdsWorld, secFetchSiteValue: string) {
     // We need a valid request_uri to avoid a different error (missing
     // request_uri) masking the sec-fetch-site rejection. Try PAR first;
@@ -71,15 +71,11 @@ When(
     })
 
     this.lastHttpStatus = res.status
+    const text = await res.text()
     try {
-      const text = await res.text()
-      try {
-        this.lastHttpJson = JSON.parse(text) as Record<string, unknown>
-      } catch {
-        this.lastHttpJson = { body: text }
-      }
+      this.lastHttpJson = JSON.parse(text) as Record<string, unknown>
     } catch {
-      this.lastHttpJson = {}
+      this.lastHttpJson = { body: text }
     }
   },
 )
@@ -90,11 +86,11 @@ Then(
     const status = this.lastHttpStatus
     const body = this.lastHttpJson
 
-    const bodyStr = JSON.stringify(body ?? {})
+    const bodyStr = JSON.stringify(body ?? {}).toLowerCase()
     const isSecFetchRejection =
       status === 400 &&
       bodyStr.includes('sec-fetch-site') &&
-      bodyStr.includes('Forbidden')
+      bodyStr.includes('forbidden')
 
     if (isSecFetchRejection) {
       throw new Error(

--- a/e2e/step-definitions/sec-fetch-site.steps.ts
+++ b/e2e/step-definitions/sec-fetch-site.steps.ts
@@ -1,0 +1,112 @@
+/**
+ * Step definitions for the same-site deployment topology scenario.
+ *
+ * See the comment block in features/security.feature for full context.
+ *
+ * TL;DR: ePDS puts the auth service on a subdomain of the PDS (e.g.
+ * auth.pds.example / pds.example). When the browser follows the redirect
+ * chain auth → pds /oauth/epds-callback → pds /oauth/authorize, it sends
+ * sec-fetch-site: same-site. The upstream @atproto/oauth-provider rejects
+ * that value. On Railway CI, this is masked because up.railway.app is a
+ * public suffix (so cross-service requests are cross-site, not same-site).
+ *
+ * These steps send a direct HTTP request with sec-fetch-site: same-site to
+ * verify the PDS doesn't reject it — catching the bug regardless of the
+ * CI domain topology.
+ */
+
+import { When, Then } from '@cucumber/cucumber'
+import type { EpdsWorld } from '../support/world.js'
+import { testEnv } from '../support/env.js'
+
+When(
+  'a GET request is sent to the PDS \\/oauth\\/authorize with sec-fetch-site {string}',
+  async function (this: EpdsWorld, secFetchSiteValue: string) {
+    // We need a valid request_uri to avoid a different error (missing
+    // request_uri) masking the sec-fetch-site rejection. Try PAR first;
+    // if it requires DPoP (which we can't easily provide here), fall back
+    // to a dummy URI — the sec-fetch-site check runs before request_uri
+    // validation, so the 400 about sec-fetch-site will still surface.
+    const clientMetaUrl = `${testEnv.demoUrl}/client-metadata.json`
+
+    const parBody = new URLSearchParams({
+      client_id: clientMetaUrl,
+      redirect_uri: `${testEnv.demoUrl}/api/oauth/callback`,
+      response_type: 'code',
+      scope: 'atproto transition:generic',
+      state: 'test-state',
+      code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+      code_challenge_method: 'S256',
+    })
+
+    const parRes = await fetch(`${testEnv.pdsUrl}/oauth/par`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: parBody.toString(),
+      redirect: 'manual',
+    })
+
+    let requestUri: string
+    if (parRes.ok) {
+      const parData = (await parRes.json()) as { request_uri: string }
+      requestUri = parData.request_uri
+    } else {
+      requestUri = 'urn:ietf:params:oauth:request_uri:req-test-dummy'
+    }
+
+    // Send GET /oauth/authorize with the sec-fetch-site header that a real
+    // browser would send on a same-site deployment (e.g. *.certified.app).
+    const authorizeUrl = new URL('/oauth/authorize', testEnv.pdsUrl)
+    authorizeUrl.searchParams.set('request_uri', requestUri)
+    authorizeUrl.searchParams.set('client_id', clientMetaUrl)
+
+    const res = await fetch(authorizeUrl.toString(), {
+      method: 'GET',
+      headers: {
+        'sec-fetch-site': secFetchSiteValue,
+        'sec-fetch-mode': 'navigate',
+        'sec-fetch-dest': 'document',
+      },
+      redirect: 'manual',
+    })
+
+    this.lastHttpStatus = res.status
+    try {
+      const text = await res.text()
+      try {
+        this.lastHttpJson = JSON.parse(text) as Record<string, unknown>
+      } catch {
+        this.lastHttpJson = { body: text }
+      }
+    } catch {
+      this.lastHttpJson = {}
+    }
+  },
+)
+
+Then(
+  'the response is not a 400 error about forbidden sec-fetch-site header',
+  function (this: EpdsWorld) {
+    const status = this.lastHttpStatus
+    const body = this.lastHttpJson
+
+    const bodyStr = JSON.stringify(body ?? {})
+    const isSecFetchRejection =
+      status === 400 &&
+      bodyStr.includes('sec-fetch-site') &&
+      bodyStr.includes('Forbidden')
+
+    if (isSecFetchRejection) {
+      throw new Error(
+        `PDS /oauth/authorize rejected sec-fetch-site header with 400.\n` +
+          `This means the redirect chain from auth subdomain → PDS will fail ` +
+          `on deployments where auth and PDS share the same registrable domain ` +
+          `(e.g. *.certified.app). The upstream @atproto/oauth-provider rejects ` +
+          `"same-site" but browsers send it when redirecting between subdomains ` +
+          `of the same site.\n\n` +
+          `Fix: add middleware in pds-core to rewrite sec-fetch-site: same-site ` +
+          `→ same-origin for requests arriving from the trusted auth subdomain.`,
+      )
+    }
+  },
+)

--- a/features/security.feature
+++ b/features/security.feature
@@ -8,28 +8,33 @@ Feature: Security measures
 
   # --- CSRF protection ---
 
+  @pending
   Scenario: Forms include CSRF protection
     When the login page is loaded
     Then the response sets a CSRF cookie
     And the HTML form contains a hidden CSRF token field
 
+  @pending
   Scenario: POST without CSRF token is rejected
     When a POST request is sent to the OTP verification endpoint without a CSRF token
     Then the response status is 403
 
   # --- Rate limiting ---
 
+  @pending
   Scenario: Excessive requests from one IP are rate-limited
     When more than 60 requests are sent from the same IP within one minute
     Then subsequent requests receive a 429 Too Many Requests response
     And the response includes a Retry-After header
 
+  @pending
   Scenario: Excessive OTP requests for one email are throttled
     When OTP codes are requested for the same email many times in quick succession
     Then the rate limiter throttles further OTP sends for that email
 
   # --- Security headers ---
 
+  @pending
   Scenario: Auth service responses include security headers
     When any page is loaded from the auth service via Caddy
     Then the response includes:
@@ -39,6 +44,7 @@ Feature: Security measures
       | X-Content-Type-Options    | nosniff          |
       | Referrer-Policy           | no-referrer      |
 
+  @pending
   Scenario: Content-Security-Policy restricts inline content
     When the login page is loaded
     Then the Content-Security-Policy header is present
@@ -46,20 +52,54 @@ Feature: Security measures
 
   # --- Monitoring ---
 
+  @pending
   Scenario: Health check endpoints are available
     When GET /health is called on the auth service
     Then it returns status 200 with { "status": "ok" }
     When GET /health is called on the PDS core
     Then it returns status 200 with { "status": "ok" }
 
+  @pending
   Scenario: Metrics endpoint requires authentication
     When GET /metrics is called on the auth service without credentials
     Then the response status is 401
     When GET /metrics is called with valid Basic auth credentials
     Then the response includes uptime and memory usage metrics
 
+  # --- Same-site deployment topology (sec-fetch-site) ---
+  #
+  # Background: ePDS splits the OAuth authorization server onto a subdomain
+  # (e.g. auth.epds1.certified.app) while the PDS stays on the parent domain
+  # (epds1.certified.app). In stock atproto, the PDS serves its own login UI,
+  # so this split never occurs.
+  #
+  # After OTP verification, the auth service redirects the browser through a
+  # 303 chain: auth-service/auth/complete → pds-core/oauth/epds-callback →
+  # pds-core/oauth/authorize. Browsers compute sec-fetch-site from the full
+  # redirect chain — since the chain crosses from the auth subdomain to the
+  # PDS, the browser sends sec-fetch-site: same-site on the final request.
+  #
+  # The upstream @atproto/oauth-provider validates sec-fetch-site on
+  # GET /oauth/authorize and allows same-origin, cross-site, and none — but
+  # rejects same-site. This is reasonable for stock atproto (where same-site
+  # would be unexpected) but breaks ePDS's subdomain architecture.
+  #
+  # Why CI doesn't catch this naturally: Railway PR preview environments use
+  # *.up.railway.app domains. Because up.railway.app is on the Public Suffix
+  # List (https://publicsuffix.org), each Railway subdomain is its own "site",
+  # making cross-service requests cross-site rather than same-site. The
+  # atproto validation accepts cross-site, so the bug is invisible on Railway.
+  #
+  # This scenario catches it by sending sec-fetch-site: same-site directly
+  # via HTTP, simulating what a real browser sends on *.certified.app.
+
+  Scenario: PDS /oauth/authorize accepts sec-fetch-site: same-site
+    When a GET request is sent to the PDS /oauth/authorize with sec-fetch-site "same-site"
+    Then the response is not a 400 error about forbidden sec-fetch-site header
+
   # --- Email privacy ---
 
+  @pending
   Scenario: Displayed emails are masked on error/status pages
     When an email address is displayed on a server-rendered page
     Then it appears masked (e.g. "j***n@example.com")

--- a/packages/pds-core/src/__tests__/sec-fetch-site-rewrite.test.ts
+++ b/packages/pds-core/src/__tests__/sec-fetch-site-rewrite.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { shouldRewriteSecFetchSite } from '../lib/sec-fetch-site-rewrite.js'
+
+const BASE = {
+  method: 'GET',
+  path: '/oauth/authorize',
+  secFetchSite: 'same-site' as string | undefined,
+  referer: undefined as string | undefined,
+  authOrigin: 'https://auth.pds.example',
+  pdsOrigin: 'https://pds.example',
+}
+
+describe('shouldRewriteSecFetchSite', () => {
+  it('rewrites when referer is the auth subdomain', () => {
+    expect(
+      shouldRewriteSecFetchSite({
+        ...BASE,
+        referer: 'https://auth.pds.example/oauth/authorize?foo=bar',
+      }),
+    ).toBe(true)
+  })
+
+  it('rewrites when referer is absent (no referer)', () => {
+    expect(shouldRewriteSecFetchSite({ ...BASE, referer: undefined })).toBe(
+      true,
+    )
+  })
+
+  it('rewrites when referer is the PDS itself', () => {
+    expect(
+      shouldRewriteSecFetchSite({
+        ...BASE,
+        referer: 'https://pds.example/oauth/authorize',
+      }),
+    ).toBe(true)
+  })
+
+  it('does NOT rewrite for an unknown same-site origin', () => {
+    expect(
+      shouldRewriteSecFetchSite({
+        ...BASE,
+        referer: 'https://evil.example/page',
+      }),
+    ).toBe(false)
+  })
+
+  it('does NOT rewrite when sec-fetch-site is cross-site', () => {
+    expect(
+      shouldRewriteSecFetchSite({ ...BASE, secFetchSite: 'cross-site' }),
+    ).toBe(false)
+  })
+
+  it('does NOT rewrite when sec-fetch-site is same-origin', () => {
+    expect(
+      shouldRewriteSecFetchSite({ ...BASE, secFetchSite: 'same-origin' }),
+    ).toBe(false)
+  })
+
+  it('does NOT rewrite when sec-fetch-site is none', () => {
+    expect(shouldRewriteSecFetchSite({ ...BASE, secFetchSite: 'none' })).toBe(
+      false,
+    )
+  })
+
+  it('does NOT rewrite for a different path', () => {
+    expect(shouldRewriteSecFetchSite({ ...BASE, path: '/oauth/token' })).toBe(
+      false,
+    )
+  })
+
+  it('does NOT rewrite for POST /oauth/authorize', () => {
+    expect(shouldRewriteSecFetchSite({ ...BASE, method: 'POST' })).toBe(false)
+  })
+})

--- a/packages/pds-core/src/index.ts
+++ b/packages/pds-core/src/index.ts
@@ -34,6 +34,7 @@ import {
   validateLocalPart,
   resolveClientMetadata,
 } from '@certified-app/shared'
+import { shouldRewriteSecFetchSite } from './lib/sec-fetch-site-rewrite.js'
 
 const logger = createLogger('pds-core')
 
@@ -490,17 +491,43 @@ async function main() {
     next()
   }
 
-  // Insert at position 0 in the Express middleware stack so it runs before
-  // the stock authRoutes middleware that serves the pre-serialized metadata.
+  // Rewrite sec-fetch-site: same-site → same-origin for GET /oauth/authorize.
+  //
+  // PR #21 changed epds-callback to redirect through the stock
+  // @atproto/oauth-provider /oauth/authorize endpoint. The browser tags that
+  // redirect as `same-site` (auth subdomain → PDS origin), but the upstream
+  // oauth-provider rejects `same-site` — it only accepts `same-origin`,
+  // `cross-site`, or `none`.
+  //
+  // We rewrite only when the referer is the auth subdomain, the PDS itself,
+  // or absent (no referer). Unknown same-site origins are left untouched to
+  // preserve the security boundary.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Express middleware injected into raw stack
+  const secFetchSiteRewrite = (req: any, _res: any, next: any) => {
+    if (
+      shouldRewriteSecFetchSite({
+        method: req.method,
+        path: req.path,
+        secFetchSite: req.headers['sec-fetch-site'],
+        referer: req.headers['referer'],
+        authOrigin: `https://${authHostname}`,
+        pdsOrigin: pdsUrl,
+      })
+    ) {
+      req.headers['sec-fetch-site'] = 'same-origin'
+    }
+    next()
+  }
+
+  // Insert both middlewares at position 0 in the Express middleware stack so
+  // they run before the stock authRoutes middleware. Register them both, then
+  // pop and splice each one in, in reverse registration order so that
+  // secFetchSiteRewrite ends up at insertIdx and asMetadataOverride follows.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing Express internal _router stack
   const stack = (pds.app as any)._router?.stack
   if (stack) {
-    // Create a Layer-like entry by temporarily registering and then moving it
-    pds.app.use(asMetadataOverride)
-    const layer = stack.pop()
-    // Insert after query (0) and expressInit (1) so req.path is available,
+    // Find expressInit and insert right after it so req.path is available,
     // but before the authRoutes router that serves stock OAuth metadata.
-    // Find expressInit and insert right after it.
     let insertIdx = 0
     for (let i = 0; i < stack.length; i++) {
       if (stack[i].name === 'expressInit') {
@@ -508,8 +535,16 @@ async function main() {
         break
       }
     }
-    stack.splice(insertIdx, 0, layer)
-    logger.info('AS metadata override installed')
+
+    pds.app.use(asMetadataOverride)
+    const metadataLayer = stack.pop()
+
+    pds.app.use(secFetchSiteRewrite)
+    const secFetchLayer = stack.pop()
+
+    // Insert in order: secFetchSiteRewrite first, then asMetadataOverride
+    stack.splice(insertIdx, 0, secFetchLayer, metadataLayer)
+    logger.info('AS metadata override and sec-fetch-site rewrite installed')
   }
 
   // =========================================================================

--- a/packages/pds-core/src/lib/sec-fetch-site-rewrite.ts
+++ b/packages/pds-core/src/lib/sec-fetch-site-rewrite.ts
@@ -1,0 +1,43 @@
+/**
+ * sec-fetch-site rewrite logic for GET /oauth/authorize.
+ *
+ * PR #21 changed epds-callback to redirect through the stock
+ * @atproto/oauth-provider /oauth/authorize endpoint. The browser tags that
+ * redirect as `same-site` (auth subdomain → PDS origin), but the upstream
+ * oauth-provider rejects `same-site` — it only accepts `same-origin`,
+ * `cross-site`, or `none`.
+ *
+ * Extracted into a pure function so it can be unit-tested without Express.
+ */
+
+export interface RewriteParams {
+  method: string
+  path: string
+  secFetchSite: string | undefined
+  referer: string | undefined
+  authOrigin: string
+  pdsOrigin: string
+}
+
+/**
+ * Returns true if the sec-fetch-site header should be rewritten from
+ * `same-site` to `same-origin` for this request.
+ *
+ * Only rewrites when:
+ * - The request is GET /oauth/authorize
+ * - sec-fetch-site is exactly `same-site`
+ * - The referer is the auth subdomain, the PDS itself, or absent
+ *
+ * Unknown same-site origins are left untouched to preserve the security boundary.
+ */
+export function shouldRewriteSecFetchSite(params: RewriteParams): boolean {
+  const { method, path, secFetchSite, referer, authOrigin, pdsOrigin } = params
+
+  if (method !== 'GET' || path !== '/oauth/authorize') return false
+  if (secFetchSite !== 'same-site') return false
+
+  if (!referer) return true
+
+  const allowedOrigins = [authOrigin, pdsOrigin]
+  return allowedOrigins.some((origin) => referer.startsWith(origin))
+}

--- a/packages/shared/src/__tests__/db.test.ts
+++ b/packages/shared/src/__tests__/db.test.ts
@@ -214,22 +214,22 @@ describe('Auth Flow Operations', () => {
   })
 })
 
-describe('Migration: v8 drops client_logins table', () => {
-  it('client_logins table does not exist after migration', () => {
-    // EpdsDb constructor runs all migrations including v8.
-    // Verify the table was dropped by querying sqlite_master.
+describe('Migration: v9 is a no-op (client_logins preserved)', () => {
+  it('client_logins table still exists after all migrations', () => {
+    // v9 was originally a DROP but changed to a no-op. The table is no
+    // longer used by current code but kept to avoid breaking rollbacks.
     const tables = db['db']
       .prepare(
         `SELECT name FROM sqlite_master WHERE type='table' AND name='client_logins'`,
       )
       .all()
-    expect(tables).toHaveLength(0)
+    expect(tables).toHaveLength(1)
   })
 
-  it('schema version is at least 8 after migration', () => {
+  it('schema version is at least 9 after migration', () => {
     const row = db['db']
       .prepare('SELECT version FROM schema_version')
       .get() as { version: number }
-    expect(row.version).toBeGreaterThanOrEqual(8)
+    expect(row.version).toBeGreaterThanOrEqual(9)
   })
 })

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -183,11 +183,10 @@ export class EpdsDb {
         this.db.exec(`ALTER TABLE auth_flow ADD COLUMN handle_mode TEXT;`)
       },
 
-      // v9: Drop client_logins table — consent tracking is now handled by the
-      // stock @atproto/oauth-provider via its authorizedClients mechanism.
-      () => {
-        this.db.exec(`DROP TABLE IF EXISTS client_logins;`)
-      },
+      // v9: no-op. PR #21 originally dropped client_logins here, but
+      // changed to a no-op since the table is harmless to keep and dropping
+      // it prevents rollback. The table is no longer used by current code.
+      () => {},
     ]
 
     for (let i = currentVersion; i < migrations.length; i++) {


### PR DESCRIPTION
## Summary

- Add middleware in pds-core to rewrite `sec-fetch-site: same-site` to `same-origin` for `GET /oauth/authorize` requests from the trusted auth subdomain
- Add e2e scenario that sends `sec-fetch-site: same-site` directly via HTTP to catch this regression regardless of CI domain topology
- Replace DB migration v9 (DROP `client_logins`) with a no-op to prevent breaking emergency rollbacks
- Add no-drop-tables rule to AGENTS.md
- Add `**/tsconfig.tsbuildinfo` to `.dockerignore` to fix stale build cache in Docker

Fixes HYPER-293

## Context

PR #21 changed the epds-callback to redirect through the stock `@atproto/oauth-provider` `/oauth/authorize` endpoint. On deployments where auth and PDS share a registrable domain (e.g. `*.test.certified.app`), browsers send `sec-fetch-site: same-site` on the 303 redirect chain from the auth subdomain. The upstream atproto code rejects `same-site` (it allows `same-origin`, `cross-site`, `none`).

CI never caught this because Railway's `up.railway.app` is on the [Public Suffix List](https://publicsuffix.org), making each Railway subdomain its own "site" — so cross-service requests are `cross-site` (allowed) rather than `same-site` (rejected). Transparent browser-level testing via Playwright's `page.route()` is not possible because `sec-fetch-site` is a browser-controlled header that cannot be overridden via CDP, and `page.route()` does not intercept redirect chain targets.

## Test plan

- [x] Verify the e2e scenario fails against pr-base (before fix) — confirmed
- [x] Verify the middleware fix passes unit tests locally
- [x] Reproduce the error manually on local docker deployment with `*.test.certified.app` domain
- [x] Verify the e2e scenario passes in CI (after fix deployed)
- [x] Verify manual login works on local docker deployment with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed sign-in failures that occurred when the login service and data server shared the same domain name
- Database migrations now preserve existing tables rather than removing them during upgrades

**Tests**
- Added comprehensive end-to-end tests validating OAuth authorization endpoint security

**Documentation**
- Updated database migration guidelines to explicitly prohibit destructive schema changes, such as dropping tables or columns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->