### PR TITLE
[HYPER-305] fix(pds-core): set PDS_VERSION fallback so /xrpc/_health reports version

### DIFF
--- a/.changeset/version-health-endpoint.md
+++ b/.changeset/version-health-endpoint.md
@@ -4,8 +4,8 @@
 
 The health endpoint now reports the running ePDS version.
 
-**Affects:** Operators
+**Affects:** Client app developers, Operators
 
-**Operators:** the `/health` endpoint on both pds-core and auth-service now includes a `version` field in its JSON response (e.g. `{ "status": "ok", "service": "epds", "version": "0.2.2+f37823ee" }`). In Docker and Railway deployments the version is automatically set to `<package.json version>+<8-char commit SHA>` at build time. In local dev it falls back to the root `package.json` version (e.g. `0.2.2`). To override, set the `EPDS_VERSION` environment variable to any string. The demo frontend also displays the version in its page footer.
+**Client app developers:** both `/health` endpoints (pds-core and auth-service) now include a `version` field in their JSON response (e.g. `{ "status": "ok", "service": "epds", "version": "0.2.2+f37823ee" }`). You can use this to check which ePDS release your app is running against. The demo frontend also displays the version in its page footer.
 
-Docker Compose users should now build with `pnpm docker:build` instead of `docker compose build` directly — the wrapper stamps the version before building, and the build will fail if the version stamp is missing.
+**Operators:** in Docker and Railway deployments the version is automatically set to `<package.json version>+<8-char commit SHA>` at build time. In local dev it falls back to the root `package.json` version (e.g. `0.2.2`). To override, set the `EPDS_VERSION` environment variable to any string. Docker Compose users should now build with `pnpm docker:build` instead of `docker compose build` directly — the wrapper stamps the version before building, and the build will fail if the version stamp is missing.

--- a/.changeset/xrpc-health-pds-version.md
+++ b/.changeset/xrpc-health-pds-version.md
@@ -1,0 +1,11 @@
+---
+'ePDS': patch
+---
+
+The upstream PDS version now appears on the stock health endpoint.
+
+**Affects:** Client app developers, Operators
+
+`/xrpc/_health` now returns the upstream `@atproto/pds` version in its JSON response (e.g. `{ "version": "0.4.211" }`). Previously this endpoint returned `{}`. This is independent of the ePDS version reported by `/health`.
+
+**Operators:** no configuration is needed — the version is read from the installed `@atproto/pds` package at startup. To override, set the `PDS_VERSION` environment variable.

