### PR TITLE
feat(auth-service): style all error pages with shared renderError

### DIFF
--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -145,7 +145,10 @@ export function createAuthService(config: AuthServiceConfig): {
       next: express.NextFunction,
     ) => {
       logger.error({ err, path: req.path }, 'Unhandled error in auth-service')
-      if (res.headersSent) return next(err)
+      if (res.headersSent) {
+        next(err)
+        return
+      }
       if (req.accepts('html')) {
         res
           .status(500)

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -142,10 +142,10 @@ export function createAuthService(config: AuthServiceConfig): {
       err: unknown,
       req: express.Request,
       res: express.Response,
-      _next: express.NextFunction,
+      next: express.NextFunction,
     ) => {
       logger.error({ err, path: req.path }, 'Unhandled error in auth-service')
-      if (res.headersSent) return
+      if (res.headersSent) return next(err)
       if (req.accepts('html')) {
         res.status(500).send(renderError('Something went wrong. Please try again.'))
       } else {

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -147,7 +147,9 @@ export function createAuthService(config: AuthServiceConfig): {
       logger.error({ err, path: req.path }, 'Unhandled error in auth-service')
       if (res.headersSent) return next(err)
       if (req.accepts('html')) {
-        res.status(500).send(renderError('Something went wrong. Please try again.'))
+        res
+          .status(500)
+          .send(renderError('Something went wrong. Please try again.'))
       } else {
         res.status(500).json({ error: 'internal_error' })
       }

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -16,6 +16,7 @@ import { createAccountSettingsRouter } from './routes/account-settings.js'
 import { createCompleteRouter } from './routes/complete.js'
 import { createChooseHandleRouter } from './routes/choose-handle.js'
 import { resolveAuthPort } from './lib/resolve-port.js'
+import { renderError } from './lib/render-error.js'
 
 const logger = createLogger('auth-service')
 
@@ -117,6 +118,41 @@ export function createAuthService(config: AuthServiceConfig): {
   app.get('/health', (_req, res) => {
     res.json({ status: 'ok', service: 'auth', version: getEpdsVersion() })
   })
+
+  // Styled 404 for any unmatched HTML route. JSON clients get JSON.
+  app.use((req, res) => {
+    if (req.accepts('html')) {
+      res
+        .status(404)
+        .send(
+          renderError(
+            "The page you're looking for doesn't exist.",
+            'Page not found',
+          ),
+        )
+    } else {
+      res.status(404).json({ error: 'not_found' })
+    }
+  })
+
+  // Styled 500 for any uncaught error. Log the cause, keep the user-facing
+  // message generic to avoid leaking internals.
+  app.use(
+    (
+      err: unknown,
+      req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      logger.error({ err, path: req.path }, 'Unhandled error in auth-service')
+      if (res.headersSent) return
+      if (req.accepts('html')) {
+        res.status(500).send(renderError('Something went wrong. Please try again.'))
+      } else {
+        res.status(500).json({ error: 'internal_error' })
+      }
+    },
+  )
 
   return { app, ctx }
 }

--- a/packages/auth-service/src/lib/render-error.ts
+++ b/packages/auth-service/src/lib/render-error.ts
@@ -1,0 +1,27 @@
+import { escapeHtml } from '@certified-app/shared'
+
+const ERROR_CSS = `
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 20px; }
+  .container { background: white; border-radius: 12px; padding: 40px; max-width: 420px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
+  h1 { font-size: 24px; margin-bottom: 16px; color: #111; }
+  .error { color: #dc3545; background: #fdf0f0; padding: 12px; border-radius: 8px; font-size: 15px; line-height: 1.5; }
+`
+
+export function renderError(message: string, title = 'Error'): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)}</title>
+  <style>${ERROR_CSS}</style>
+</head>
+<body>
+  <div class="container">
+    <h1>${escapeHtml(title)}</h1>
+    <p class="error">${escapeHtml(message)}</p>
+  </div>
+</body>
+</html>`
+}

--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -10,6 +10,7 @@ import {
 import { fromNodeHeaders } from 'better-auth/node'
 import { getDidByEmail } from '../lib/get-did-by-email.js'
 import { ensurePdsUrl } from '../lib/pds-url.js'
+import { renderError } from '../lib/render-error.js'
 
 const logger = createLogger('auth:account-settings')
 
@@ -142,7 +143,7 @@ export function createAccountSettingsRouter(
   router.get('/account/backup-email/verify', (req: Request, res: Response) => {
     const token = req.query.token as string | undefined
     if (!token) {
-      res.status(400).send('<p>Missing verification token.</p>')
+      res.status(400).send(renderError('Missing verification token.'))
       return
     }
 
@@ -172,7 +173,7 @@ export function createAccountSettingsRouter(
   router.post('/account/backup-email/verify', (req: Request, res: Response) => {
     const token = ((req.body.token as string) || '').trim()
     if (!token) {
-      res.status(400).send('<p>Missing verification token.</p>')
+      res.status(400).send(renderError('Missing verification token.'))
       return
     }
 

--- a/packages/auth-service/src/routes/choose-handle.ts
+++ b/packages/auth-service/src/routes/choose-handle.ts
@@ -28,6 +28,7 @@ import { fromNodeHeaders } from 'better-auth/node'
 import { getDidByEmail } from '../lib/get-did-by-email.js'
 import { pingParRequest } from '../lib/ping-par-request.js'
 import { requireInternalEnv } from '../lib/require-internal-env.js'
+import { renderError } from '../lib/render-error.js'
 import { resolveClientBranding } from '../lib/client-metadata.js'
 import { renderOptionalStyleTag } from '../lib/page-helpers.js'
 
@@ -691,10 +692,3 @@ function renderChooseHandlePage(
 </html>`
 }
 
-function renderError(message: string): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"><title>Error</title></head>
-<body><p style="color:red;padding:20px">${escapeHtml(message)}</p></body>
-</html>`
-}

--- a/packages/auth-service/src/routes/choose-handle.ts
+++ b/packages/auth-service/src/routes/choose-handle.ts
@@ -691,4 +691,3 @@ function renderChooseHandlePage(
 </body>
 </html>`
 }
-

--- a/packages/auth-service/src/routes/complete.ts
+++ b/packages/auth-service/src/routes/complete.ts
@@ -28,6 +28,7 @@ import { fromNodeHeaders } from 'better-auth/node'
 import { getDidByEmail } from '../lib/get-did-by-email.js'
 import { pingParRequest } from '../lib/ping-par-request.js'
 import { requireInternalEnv } from '../lib/require-internal-env.js'
+import { renderError } from '../lib/render-error.js'
 
 const logger = createLogger('auth:complete')
 
@@ -49,7 +50,7 @@ export function createCompleteRouter(
       logger.warn('No epds_auth_flow cookie found on /auth/complete')
       res
         .status(400)
-        .send('<p>Authentication session expired. Please try again.</p>')
+        .send(renderError('Authentication session expired. Please try again.'))
       return
     }
 
@@ -60,7 +61,7 @@ export function createCompleteRouter(
       res.clearCookie(AUTH_FLOW_COOKIE)
       res
         .status(400)
-        .send('<p>Authentication session expired. Please try again.</p>')
+        .send(renderError('Authentication session expired. Please try again.'))
       return
     }
 
@@ -73,7 +74,9 @@ export function createCompleteRouter(
       })
     } catch (err) {
       logger.error({ err }, 'Failed to get better-auth session')
-      res.status(500).send('<p>Authentication failed. Please try again.</p>')
+      res
+        .status(500)
+        .send(renderError('Authentication failed. Please try again.'))
       return
     }
 

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -579,4 +579,3 @@ function renderLoginPage(opts: {
 </body>
 </html>`
 }
-

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -43,6 +43,7 @@ import {
 } from '../lib/resolve-login-hint.js'
 import { ensurePdsUrl } from '../lib/pds-url.js'
 import { renderOptionalStyleTag } from '../lib/page-helpers.js'
+import { renderError } from '../lib/render-error.js'
 
 const logger = createLogger('auth:login-page')
 
@@ -579,10 +580,3 @@ function renderLoginPage(opts: {
 </html>`
 }
 
-function renderError(message: string): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"><title>Error</title></head>
-<body><p style="color:red;padding:20px">${escapeHtml(message)}</p></body>
-</html>`
-}

--- a/packages/auth-service/src/routes/recovery.ts
+++ b/packages/auth-service/src/routes/recovery.ts
@@ -20,6 +20,7 @@ import { createLogger, escapeHtml, maskEmail } from '@certified-app/shared'
 import { buildOtpInputProps } from '../otp-input.js'
 import { resolveClientBranding } from '../lib/client-metadata.js'
 import { renderOptionalStyleTag } from '../lib/page-helpers.js'
+import { renderError } from '../lib/render-error.js'
 
 const logger = createLogger('auth:recovery')
 
@@ -189,7 +190,7 @@ export function createRecoveryRouter(
     const requestUri = req.body.request_uri as string
 
     if (!code || !email || !requestUri) {
-      res.status(400).send('<p>Missing required fields.</p>')
+      res.status(400).send(renderError('Missing required fields.'))
       return
     }
 
@@ -343,14 +344,6 @@ function renderOtpForm(opts: {
     <a href="${backHref}" class="btn-secondary">Back to sign in</a>
   </div>
 </body>
-</html>`
-}
-
-function renderError(message: string): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"><title>Error</title><style>${CSS}</style></head>
-<body><div class="container"><h1>Error</h1><p class="error">${escapeHtml(message)}</p></div></body>
 </html>`
 }
 


### PR DESCRIPTION
## Summary
- Introduce `lib/render-error.ts` as a single styled template for all auth-service error pages and route every error response through it.
- Replace bare `<p>`-only error responses across `complete.ts`, `recovery.ts`, `choose-handle.ts`, and `account-settings.ts`; delete three duplicate local `renderError` functions (`login-page`, `choose-handle`, `recovery`).
- Add catch-all 404 + 500 middleware so unmatched paths and uncaught errors render the same styled card instead of Express's default text output (JSON clients still get JSON).

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm --filter @certified-app/auth-service test` passes
- [x] Manual visual check — confirmed styled card rendered for:
  - `GET /auth/complete` (no cookie) → "Authentication session expired"
  - `GET /` → styled 404 "Page not found"
- [ ] Reviewer: spot-check any other error paths (e.g. recovery OTP failure, choose-handle session expiry) render the styled card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catch-all handler returning a styled 404 page for browsers and JSON for non‑HTML clients.
  * Shared HTML error renderer applied across auth routes for consistent error pages.

* **Bug Fixes**
  * Centralized error-handling middleware that logs errors and returns proper 500 responses for HTML and non‑HTML clients.
  * Error output is HTML-escaped to prevent injection and ensure safer error rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->