### PR TITLE
docs: clarify which service each env var belongs to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
   **Client app developers:** both `/health` endpoints (pds-core and auth-service) now include a `version` field in their JSON response (e.g. `{ "status": "ok", "service": "epds", "version": "0.2.2+f37823ee" }`). You can use this to check which ePDS release your app is running against. The demo frontend also displays the version in its page footer.
 
-  **Operators:** in Docker and Railway deployments the version is automatically set to `<package.json version>+<8-char commit SHA>` at build time. In local dev it falls back to the root `package.json` version (e.g. `0.2.2`). To override, set the `EPDS_VERSION` environment variable to any string. Docker Compose users should now build with `pnpm docker:build` instead of `docker compose build` directly — the wrapper stamps the version before building, and the build will fail if the version stamp is missing.
+  **Operators:** in Docker and Railway deployments the version is automatically set to `<package.json version>+<8-char commit SHA>` at build time. In local dev it falls back to the root `package.json` version (e.g. `0.2.2`). To override, set the `EPDS_VERSION` environment variable on both pds-core and auth-service to any string. Docker Compose users should now build with `pnpm docker:build` instead of `docker compose build` directly — the wrapper stamps the version before building, and the build will fail if the version stamp is missing.
 
 ### Patch Changes
 
@@ -26,7 +26,7 @@
 
   `/xrpc/_health` now returns the upstream `@atproto/pds` version in its JSON response (e.g. `{ "version": "0.4.211" }`). Previously this endpoint returned `{}`. This is independent of the ePDS version reported by `/health`.
 
-  **Operators:** no configuration is needed — the version is read from the installed `@atproto/pds` package at startup. To override, set the `PDS_VERSION` environment variable.
+  **Operators:** no configuration is needed — the version is read from the installed `@atproto/pds` package at startup. To override, set the `PDS_VERSION` environment variable on pds-core.
 
 ## 0.2.2
 
@@ -58,7 +58,7 @@
 
   **Client app developers:** To opt in, your client metadata must include `epds_skip_consent_on_signup: true`. The skip only applies on initial sign-up, only for trusted clients, and only when the server is configured to allow it.
 
-  **Operators:** This feature has separate configuration from the normal consent-screen changes. To enable it, set `PDS_SIGNUP_ALLOW_CONSENT_SKIP=true`. The skip only applies to clients already trusted via `PDS_OAUTH_TRUSTED_CLIENTS` and only when the client metadata opts in with `epds_skip_consent_on_signup: true`.
+  **Operators:** This feature has separate configuration from the normal consent-screen changes. To enable it, set `PDS_SIGNUP_ALLOW_CONSENT_SKIP=true` on pds-core. The skip only applies to clients already trusted via `PDS_OAUTH_TRUSTED_CLIENTS` (also on pds-core) and only when the client metadata opts in with `epds_skip_consent_on_signup: true`.
 
 - <a id="v0.2.2-sign-in-no-longer-fails-when-the-login-service-and-your"></a> [#65](https://github.com/hypercerts-org/ePDS/pull/65) [`313c071`](https://github.com/hypercerts-org/ePDS/commit/313c07176ac04ae6f517f18cfe95cf15af1d0812) Thanks [@aspiers](https://github.com/aspiers)! - Sign-in no longer fails when the login service and your data server share a domain name.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,8 @@ auto-generate secrets. Safe to re-run — existing secrets are preserved.
 
 ## Shared variables
 
+> Set these on **both** pds-core and auth-service. In Docker Compose they come from the single top-level `.env`; on Railway, use a shared variable group or paste identical values into both services.
+
 These must have **identical values** in pds-core and auth-service. They are
 marked `[shared]` in the per-package `.env.example` files.
 
@@ -35,6 +37,8 @@ marked `[shared]` in the per-package `.env.example` files.
 | `LOG_LEVEL`            | Log verbosity: `fatal`, `error`, `warn`, `info` (default), `debug`, or `trace`. Applied to both pds-core and auth-service.                                                                                                                                   |
 
 ## PDS Core
+
+> All variables in this section are set on the **pds-core** service only (except shared variables listed above).
 
 | Variable                                    | Description                                                                                                                                           |
 | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -69,6 +73,8 @@ Optional PDS email variables:
 | `PDS_MODERATION_EMAIL_ADDRESS`  | Moderation report address                        |
 
 ## Auth Service
+
+> All variables in this section are set on the **auth-service** only.
 
 | Variable              | Description                                                                                                                                                                                                 |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -143,6 +149,8 @@ buttons appear on the login page.
 
 ## Demo
 
+> All variables in this section are set on the **demo** service only.
+
 The demo is standalone — it does not share variables with pds-core or
 auth-service.
 
@@ -161,12 +169,16 @@ Optional:
 
 ## Docker / Caddy
 
+> These variables are for the Caddy reverse-proxy container only (not applicable on Railway).
+
 | Variable        | Description                                                |
 | --------------- | ---------------------------------------------------------- |
 | `PDS_UPSTREAM`  | Override PDS reverse proxy upstream (default `core:3000`)  |
 | `AUTH_UPSTREAM` | Override auth reverse proxy upstream (default `auth:3001`) |
 
 ## Runtime
+
+> Set on **pds-core**.
 
 | Variable       | Description                    |
 | -------------- | ------------------------------ |

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -34,7 +34,7 @@ back to your app, and your app exchanges that redirect for a token.
 3. Your app redirects the user's browser to the ePDS auth page (with the
    same `login_hint`)
 4. ePDS immediately sends the OTP and shows the code-entry screen