--- a/e2e/cucumber.mjs
+++ b/e2e/cucumber.mjs
@@ -1,5 +1,6 @@
 export default {
   paths: [
+    'features/health.feature',
     'features/passwordless-authentication.feature',
     'features/automatic-account-creation.feature',
     'features/consent-screen.feature',

--- a/e2e/step-definitions/health.steps.ts
+++ b/e2e/step-definitions/health.steps.ts
@@ -1,0 +1,74 @@
+import { When, Then } from '@cucumber/cucumber'
+import type { EpdsWorld } from '../support/world.js'
+import { testEnv } from '../support/env.js'
+
+// Cucumber Expressions treat `/` as an alternation separator.
+// Use String.raw so `\/` reaches Cucumber as a literal escaped slash.
+
+// -- /health (ePDS version) --
+
+When(
+  String.raw`the PDS \/health endpoint is queried`,
+  async function (this: EpdsWorld) {
+    const res = await fetch(`${testEnv.pdsUrl}/health`)
+    this.lastHttpStatus = res.status
+    this.lastHttpJson = (await res.json()) as Record<string, unknown>
+  },
+)
+
+Then(
+  'the response contains an ePDS version string',
+  function (this: EpdsWorld) {
+    const { version } = this.lastHttpJson as { version?: string }
+    if (!version || typeof version !== 'string') {
+      throw new Error(
+        `/health response is missing "version": ${JSON.stringify(this.lastHttpJson)}`,
+      )
+    }
+    // Expect semver, optionally with +sha suffix (e.g. "0.2.2" or "0.2.2+f37823ee")
+    if (!/^\d+\.\d+\.\d+/.test(version)) {
+      throw new Error(
+        `/health version does not start with semver: "${version}"`,
+      )
+    }
+  },
+)
+
+// -- auth service /health (ePDS version) --
+
+When(
+  String.raw`the auth service \/health endpoint is queried`,
+  async function (this: EpdsWorld) {
+    const res = await fetch(`${testEnv.authUrl}/health`)
+    this.lastHttpStatus = res.status
+    this.lastHttpJson = (await res.json()) as Record<string, unknown>
+  },
+)
+
+// -- /xrpc/_health (upstream @atproto/pds version) --
+
+When(
+  String.raw`the PDS \/xrpc\/_health endpoint is queried`,
+  async function (this: EpdsWorld) {
+    const res = await fetch(`${testEnv.pdsUrl}/xrpc/_health`)
+    this.lastHttpStatus = res.status
+    this.lastHttpJson = (await res.json()) as Record<string, unknown>
+  },
+)
+
+Then(
+  'the response contains an upstream PDS version string',
+  function (this: EpdsWorld) {
+    const { version } = this.lastHttpJson as { version?: string }
+    if (!version || typeof version !== 'string') {
+      throw new Error(
+        `/xrpc/_health response is missing "version": ${JSON.stringify(this.lastHttpJson)}`,
+      )
+    }
+    if (!/^\d+\.\d+\.\d+/.test(version)) {
+      throw new Error(
+        `/xrpc/_health version does not start with semver: "${version}"`,
+      )
+    }
+  },
+)

--- a/features/health.feature
+++ b/features/health.feature
@@ -1,0 +1,18 @@
+Feature: Health endpoints
+  Both ePDS services expose /health with the ePDS version. The PDS also
+  exposes /xrpc/_health which reports the upstream @atproto/pds version.
+
+  Background:
+    Given the ePDS test environment is running
+
+  Scenario: PDS /health reports the ePDS version
+    When the PDS /health endpoint is queried
+    Then the response contains an ePDS version string
+
+  Scenario: Auth service /health reports the ePDS version
+    When the auth service /health endpoint is queried
+    Then the response contains an ePDS version string
+
+  Scenario: /xrpc/_health reports the upstream PDS version
+    When the PDS /xrpc/_health endpoint is queried
+    Then the response contains an upstream PDS version string

--- a/packages/pds-core/src/index.ts
+++ b/packages/pds-core/src/index.ts
@@ -25,6 +25,11 @@ applyPdsPortFallback()
 import type * as http from 'node:http'
 import { randomBytes, timingSafeEqual, createHash } from 'node:crypto'
 import { PDS, envToCfg, envToSecrets, readEnv } from '@atproto/pds'
+import { readFileSync } from 'node:fs'
+/* v8 ignore next 3 -- module-level init, only testable via e2e */
+const atprotoPdsPkg: { version: string } = JSON.parse(
+  readFileSync(require.resolve('@atproto/pds/package.json'), 'utf8'),
+)
 import { HandleUnavailableError } from '@atproto/oauth-provider'
 import {
   generateRandomHandle,
@@ -41,6 +46,7 @@ const logger = createLogger('pds-core')
 
 async function main() {
   const env = readEnv()
+  env.version ??= atprotoPdsPkg.version
   const cfg = envToCfg(env)
   const secrets = envToSecrets(env)
 


### PR DESCRIPTION
## Summary

- The vanilla `@atproto/pds` entrypoint does `env.version ??= pkg.version` to fall back to the package.json version when `PDS_VERSION` is unset
- ePDS omitted this, so `/xrpc/_health` returned `{}` instead of `{ "version": "0.4.211" }`
- One-line fix: read `@atproto/pds/package.json` version and apply the same `??=` fallback before `envToCfg()`

Note: this is the upstream PDS version on `/xrpc/_health`, separate from the ePDS version on `/health` (HYPER-304, PR #74).

## Test plan

- [ ] `curl https://<pds>/xrpc/_health` returns `{ "version": "0.4.211" }` (or current @atproto/pds version)
- [ ] `/health` still returns the ePDS version separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Startup now populates the app version from installed package metadata when not explicitly set.

* **New Features**
  * Health endpoints now include a version field in their JSON responses (both service and upstream PDS).

* **Tests**
  * Added end-to-end health checks validating presence and format of reported version strings.

* **Documentation**
  * Changeset notes updated to document version reporting and audience guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->