### PR TITLE
docs: cover v0.2.0/v0.2.2 features missing from docs/ (HYPER-295)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,22 +34,22 @@ marked `[shared]` in the per-package `.env.example` files.
 
 ## PDS Core
 
-| Variable                                    | Description                                                                                      |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Variable                                    | Description                                                                                                                                           |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PDS_PORT`                                  | Port for PDS Core. Resolved as `PDS_PORT` → `PORT` → `3000`, so platforms that inject `PORT` (e.g. Railway) work without a service-specific override. |
-| `PDS_DATA_DIRECTORY`                        | Path to data directory (default `/data`)                                                         |
-| `PDS_DID_PLC_URL`                           | AT Protocol PLC directory URL (default `https://plc.directory`)                                  |
-| `PDS_BSKY_APP_VIEW_URL`                     | Bluesky app view URL (default `https://api.bsky.app`)                                            |
-| `PDS_BSKY_APP_VIEW_DID`                     | Bluesky app view DID (default `did:web:api.bsky.app`)                                            |
-| `PDS_CRAWLERS`                              | AT Protocol crawlers (default `https://bsky.network`)                                            |
-| `PDS_JWT_SECRET`                            | Secret for JWT signing — generate with `openssl rand -hex 32`                                    |
-| `PDS_DPOP_SECRET`                           | Secret for DPoP — generate with `openssl rand -hex 32`                                           |
-| `PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX` | secp256k1 private key for PLC rotation — see [deployment.md](deployment.md)                      |
-| `PDS_EMAIL_SMTP_URL`                        | SMTP URL (e.g. `smtps://user:pass@smtp.resend.com:465`)                                          |
-| `PDS_EMAIL_FROM_ADDRESS`                    | Sender address for PDS emails                                                                    |
-| `PDS_BLOBSTORE_DISK_LOCATION`               | Path to blob storage directory (default `/data/blobs`)                                           |
-| `EPDS_INVITE_CODE`                          | Pre-generated invite code for account creation (see [deployment.md](deployment.md#invite-codes)) |
-| `PDS_INVITE_REQUIRED`                       | Whether invite codes are required for account creation (default `true`)                          |
+| `PDS_DATA_DIRECTORY`                        | Path to data directory (default `/data`)                                                                                                              |
+| `PDS_DID_PLC_URL`                           | AT Protocol PLC directory URL (default `https://plc.directory`)                                                                                       |
+| `PDS_BSKY_APP_VIEW_URL`                     | Bluesky app view URL (default `https://api.bsky.app`)                                                                                                 |
+| `PDS_BSKY_APP_VIEW_DID`                     | Bluesky app view DID (default `did:web:api.bsky.app`)                                                                                                 |
+| `PDS_CRAWLERS`                              | AT Protocol crawlers (default `https://bsky.network`)                                                                                                 |
+| `PDS_JWT_SECRET`                            | Secret for JWT signing — generate with `openssl rand -hex 32`                                                                                         |
+| `PDS_DPOP_SECRET`                           | Secret for DPoP — generate with `openssl rand -hex 32`                                                                                                |
+| `PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX` | secp256k1 private key for PLC rotation — see [deployment.md](deployment.md)                                                                           |
+| `PDS_EMAIL_SMTP_URL`                        | SMTP URL (e.g. `smtps://user:pass@smtp.resend.com:465`)                                                                                               |
+| `PDS_EMAIL_FROM_ADDRESS`                    | Sender address for PDS emails                                                                                                                         |
+| `PDS_BLOBSTORE_DISK_LOCATION`               | Path to blob storage directory (default `/data/blobs`)                                                                                                |
+| `EPDS_INVITE_CODE`                          | Pre-generated invite code for account creation (see [deployment.md](deployment.md#invite-codes))                                                      |
+| `PDS_INVITE_REQUIRED`                       | Whether invite codes are required for account creation (default `true`)                                                                               |
 
 Optional PDS email variables:
 
@@ -78,15 +78,15 @@ Optional PDS email variables:
 
 ### OTP code
 
-| Variable      | Description                                                                                                                                                                       |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OTP_LENGTH`  | Number of characters in the email verification code. Integer in the range 4–12 (default `8`). Values outside the range cause the auth service to fail on startup.                 |
+| Variable      | Description                                                                                                                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OTP_LENGTH`  | Number of characters in the email verification code. Integer in the range 4–12 (default `8`). Values outside the range cause the auth service to fail on startup.                                     |
 | `OTP_CHARSET` | Character set for the verification code: `numeric` (digits only, default) or `alphanumeric` (uppercase A–Z plus 0–9). Alphanumeric codes have higher entropy but lose the numeric on-screen keyboard. |
 
 ### Handle picker
 
-| Variable                   | Description                                                                                                                                                                                                                               |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Variable                   | Description                                                                                                                                                                                                                                                                                              |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `EPDS_DEFAULT_HANDLE_MODE` | Default handle assignment mode for new user signups when neither the OAuth `epds_handle_mode` query parameter nor the client metadata field is set. One of `picker`, `random`, or `picker-with-random` (default). See [tutorial.md](tutorial.md) for the full precedence rules and per-client overrides. |
 
 ### Better Auth session

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,9 +85,9 @@ Optional PDS email variables:
 
 ### Handle picker
 
-| Variable                   | Description                                                                                                                                                                                                                                                                                              |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `EPDS_DEFAULT_HANDLE_MODE` | Default handle assignment mode for new user signups when neither the OAuth `epds_handle_mode` query parameter nor the client metadata field is set. One of `picker`, `random`, or `picker-with-random` (default). See [tutorial.md](tutorial.md) for the full precedence rules and per-client overrides. |
+| Variable                   | Description                                                                                                                                                                                                                                                                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `EPDS_DEFAULT_HANDLE_MODE` | Default handle assignment mode for new user signups when neither the OAuth `epds_handle_mode` query parameter nor the client metadata field is set. One of `picker`, `random`, or `picker-with-random` (default: `picker-with-random`). See [tutorial.md](tutorial.md) for the full precedence rules and per-client overrides. |
 
 ### Better Auth session
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,7 @@ marked `[shared]` in the per-package `.env.example` files.
 
 | Variable                                    | Description                                                                                      |
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `PDS_PORT`                                  | Port for PDS Core (default `3000`)                                                               |
+| `PDS_PORT`                                  | Port for PDS Core. Resolved as `PDS_PORT` → `PORT` → `3000`, so platforms that inject `PORT` (e.g. Railway) work without a service-specific override. |
 | `PDS_DATA_DIRECTORY`                        | Path to data directory (default `/data`)                                                         |
 | `PDS_DID_PLC_URL`                           | AT Protocol PLC directory URL (default `https://plc.directory`)                                  |
 | `PDS_BSKY_APP_VIEW_URL`                     | Bluesky app view URL (default `https://api.bsky.app`)                                            |
@@ -64,7 +64,7 @@ Optional PDS email variables:
 | Variable              | Description                                                                                                                                                                                                 |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `AUTH_HOSTNAME`       | Auth subdomain (e.g. `auth.pds.example.com`) — must be a subdomain of `PDS_HOSTNAME`                                                                                                                        |
-| `AUTH_PORT`           | Port for Auth Service (default `3001`)                                                                                                                                                                      |
+| `AUTH_PORT`           | Port for Auth Service. Resolved as `AUTH_PORT` → `PORT` → `3001`, so platforms that inject `PORT` (e.g. Railway) work without a service-specific override.                                                  |
 | `AUTH_SESSION_SECRET` | Session secret — generate with `openssl rand -hex 32`                                                                                                                                                       |
 | `AUTH_CSRF_SECRET`    | CSRF secret — generate with `openssl rand -hex 32`                                                                                                                                                          |
 | `PDS_INTERNAL_URL`    | **Required.** Internal URL for auth→PDS calls. Docker: `http://core:3000`; Railway: `http://<service>.railway.internal:3000`; local dev: `http://localhost:3000`. Auth service crashes at startup if unset. |
@@ -75,6 +75,19 @@ Optional PDS email variables:
 | -------------------------- | ---------------------------------------------------------- |
 | `EPDS_LINK_EXPIRY_MINUTES` | Link expiry in minutes (default `10`)                      |
 | `EPDS_LINK_BASE_URL`       | Base URL for verification links — must match AUTH_HOSTNAME |
+
+### OTP code
+
+| Variable      | Description                                                                                                                                                                       |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OTP_LENGTH`  | Number of characters in the email verification code. Integer in the range 4–12 (default `8`). Values outside the range cause the auth service to fail on startup.                 |
+| `OTP_CHARSET` | Character set for the verification code: `numeric` (digits only, default) or `alphanumeric` (uppercase A–Z plus 0–9). Alphanumeric codes have higher entropy but lose the numeric on-screen keyboard. |
+
+### Handle picker
+
+| Variable                   | Description                                                                                                                                                                                                                               |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EPDS_DEFAULT_HANDLE_MODE` | Default handle assignment mode for new user signups when neither the OAuth `epds_handle_mode` query parameter nor the client metadata field is set. One of `picker`, `random`, or `picker-with-random` (default). See [tutorial.md](tutorial.md) for the full precedence rules and per-client overrides. |
 
 ### Better Auth session
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -229,11 +229,11 @@ an `epds_handle_mode` field to your client metadata:
 
 Accepted values (case-sensitive):
 
-| Value                | Behaviour                                                                  |
-| -------------------- | -------------------------------------------------------------------------- |
-| `picker`             | Always show the handle picker. No "generate random" button.                |
-| `random`             | Always assign a random handle. No picker shown (pre-0.2.0 behaviour).      |
-| `picker-with-random` | Show the picker with a "generate random" button (this is the default).    |
+| Value                | Behaviour                                                              |
+| -------------------- | ---------------------------------------------------------------------- |
+| `picker`             | Always show the handle picker. No "generate random" button.            |
+| `random`             | Always assign a random handle. No picker shown (pre-0.2.0 behaviour).  |
+| `picker-with-random` | Show the picker with a "generate random" button (this is the default). |
 
 The mode is resolved per request with the following precedence — first
 match wins:
@@ -348,11 +348,11 @@ function derToRaw(der: Buffer): Buffer {
 In Flow 1 your app passes an identifier for the user to ePDS in the
 OAuth `login_hint` parameter. ePDS accepts three forms:
 
-| Form   | Example                   | When to use                                                                                       |
-| ------ | ------------------------- | ------------------------------------------------------------------------------------------------- |
-| Email  | `alice@example.com`       | Your app collects email addresses (e.g. via a sign-in form).                                      |
-| Handle | `alice.pds.example.com`   | Your app already knows the user's AT Protocol handle (e.g. from a previous session, or a follow). |
-| DID    | `did:plc:abc123…`         | Your app stores users by DID and never sees their handle.                                         |
+| Form   | Example                 | When to use                                                                                       |
+| ------ | ----------------------- | ------------------------------------------------------------------------------------------------- |
+| Email  | `alice@example.com`     | Your app collects email addresses (e.g. via a sign-in form).                                      |
+| Handle | `alice.pds.example.com` | Your app already knows the user's AT Protocol handle (e.g. from a previous session, or a follow). |
+| DID    | `did:plc:abc123…`       | Your app stores users by DID and never sees their handle.                                         |
 
 All three behave the same way from the client's perspective: ePDS sends
 the OTP to the account's email address and shows the code-entry screen

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -244,9 +244,12 @@ match wins:
 4. Built-in default: `picker-with-random`
 
 If you need to override per request — e.g. for a specific signup
-campaign — append `?epds_handle_mode=picker` (or any other accepted
-value) to the `/oauth/authorize` URL you redirect the user to. Unknown or
-invalid values are silently ignored and fall through to the next source.
+campaign — add `epds_handle_mode=picker` (or any other accepted value) as
+an additional query parameter when you build the `/oauth/authorize` URL
+in [_Redirecting the user to ePDS_](#redirecting-the-user-to-epds) below.
+The `/oauth/authorize` URL already carries `client_id` and `request_uri`,
+so use `&epds_handle_mode=...`, not `?`. Unknown or invalid values are
+silently ignored and fall through to the next source.
 
 ### Security helpers
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -211,6 +211,39 @@ placeholder. Supported template variables:
 | `{{#is_new_user}}...{{/is_new_user}}` | Shown only on first sign-up               |
 | `{{^is_new_user}}...{{/is_new_user}}` | Shown only on subsequent sign-ins         |
 
+#### Optional: control the handle picker
+
+When a new user signs up through your app, ePDS shows them a handle picker
+by default. You can override which variant of the picker is shown by adding
+an `epds_handle_mode` field to your client metadata:
+
+```json
+{
+  "epds_handle_mode": "picker"
+}
+```
+
+Accepted values (case-sensitive):
+
+| Value                | Behaviour                                                                  |
+| -------------------- | -------------------------------------------------------------------------- |
+| `picker`             | Always show the handle picker. No "generate random" button.                |
+| `random`             | Always assign a random handle. No picker shown (pre-0.2.0 behaviour).      |
+| `picker-with-random` | Show the picker with a "generate random" button (this is the default).    |
+
+The mode is resolved per request with the following precedence — first
+match wins:
+
+1. `epds_handle_mode` query parameter on the `/oauth/authorize` URL
+2. `epds_handle_mode` field in your client metadata JSON
+3. `EPDS_DEFAULT_HANDLE_MODE` environment variable on the auth service
+4. Built-in default: `picker-with-random`
+
+If you need to override per request — e.g. for a specific signup
+campaign — append `?epds_handle_mode=picker` (or any other accepted
+value) to the `/oauth/authorize` URL you redirect the user to. Unknown or
+invalid values are silently ignored and fall through to the next source.
+
 ### Security helpers
 
 ePDS uses two standard security mechanisms to protect the login flow:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -22,9 +22,13 @@ your app, and your app exchanges that redirect for a token.
 
 ## Flow 1 — App has its own email form
 
-1. User enters email in your app and clicks "Sign in"
-2. Your login handler registers the login attempt with ePDS (passing the email)
-3. Your app redirects the user's browser to the ePDS auth page (with the email)
+1. User enters email in your app and clicks "Sign in" — or your app
+   already knows the user's handle or DID from a previous session (see
+   [Identifying the user](#identifying-the-user))
+2. Your login handler registers the login attempt with ePDS (passing the
+   identifier as `login_hint`)
+3. Your app redirects the user's browser to the ePDS auth page (with the
+   same `login_hint`)
 4. ePDS immediately sends the OTP and shows the code-entry screen
 5. User reads the 8-digit code from their email and submits it
 6. ePDS verifies the code
@@ -339,6 +343,27 @@ function derToRaw(der: Buffer): Buffer {
 }
 ```
 
+### Identifying the user
+
+In Flow 1 your app passes an identifier for the user to ePDS in the
+OAuth `login_hint` parameter. ePDS accepts three forms:
+
+| Form   | Example                   | When to use                                                                                       |
+| ------ | ------------------------- | ------------------------------------------------------------------------------------------------- |
+| Email  | `alice@example.com`       | Your app collects email addresses (e.g. via a sign-in form).                                      |
+| Handle | `alice.pds.example.com`   | Your app already knows the user's AT Protocol handle (e.g. from a previous session, or a follow). |
+| DID    | `did:plc:abc123…`         | Your app stores users by DID and never sees their handle.                                         |
+
+All three behave the same way from the client's perspective: ePDS sends
+the OTP to the account's email address and shows the code-entry screen
+directly. Handles and DIDs are resolved internally by the auth service.
+
+If the identifier doesn't match any existing account, ePDS falls back to
+its own email input form (the same form used in Flow 2), so passing a
+stale or unknown handle is safe.
+
+In Flow 2 you simply omit `login_hint` entirely.
+
 ### Login handler — registering the login attempt
 
 Your login handler calls ePDS's `/oauth/par` endpoint to register the login
@@ -359,8 +384,9 @@ const parBody = new URLSearchParams({
   state,
   code_challenge: codeChallenge,
   code_challenge_method: 'S256',
-  // Flow 1 only — omit for Flow 2:
-  login_hint: email,
+  // Flow 1 only — omit for Flow 2.
+  // May be an email, an AT Protocol handle, or a DID — see above.
+  login_hint: identifier,
 })
 
 // First attempt (will get a 400 with dpop-nonce)
@@ -401,12 +427,14 @@ const { request_uri } = await parRes.json()
 ### Redirecting the user to ePDS
 
 After registering the login attempt, redirect the user's browser to the ePDS
-auth page. For Flow 1, include the email so ePDS skips its own email form and
-goes straight to OTP entry:
+auth page. For Flow 1, include the same `login_hint` you passed to `/oauth/par`
+so ePDS skips its own email form and goes straight to OTP entry. The
+identifier may be an email, an AT Protocol handle, or a DID — see
+[Identifying the user](#identifying-the-user):
 
 ```typescript
 // Flow 1
-const authUrl = `${authEndpoint}?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(request_uri)}&login_hint=${encodeURIComponent(email)}`
+const authUrl = `${authEndpoint}?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(request_uri)}&login_hint=${encodeURIComponent(identifier)}`
 
 // Flow 2
 const authUrl = `${authEndpoint}?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(request_uri)}`


### PR DESCRIPTION
## Summary

Several features released in v0.2.0 / v0.2.2 had landed in the code, the
`.env.example` files, and the `CHANGELOG`, but were never reflected in
`docs/`. This PR closes those gaps. Markdown-only — no code, no
`packages/demo`, no skill changes.

Linear: [HYPER-295](https://linear.app/hypercerts/issue/HYPER-295/document-released-v020v022-features-missing-from-docs)

Three commits, one per gap-cluster, easy to review individually:

1. **`docs(configuration)`** ([HYPER-301](https://linear.app/hypercerts/issue/HYPER-301))
   — `docs/configuration.md`:
   - New `### OTP code` subsection documenting `OTP_LENGTH` (4–12, default 8)
     and `OTP_CHARSET` (`numeric` / `alphanumeric`). Shipped in v0.2.0 (#14).
   - New `### Handle picker` subsection documenting `EPDS_DEFAULT_HANDLE_MODE`
     and pointing at the tutorial for the full per-client precedence rules.
     Shipped in v0.2.0 (#13/#29/#33/#36).
   - `AUTH_PORT` and `PDS_PORT` rows now mention the v0.2.0 `PORT` fallback
     precedence (#27): `AUTH_PORT → PORT → 3001` and `PDS_PORT → PORT → 3000`,
     so operators migrating pre-0.2.0 Railway setups can drop their
     service-specific port overrides.

2. **`docs(tutorial): epds_handle_mode`** ([HYPER-302](https://linear.app/hypercerts/issue/HYPER-302))
   — new `#### Optional: control the handle picker` subsection under
   _Register your app_, covering accepted values, the per-request
   precedence (query param → client metadata → env var → built-in default),
   and an example client metadata snippet plus the
   `?epds_handle_mode=` query-param override.

3. **`docs(tutorial): handle/DID login_hint`** ([HYPER-303](https://linear.app/hypercerts/issue/HYPER-303))
   — new `### Identifying the user` subsection documenting all three
   forms of `login_hint` (email / handle / DID) shipped in v0.2.0 (#3/#6).
   The Flow 1 step list and the PAR / authorize-redirect code snippets
   are updated to use a generic `identifier` variable and link back to the
   new subsection. The fallback behaviour ("if the identifier doesn't
   match an existing account, ePDS shows its own email form") is called
   out so apps can pass stale handles safely.

## Out of scope

- The confidential-client demo refactor (moving demo to
  `@atproto/oauth-client-node`) and related skill / tutorial OAuth
  integration rewrites — tracked separately.
- Retroactive `CHANGELOG` edits for v0.2.0 / v0.2.2 — the changelog is
  correct as shipped; this PR brings `docs/` into line with it.

## Test plan

- [x] `docs/configuration.md` renders cleanly on GitHub (tables, no
      mangled rows).
- [x] `docs/tutorial.md` renders cleanly on GitHub (heading hierarchy
      ###/#### intact, anchor link `#identifying-the-user` resolves).
- [x] Skim-read for contradictions with the existing tutorial examples
      (none expected — only additive, plus `email` → `identifier`
      rename in the two `login_hint` snippets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified port env var resolution order and updated defaults.
  * Added OTP configuration docs (length range, charset, startup validation).
  * Documented handle-picker modes and resolution precedence for picker control.
  * Updated Flow 1 tutorial to use a generic identifier (email, handle, or DID) and to reuse it as the OAuth login_hint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->