### PR TITLE
ci(e2e): cache Playwright browser binaries across runs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -91,7 +91,21 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: npx playwright install --with-deps chromium
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Resolve target SHA
         id: sha


### PR DESCRIPTION
## Summary

- Cache `~/.cache/ms-playwright` in the e2e workflow using `actions/cache@v4`
- On cache hit, skip the ~112MB Chromium download and only install OS system deps
- Cache key is based on `pnpm-lock.yaml` so it refreshes when Playwright version changes

Playwright install was taking up to 12 minutes on some runs. This should bring it down to seconds on cache hits.

## Test plan

- [ ] First run: cache miss, full install (same as before)
- [ ] Second run: cache hit, only `install-deps` runs (should be much faster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized end-to-end test CI/CD pipeline with cached Playwright browser downloads, reducing test execution time and improving deployment velocity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->