### PR TITLE
fix(pds-core): redact request_uri from CSS middleware log

### DIFF
--- a/packages/pds-core/src/lib/client-css-injection.ts
+++ b/packages/pds-core/src/lib/client-css-injection.ts
@@ -172,7 +172,7 @@ export function createClientCssInjectionMiddleware({
           clientId = await resolveClientIdFromRequestUri(requestUri)
         } catch (err) {
           logger.warn(
-            { err, requestUri },
+            { err, hasRequestUri: true },
             'CSS middleware: failed to resolve client_id from request_uri',
           )
         }


### PR DESCRIPTION
## Summary
- Stop logging raw PAR `request_uri` values in the CSS injection middleware's warn log. Log only presence (`hasRequestUri: true`) since the URI is an opaque short-lived handle.

Addresses CodeRabbit review comment on PR #48: https://github.com/hypercerts-org/ePDS/pull/48#discussion_r3080255602

## Test plan
- [x] Existing unit tests pass (19/19 in client-css-injection.test.ts)
- [ ] Verify Railway pds-core logs no longer contain raw request_uri values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging during client-side CSS injection by avoiding potentially sensitive request URI details while retaining relevant diagnostic information.

* **Chores**
  * Updated code coverage thresholds for reporting and failure detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->