### PR TITLE
fix(changeset): update package name from epds to ePDS

### DIFF
--- a/.changeset/consent-upstream-oauth-ui.md
+++ b/.changeset/consent-upstream-oauth-ui.md
@@ -1,5 +1,5 @@
 ---
-'epds': patch
+'ePDS': patch
 ---
 
 The permissions shown on the sign-in approval screen now match what the app actually asked for.


### PR DESCRIPTION
## Summary
- The `consent-upstream-oauth-ui` changeset still referenced the old package name `epds`, which was renamed to `ePDS` in 6e35c8d33
- This caused the [release workflow](https://github.com/hypercerts-org/ePDS/actions/runs/24259652884/job/70839969272) to fail with `Found changeset for package epds which is not in the workspace`

## Test plan
- [ ] Re-run the release workflow after merge and confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)