-5. User reads the 8-digit code from their email and submits it
+5. User reads the code from their email and submits it
 6. ePDS verifies the code
 7. **New users only**: ePDS shows a handle picker — user chooses their handle
 8. ePDS redirects back to your app's callback URL
@@ -53,7 +53,7 @@ Flow 2 covers three input variants — all use the same code path:
 3. Library sends PAR request, stores state, returns auth URL
 4. Your app redirects the user's browser to the auth URL
 5. ePDS collects email if needed, sends the OTP, shows the code-entry screen
-6. User reads the 8-digit code from their email and submits it
+6. User reads the code from their email and submits it
 7. ePDS verifies the code
 8. **New users only**: ePDS shows a handle picker — user chooses their handle
 9. ePDS redirects back to your app's callback URL
@@ -83,7 +83,7 @@ sequenceDiagram
     Auth->>Auth: Creates auth_flow row (flow_id, request_uri)<br/>Sets epds_auth_flow cookie
     Auth->>Auth: Sends OTP to email (via better-auth, server-side JS call)
     Auth-->>User: Renders page with OTP input visible<br/>(email step hidden)
-    Auth->>Email: Sends 8-digit OTP code
+    Auth->>Email: Sends OTP code
 
     User->>Email: Reads OTP code
     User->>Auth: Submits OTP code
@@ -139,7 +139,7 @@ sequenceDiagram
     User->>Auth: Submits email address
     Auth->>Auth: Sends OTP to email (via better-auth JS call)
     Auth-->>User: Shows OTP input
-    Auth->>Email: Sends 8-digit OTP code
+    Auth->>Email: Sends OTP code
 
     User->>Email: Reads OTP code
     User->>Auth: Submits OTP code
@@ -274,7 +274,7 @@ placeholder. Supported template variables:
 
 | Variable                              | Description                               |
 | ------------------------------------- | ----------------------------------------- |
-| `{{code}}`                            | The 8-digit OTP code (required)           |
+| `{{code}}`                            | The OTP code (required)                   |
 | `{{app_name}}`                        | Value of `client_name` from your metadata |
 | `{{logo_uri}}`                        | Value of `logo_uri` from your metadata    |
 | `{{#is_new_user}}...{{/is_new_user}}` | Shown only on first sign-up               |


### PR DESCRIPTION
## Summary

- Add service-attribution notes (as blockquotes) to each section of `docs/configuration.md` so operators who search or jump into the page immediately see which Railway service or Docker container a variable belongs on
- Remove hardcoded "8-digit" OTP references from `docs/tutorial.md` since `OTP_LENGTH` is configurable (range 4-12, default 8)

Prompted by discovering that `epds1.test` had `OTP_LENGTH=6` set on its auth-service, which was confusing because the docs didn't make it obvious that OTP configuration lives on the auth-service specifically.

## Test plan

- [ ] Verify `docs/configuration.md` renders correctly on GitHub (blockquotes under each section heading)
- [ ] Verify `docs/tutorial.md` Mermaid diagrams still render (removed "8-digit" from sequence diagram labels)
- [ ] Spot-check that no "8-digit" references remain in tutorial.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)