### PR TITLE
fix(ci): handle pr-base env name in e2e workflow dispatch

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       env_name:
-        description: "Railway env name, e.g. 'ePDS / ePDS-pr-48' or 'ePDS / pr-3897f1-47' (as shown in the Railway PR comment)"
+        description: "Railway env name, e.g. 'ePDS / ePDS-pr-48', 'ePDS / pr-3897f1-47', or 'ePDS / pr-base'"
         required: true
         type: string
 
@@ -518,6 +518,12 @@ jobs:
           fi
           ENV_NAME="${FULL_ENV##* / }"
           ENV_SLUG="${ENV_NAME,,}"
+          # Railway auto-generates PR env names as "ePDS-pr-<N>", but
+          # named envs (pr-base, test, …) use bare names without the
+          # project prefix. Strip "epds-" unless it's a PR env.
+          if [[ "$ENV_SLUG" == epds-* && ! "$ENV_SLUG" =~ ^epds-pr-[0-9]+$ ]]; then
+            ENV_SLUG="${ENV_SLUG#epds-}"
+          fi
           echo "  FULL_ENV = $FULL_ENV"
           echo "  ENV_NAME = $ENV_NAME"
           echo "  ENV_SLUG = $ENV_SLUG"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ script — all tests are run from the root via vitest.
 ### End-to-end tests in CI
 
 The e2e suite lives in `e2e/` and its feature files in `features/`. Normally
-the `E2E tests` workflow (`.github/workflows/e2e-pr.yml`) runs itself off
+the `E2E tests` workflow (`.github/workflows/e2e-tests.yml`) runs itself off
 Railway's `deployment_status` webhook — no action needed on an ordinary PR.
 
 To manually trigger it against a Railway environment (for e2e-only changes
@@ -79,9 +79,15 @@ that don't cause a rebuild, or to re-run without a new commit), **always
 pass both `--ref` and `-f env_name`**:
 
 ```bash
-gh workflow run e2e-pr.yml \
+# Against a PR environment:
+gh workflow run e2e-tests.yml \
   --ref <your-branch> \
   -f env_name="ePDS / ePDS-pr-<N>"
+
+# Against the persistent pr-base environment (post-merge backstop):
+gh workflow run e2e-tests.yml \
+  --ref main \
+  -f env_name="ePDS / pr-base"
 ```
 
 `--ref` controls which version of the feature files, step definitions, and

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -120,7 +120,7 @@ or scenarios and loads step definitions via `--import`.
 
 ## Running the CI e2e job against a Railway environment
 
-The `E2E tests` GitHub Actions workflow (`.github/workflows/e2e-pr.yml`) normally
+The `E2E tests` GitHub Actions workflow (`.github/workflows/e2e-tests.yml`) normally
 runs itself: whenever Railway successfully deploys a PR preview environment, it
 posts a `deployment_status` webhook that triggers the workflow against the
 environment it just deployed. For everyday PR work you don't need to do anything.
@@ -136,7 +136,7 @@ You do need to trigger it manually in two situations:
 Use `gh workflow run` with **both** `--ref` and `-f env_name`:
 
 ```bash
-gh workflow run e2e-pr.yml \
+gh workflow run e2e-tests.yml \
   --ref <your-branch> \
   -f env_name="ePDS / <railway-env-name>"
 ```
@@ -147,16 +147,17 @@ gh workflow run e2e-pr.yml \
   so your local changes won't be exercised — the workflow will run against
   old test code and produce confusing results.
 - `-f env_name="..."` is the display name shown in the Railway PR comment.
-  Use the exact string you see there. Both formats are accepted:
+  Use the exact string you see there. Accepted formats:
   - `ePDS / ePDS-pr-<N>` — standard PR environment name.
   - `ePDS / pr-<hash>-<N>` — Railway's collision-avoidance fallback, seen
     after a close/reopen or force-push inside the env-cleanup window.
     See [Railway discussion](https://station.railway.com/questions/pr-environment-name-format-change-causin-9aaa904f).
+  - `ePDS / pr-base` — the persistent post-merge backstop environment.
 
 Example:
 
 ```bash
-gh workflow run e2e-pr.yml \
+gh workflow run e2e-tests.yml \
   --ref fix/consent-use-upstream-oauth-ui \
   -f env_name="ePDS / ePDS-pr-21"
 ```
@@ -164,7 +165,7 @@ gh workflow run e2e-pr.yml \
 After dispatching, watch the run:
 
 ```bash
-gh run list --workflow=e2e-pr.yml --event=workflow_dispatch --limit 1
+gh run list --workflow=e2e-tests.yml --event=workflow_dispatch --limit 1
 gh run watch <run-id>
 ```
 


### PR DESCRIPTION
## Summary

- Normalise `ePDS-pr-base` → `pr-base` in the e2e workflow's URL slug derivation, so manually dispatching with `env_name="ePDS / ePDS-pr-base"` works correctly
- Add `ePDS / pr-base` to the `workflow_dispatch` input description
- Document pr-base usage in `AGENTS.md` and `e2e/README.md`
- Fix stale `e2e-pr.yml` filename references → `e2e-tests.yml` in both docs

## Test plan

- [ ] Manually dispatch e2e workflow with `env_name="ePDS / pr-base"` and verify it passes
- [ ] Manually dispatch e2e workflow with `env_name="ePDS / ePDS-pr-base"` and verify normalisation produces correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated end-to-end testing instructions with new workflow references.
* Added support for the persistent `pr-base` environment format for test execution in addition to PR-specific formats.
* Included examples for running tests in both PR and post-merge environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->