### PR TITLE
feat(preview): in-browser email previews

### DIFF
--- a/.changeset/demo-client-email-branding.md
+++ b/.changeset/demo-client-email-branding.md
@@ -1,0 +1,11 @@
+---
+'ePDS': minor
+---
+
+Trusted demo client now ships with a custom branded OTP email template.
+
+**Affects:** Client app developers, Operators
+
+**Client app developers:** the demo client's `client-metadata.json` now advertises `email_template_uri` (pointing at `/email-template.html` on the same origin) and `email_subject_template` (`{{code}} — your {{app_name}} code`), so operators running ePDS with the demo as a trusted client see a visually coherent login + email experience out of the box. The template is a minimal Mustache-style HTML email that respects the demo's `EPDS_CLIENT_THEME` palette: the OTP box, headings, and background all match whichever theme is active on the login and consent pages. Copy the shape from `packages/demo/src/app/email-template.html/route.ts` if you want a starting point for your own client's branded template — the supported placeholders are `{{code}}`, `{{app_name}}`, `{{logo_uri}}`, `{{email}}`, and the conditional blocks `{{#is_new_user}}…{{/is_new_user}}` / `{{^is_new_user}}…{{/is_new_user}}`.
+
+**Operators:** no env var change is required — the demo's branded email is served automatically when you run the bundled demo client as a trusted client on `PDS_OAUTH_TRUSTED_CLIENTS`. The template is served from the demo's own origin (`<demo-base-url>/email-template.html`) with `Cache-Control: public, max-age=300`, is capped at the same 100 KB / 5 s limits `makeSafeFetch` applies to any remote email template, and is only honoured for `client_id`s on the trusted-clients list (see the `gate-email-templates-on-trusted-clients` changeset). You can verify what your users will receive by opening `/preview/emails/returning-user?client_id=<demo-base-url>/client-metadata.json` on the auth service with `AUTH_PREVIEW_ROUTES=1`.

--- a/.changeset/in-browser-email-previews.md
+++ b/.changeset/in-browser-email-previews.md
@@ -1,0 +1,17 @@
+---
+'ePDS': minor
+---
+
+Preview the transactional emails ePDS sends, directly in your browser.
+
+**Affects:** Client app developers, Operators
+
+**Client app developers:** three new preview routes on the auth service render the exact email HTML real users receive, inside a sandboxed iframe:
+
+- `/preview/emails/new-user` — welcome / email-verification code sent during signup.
+- `/preview/emails/returning-user` — sign-in OTP sent when an existing user logs in to your app.
+- `/preview/emails/recovery` — backup-email verification link sent when a user adds a recovery address.
+
+Each route accepts the same `?client_id=<URL-of-your-client-metadata.json>` query param as the other preview pages, so you can see how your branded template will look without walking through a real OAuth flow. Optional extras: `?otp=<code>` to override the fixture OTP, `?app=<name>` to override the fixture app name on the returning-user template, `?verify_url=<url>` to override the backup-email verification link. Links for all three are wired into the `/preview` index page on the auth service.
+
+**Operators:** gated by the existing `AUTH_PREVIEW_ROUTES=1` flag — no new environment variables. When the flag is off the new routes return 404, identical to the rest of `/preview/*`. The previews do not touch SMTP; they call the same template builders the real sender uses, so what renders is bit-for-bit what production would put in the envelope. Intended for preview and development environments; leave the flag off in production.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -84,7 +84,23 @@ jobs:
       # needs checks:write.
       checks: write
     steps:
+      # On pull_request, `actions/checkout`'s default is the GitHub-synthesized
+      # merge commit (refs/pull/N/merge = base + head). Railway, however,
+      # deploys the PR *branch head* — there's no way to point it at a merge
+      # commit (see https://docs.railway.com/deployments/github-autodeploys).
+      # Running E2E test code from the merge commit against a Railway
+      # deployment of the head commit means main-advancing tests fail against
+      # a pre-merge-commit runtime (e.g. a new scenario asserting UI that
+      # exists on main but not yet on the PR branch). Pin checkout to the PR
+      # head SHA so both sides share one SHA. Trade-off: we won't catch
+      # main-incompatibilities until the branch is rebased — but the rebase
+      # is already the mitigation, so this makes the contract explicit.
+      # On push / workflow_dispatch, `ref` is empty → default behaviour.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Empty on push / workflow_dispatch → falls back to checkout's
+          # default (GITHUB_SHA for the triggering event).
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/e2e/step-definitions/email.steps.ts
+++ b/e2e/step-definitions/email.steps.ts
@@ -68,7 +68,6 @@ Then('an OTP email arrives in the mail trap', async function (this: EpdsWorld) {
   this.otpCode = await extractOtp(message.ID)
 })
 
-// "Welcome" for new users, "Sign-in" for returning users
 Then(
   'the email subject contains {string}',
   function (this: EpdsWorld, expected: string) {

--- a/features/email-delivery.feature
+++ b/features/email-delivery.feature
@@ -7,17 +7,21 @@ Feature: Email delivery
     Given the ePDS test environment is running
     And a mail trap is capturing outbound emails
 
+  # The demo client is on PDS_OAUTH_TRUSTED_CLIENTS and advertises its own
+  # email_subject_template ("{{code}} — your {{app_name}} code"), so the
+  # subject is the same shape for new and returning users. The welcome vs
+  # sign-in distinction is asserted by the preview + unit tests, not here.
   Scenario: New user receives a welcome OTP email
     When the user requests an OTP for a unique test email
     Then an OTP email arrives in the mail trap for the test email
-    And the email subject contains "Welcome"
+    And the email subject contains "ePDS Demo"
     And the email body contains an OTP code matching the configured charset
 
   Scenario: Returning user receives a sign-in OTP email
     Given a returning user has a PDS account
     When the user requests an OTP for the test email
     Then an OTP email arrives in the mail trap for the test email
-    And the email subject contains "Sign-in"
+    And the email subject contains "ePDS Demo"
 
   Scenario: Backup email verification link is delivered
     Given the user is logged into account settings

--- a/features/passwordless-authentication.feature
+++ b/features/passwordless-authentication.feature
@@ -17,8 +17,9 @@ Feature: Passwordless authentication via email OTP
     And the login page displays an email input form
     When the user enters a unique test email and submits
     Then an OTP email arrives in the mail trap for the test email
-    # "Welcome" for new users, "Sign-in" for returning users
-    And the email subject contains "Welcome"
+    # Demo is a trusted client with its own branded email_subject_template
+    # ("{{code}} — your {{app_name}} code"), so subject contains app name.
+    And the email subject contains "ePDS Demo"
     And the login page shows an OTP verification form
     When the user enters the OTP code
     And the user picks a handle
@@ -31,7 +32,7 @@ Feature: Passwordless authentication via email OTP
     When the demo client initiates an OAuth login
     And the user enters the test email on the login page
     Then an OTP email arrives in the mail trap
-    And the email subject contains "Sign-in"
+    And the email subject contains "ePDS Demo"
     When the user enters the OTP code
     Then the browser is redirected back to the demo client with a valid session
 
@@ -41,7 +42,7 @@ Feature: Passwordless authentication via email OTP
     When the demo client initiates an OAuth login
     And the user enters the test email on the login page
     Then an OTP email arrives in the mail trap
-    And the email subject contains "Sign-in"
+    And the email subject contains "ePDS Demo"
     When the user enters the OTP code
     Then the browser is redirected back to the demo client with a valid session
 

--- a/packages/auth-service/src/__tests__/email-template.test.ts
+++ b/packages/auth-service/src/__tests__/email-template.test.ts
@@ -212,6 +212,48 @@ describe('EmailSender', () => {
     })
   })
 
+  describe('sendOtpCode — header-injection hardening', () => {
+    const TRUSTED_ID = 'https://hdr.app/client-metadata.json'
+
+    it('strips CR/LF from client_name (From) and email_subject_template (Subject)', async () => {
+      // Even for trusted clients, metadata can be compromised upstream.
+      // A CR/LF in Subject or the From display-name would let an attacker
+      // inject extra SMTP headers (Bcc, Reply-To, …) after it.
+      _seedClientMetadataCacheForTest(TRUSTED_ID, {
+        client_name: 'Evil\r\nBcc: attacker@evil.example',
+        email_template_uri: 'https://hdr.app/email-template.html',
+        email_subject_template: '{{code}}\r\nBcc: leak@evil.example',
+      })
+      _seedTemplateCacheForTest(
+        'https://hdr.app/email-template.html',
+        '<html><body>{{code}}</body></html>',
+      )
+
+      const sender = makeSender([TRUSTED_ID])
+      const sendMailSpy = vi.spyOn(sender['transporter'], 'sendMail')
+
+      await sender.sendOtpCode({
+        to: 'u@test.com',
+        code: '11112222',
+        clientAppName: 'Fallback',
+        clientId: TRUSTED_ID,
+        pdsName: 'Test PDS',
+        pdsDomain: 'pds.example',
+      })
+
+      const mailOpts = sendMailSpy.mock.calls[0][0] as {
+        subject: string
+        from: string
+      }
+      // Key guarantee: no CR/LF in any value that lands in an SMTP
+      // header — that's what an injection attack needs. The literal
+      // string "Bcc:" surviving as *body text in the Subject* is
+      // harmless; SMTP parses headers by line, not by substring.
+      expect(mailOpts.subject).not.toMatch(/[\r\n]/)
+      expect(mailOpts.from).not.toMatch(/[\r\n]/)
+    })
+  })
+
   describe('sendBackupEmailVerification', () => {
     it('sends verification email', async () => {
       const sender = makeSender()

--- a/packages/auth-service/src/__tests__/email-templates.test.ts
+++ b/packages/auth-service/src/__tests__/email-templates.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the pure email builders used by both the real sender and the
+ * /preview/emails/* routes. Covers subject, plain-text alternative, and
+ * HTML shape — the preview routes render this HTML verbatim inside an
+ * iframe, so it's worth pinning.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  buildSignInCodeEmail,
+  buildWelcomeCodeEmail,
+  buildBackupEmailVerificationEmail,
+} from '../email/templates.js'
+
+const PDS = { pdsName: 'Test PDS', pdsDomain: 'pds.example' }
+
+describe('buildSignInCodeEmail', () => {
+  it('puts the OTP and app name in the subject, text, and html', () => {
+    const { subject, text, html } = buildSignInCodeEmail({
+      code: '12345678',
+      clientAppName: 'My App',
+      ...PDS,
+    })
+    expect(subject).toContain('Test PDS')
+    expect(subject).toContain('1234 5678')
+    expect(text).toContain('My App')
+    expect(text).toContain('12345678')
+    expect(html).toContain('My App')
+    // formatOtpHtmlGrouped renders each digit in its own span.
+    expect(html).toContain('<!DOCTYPE html>')
+  })
+
+  it('escapes HTML in the app name and pds identity', () => {
+    const { html } = buildSignInCodeEmail({
+      code: '123456',
+      clientAppName: '<script>x</script>',
+      pdsName: '<b>Name</b>',
+      pdsDomain: 'a&b.example',
+    })
+    expect(html).not.toContain('<script>x</script>')
+    expect(html).toContain('&lt;script&gt;x&lt;/script&gt;')
+    expect(html).toContain('&lt;b&gt;Name&lt;/b&gt;')
+    expect(html).toContain('a&amp;b.example')
+  })
+})
+
+describe('buildWelcomeCodeEmail', () => {
+  it('uses the welcome subject and includes the verification code', () => {
+    const { subject, text, html } = buildWelcomeCodeEmail({
+      code: '654321',
+      ...PDS,
+    })
+    expect(subject).toContain('Welcome to Test PDS')
+    expect(subject).toContain('654321')
+    expect(text).toContain('Welcome to Test PDS')
+    expect(text).toContain('654321')
+    expect(html).toContain('Welcome to Test PDS')
+  })
+})
+
+describe('buildBackupEmailVerificationEmail', () => {
+  it('puts the verify URL in both the text and the html anchor', () => {
+    const url = 'https://auth.example/account/verify?t=abc'
+    const { subject, text, html } = buildBackupEmailVerificationEmail({
+      verifyUrl: url,
+      ...PDS,
+    })
+    expect(subject).toBe('Verify your backup email - Test PDS')
+    expect(text).toContain(url)
+    expect(html).toContain(`href="${url}"`)
+  })
+
+  it('escapes a malicious verify URL', () => {
+    const { html } = buildBackupEmailVerificationEmail({
+      verifyUrl: 'https://x.example/"><script>alert(1)</script>',
+      ...PDS,
+    })
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+})

--- a/packages/auth-service/src/__tests__/email-templates.test.ts
+++ b/packages/auth-service/src/__tests__/email-templates.test.ts
@@ -67,6 +67,9 @@ describe('buildBackupEmailVerificationEmail', () => {
     expect(subject).toBe('Verify your backup email - Test PDS')
     expect(text).toContain(url)
     expect(html).toContain(`href="${url}"`)
+    // Complete-document shell so the preview iframe renders in standards
+    // mode, matching the other two builders.
+    expect(html).toContain('<!DOCTYPE html>')
   })
 
   it('escapes a malicious verify URL', () => {

--- a/packages/auth-service/src/__tests__/preview-emails.test.ts
+++ b/packages/auth-service/src/__tests__/preview-emails.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests for /preview/emails/* routes. Bring up an express
+ * app with the preview-emails router mounted, listen on an ephemeral
+ * port, and hit it with fetch. The real EmailSender is not constructed
+ * — we cast a minimal AuthServiceContext stub because the router only
+ * reads `config.email.{from,fromName}` and `config.{hostname,pdsHostname}`.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import express, { type Express } from 'express'
+import type { AddressInfo } from 'node:net'
+import type { Server } from 'node:http'
+import { createPreviewEmailsRouter } from '../routes/preview-emails.js'
+import type { AuthServiceContext } from '../context.js'
+
+function makeCtxStub(): AuthServiceContext {
+  return {
+    config: {
+      hostname: 'auth.preview.example',
+      pdsHostname: 'pds.preview.example',
+      email: { from: 'noreply@pds.preview.example', fromName: 'Preview PDS' },
+    },
+  } as unknown as AuthServiceContext
+}
+
+let server: Server
+let baseUrl: string
+let app: Express
+
+beforeAll(async () => {
+  app = express()
+  app.use(createPreviewEmailsRouter(makeCtxStub()))
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => resolve())
+  })
+  const addr = server.address() as AddressInfo
+  baseUrl = `http://127.0.0.1:${addr.port}`
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  )
+})
+
+beforeEach(() => {
+  process.env.AUTH_PREVIEW_ROUTES = '1'
+})
+
+describe('preview-emails router — gate', () => {
+  it('returns 404 for every email route when AUTH_PREVIEW_ROUTES is unset', async () => {
+    delete process.env.AUTH_PREVIEW_ROUTES
+    for (const path of [
+      '/preview/emails/new-user',
+      '/preview/emails/returning-user',
+      '/preview/emails/recovery',
+    ]) {
+      const res = await fetch(`${baseUrl}${path}`)
+      expect(res.status).toBe(404)
+    }
+  })
+})
+
+describe('preview-emails router — rendering', () => {
+  it('renders the new-user welcome email inside an iframe with srcdoc', async () => {
+    const res = await fetch(`${baseUrl}/preview/emails/new-user?otp=123456`)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toMatch(/text\/html/)
+    expect(res.headers.get('cache-control')).toBe('no-store')
+    const body = await res.text()
+    expect(body).toContain('New user')
+    expect(body).toContain('auth.preview.example') // pdsName in subject
+    expect(body).toContain('<iframe')
+    expect(body).toContain('sandbox=""')
+    expect(body).toContain('srcdoc="')
+    // The real sender's welcome HTML, escaped for the srcdoc attribute.
+    expect(body).toContain('Welcome to auth.preview.example')
+  })
+
+  it('renders the returning-user OTP email with the app name', async () => {
+    const res = await fetch(
+      `${baseUrl}/preview/emails/returning-user?otp=12345678&app=MyApp`,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('Returning user')
+    expect(body).toContain('MyApp')
+    expect(body).toContain('1234 5678') // formatted in subject
+  })
+
+  it('renders the recovery email with the backup verification URL', async () => {
+    const url = 'https://auth.preview.example/account/verify?t=xyz'
+    const res = await fetch(
+      `${baseUrl}/preview/emails/recovery?verify_url=${encodeURIComponent(url)}`,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('Account recovery')
+    expect(body).toContain('Verify your backup email')
+    // The URL lives inside the iframe's srcdoc attribute, so it is
+    // HTML-escaped twice: once for the email HTML, once for the attribute.
+    // A substring of the path is enough to prove it made it through.
+    expect(body).toContain('verify?t=xyz')
+  })
+
+  it('exposes from/to/subject headers in the preview shell', async () => {
+    const res = await fetch(
+      `${baseUrl}/preview/emails/returning-user?to=bob@test.example`,
+    )
+    const body = await res.text()
+    expect(body).toContain('Preview PDS')
+    expect(body).toContain('noreply@pds.preview.example')
+    expect(body).toContain('bob@test.example')
+  })
+})

--- a/packages/auth-service/src/__tests__/preview-emails.test.ts
+++ b/packages/auth-service/src/__tests__/preview-emails.test.ts
@@ -3,7 +3,8 @@
  * app with the preview-emails router mounted, listen on an ephemeral
  * port, and hit it with fetch. The real EmailSender is not constructed
  * — we cast a minimal AuthServiceContext stub because the router only
- * reads `config.email.{from,fromName}` and `config.{hostname,pdsHostname}`.
+ * reads `config.email.{from,fromName}`, `config.{hostname,pdsHostname}`,
+ * and `config.trustedClients`.
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import express, { type Express } from 'express'
@@ -11,6 +12,17 @@ import type { AddressInfo } from 'node:net'
 import type { Server } from 'node:http'
 import { createPreviewEmailsRouter } from '../routes/preview-emails.js'
 import type { AuthServiceContext } from '../context.js'
+import {
+  _seedTemplateCacheForTest,
+  _clearTemplateCacheForTest,
+} from '../email/client-template.js'
+import {
+  _seedClientMetadataCacheForTest,
+  clearClientMetadataCache,
+} from '@certified-app/shared'
+
+const TRUSTED_CLIENT = 'https://branded.example/client-metadata.json'
+const TRUSTED_TEMPLATE_URI = 'https://branded.example/email-template.html'
 
 function makeCtxStub(): AuthServiceContext {
   return {
@@ -18,6 +30,7 @@ function makeCtxStub(): AuthServiceContext {
       hostname: 'auth.preview.example',
       pdsHostname: 'pds.preview.example',
       email: { from: 'noreply@pds.preview.example', fromName: 'Preview PDS' },
+      trustedClients: [TRUSTED_CLIENT],
     },
   } as unknown as AuthServiceContext
 }
@@ -49,6 +62,8 @@ afterAll(async () => {
 
 beforeEach(() => {
   process.env.AUTH_PREVIEW_ROUTES = '1'
+  clearClientMetadataCache()
+  _clearTemplateCacheForTest()
 })
 
 describe('preview-emails router — gate', () => {
@@ -115,5 +130,96 @@ describe('preview-emails router — rendering', () => {
     expect(body).toContain('Preview PDS')
     expect(body).toContain('noreply@pds.preview.example')
     expect(body).toContain('bob@test.example')
+  })
+})
+
+describe('preview-emails router — ?client_id branded path', () => {
+  it('renders the branded template for a trusted client (returning-user)', async () => {
+    _seedClientMetadataCacheForTest(TRUSTED_CLIENT, {
+      client_name: 'Branded App',
+      email_template_uri: TRUSTED_TEMPLATE_URI,
+      email_subject_template: '{{code}} — your {{app_name}} code',
+      logo_uri: 'https://branded.example/logo.png',
+    })
+    _seedTemplateCacheForTest(
+      TRUSTED_TEMPLATE_URI,
+      '<html><body>Code {{code}} for {{app_name}}</body></html>',
+    )
+
+    const res = await fetch(
+      `${baseUrl}/preview/emails/returning-user?otp=654321&client_id=${encodeURIComponent(TRUSTED_CLIENT)}`,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // Branded subject template — "{{code}} — your {{app_name}} code"
+    expect(body).toContain('654321 — your Branded App code')
+    // Branded HTML appears inside the iframe srcdoc (HTML-escaped).
+    expect(body).toContain('Code 654321 for Branded App')
+    // From display name comes from the client's client_name.
+    expect(body).toContain('Branded App')
+  })
+
+  it('renders the branded template for a trusted client (new-user)', async () => {
+    _seedClientMetadataCacheForTest(TRUSTED_CLIENT, {
+      client_name: 'Branded App',
+      email_template_uri: TRUSTED_TEMPLATE_URI,
+    })
+    _seedTemplateCacheForTest(
+      TRUSTED_TEMPLATE_URI,
+      '<html><body>{{#is_new_user}}NEW USER{{/is_new_user}} code {{code}}</body></html>',
+    )
+
+    const res = await fetch(
+      `${baseUrl}/preview/emails/new-user?otp=123456&client_id=${encodeURIComponent(TRUSTED_CLIENT)}`,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // {{#is_new_user}} conditional keeps the section on the welcome route.
+    expect(body).toContain('NEW USER code 123456')
+    // Default welcome subject (no email_subject_template in metadata).
+    expect(body).toContain('Welcome to Branded App')
+  })
+
+  it('falls back to the default template when ?client_id is untrusted', async () => {
+    // Seed branded metadata for a client_id that is *not* on trustedClients.
+    // The preview must not fetch, render, or surface any of it.
+    const untrusted = 'https://evil.example/client-metadata.json'
+    _seedClientMetadataCacheForTest(untrusted, {
+      client_name: 'Evil App',
+      email_template_uri: 'https://evil.example/pwn.html',
+      email_subject_template: '{{code}} — pwned',
+    })
+    _seedTemplateCacheForTest(
+      'https://evil.example/pwn.html',
+      '<html><body>PWNED {{code}}</body></html>',
+    )
+
+    const res = await fetch(
+      `${baseUrl}/preview/emails/returning-user?otp=999999&client_id=${encodeURIComponent(untrusted)}`,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // Default subject uses the PDS hostname, not the client's metadata.
+    expect(body).toContain('auth.preview.example')
+    expect(body).not.toContain('pwned')
+    // Default From display name.
+    expect(body).toContain('Preview PDS')
+    expect(body).not.toContain('Evil App')
+    expect(body).not.toContain('PWNED')
+  })
+
+  it('falls back to the default template when trusted client has no email_template_uri', async () => {
+    _seedClientMetadataCacheForTest(TRUSTED_CLIENT, {
+      client_name: 'Branded App',
+      // no email_template_uri — should fall through to the default
+    })
+
+    const res = await fetch(
+      `${baseUrl}/preview/emails/returning-user?otp=111222&client_id=${encodeURIComponent(TRUSTED_CLIENT)}`,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('auth.preview.example')
+    expect(body).toContain('Preview PDS')
   })
 })

--- a/packages/auth-service/src/__tests__/preview-emails.test.ts
+++ b/packages/auth-service/src/__tests__/preview-emails.test.ts
@@ -30,16 +30,21 @@ beforeAll(async () => {
   app = express()
   app.use(createPreviewEmailsRouter(makeCtxStub()))
   await new Promise<void>((resolve) => {
-    server = app.listen(0, '127.0.0.1', () => resolve())
+    server = app.listen(0, '127.0.0.1', () => {
+      resolve()
+    })
   })
   const addr = server.address() as AddressInfo
   baseUrl = `http://127.0.0.1:${addr.port}`
 })
 
 afterAll(async () => {
-  await new Promise<void>((resolve, reject) =>
-    server.close((err) => (err ? reject(err) : resolve())),
-  )
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err)
+      else resolve()
+    })
+  })
 })
 
 beforeEach(() => {

--- a/packages/auth-service/src/__tests__/preview-emails.test.ts
+++ b/packages/auth-service/src/__tests__/preview-emails.test.ts
@@ -38,8 +38,10 @@ function makeCtxStub(): AuthServiceContext {
 let server: Server
 let baseUrl: string
 let app: Express
+let originalPreviewFlag: string | undefined
 
 beforeAll(async () => {
+  originalPreviewFlag = process.env.AUTH_PREVIEW_ROUTES
   app = express()
   app.use(createPreviewEmailsRouter(makeCtxStub()))
   await new Promise<void>((resolve) => {
@@ -52,6 +54,11 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
+  if (originalPreviewFlag === undefined) {
+    delete process.env.AUTH_PREVIEW_ROUTES
+  } else {
+    process.env.AUTH_PREVIEW_ROUTES = originalPreviewFlag
+  }
   await new Promise<void>((resolve, reject) => {
     server.close((err) => {
       if (err) reject(err)
@@ -88,12 +95,14 @@ describe('preview-emails router — rendering', () => {
     expect(res.headers.get('cache-control')).toBe('no-store')
     const body = await res.text()
     expect(body).toContain('New user')
-    expect(body).toContain('auth.preview.example') // pdsName in subject
+    // pdsName now mirrors better-auth.ts (SMTP_FROM_NAME / fromName),
+    // not the auth-service hostname. Preview must match production.
+    expect(body).toContain('Preview PDS')
     expect(body).toContain('<iframe')
     expect(body).toContain('sandbox=""')
     expect(body).toContain('srcdoc="')
     // The real sender's welcome HTML, escaped for the srcdoc attribute.
-    expect(body).toContain('Welcome to auth.preview.example')
+    expect(body).toContain('Welcome to Preview PDS')
   })
 
   it('renders the returning-user OTP email with the app name', async () => {
@@ -199,11 +208,10 @@ describe('preview-emails router — ?client_id branded path', () => {
     )
     expect(res.status).toBe(200)
     const body = await res.text()
-    // Default subject uses the PDS hostname, not the client's metadata.
-    expect(body).toContain('auth.preview.example')
-    expect(body).not.toContain('pwned')
-    // Default From display name.
+    // Default subject uses the PDS fromName (SMTP_FROM_NAME in prod),
+    // not the untrusted client's metadata.
     expect(body).toContain('Preview PDS')
+    expect(body).not.toContain('pwned')
     expect(body).not.toContain('Evil App')
     expect(body).not.toContain('PWNED')
   })
@@ -219,7 +227,6 @@ describe('preview-emails router — ?client_id branded path', () => {
     )
     expect(res.status).toBe(200)
     const body = await res.text()
-    expect(body).toContain('auth.preview.example')
     expect(body).toContain('Preview PDS')
   })
 })

--- a/packages/auth-service/src/email/client-template.ts
+++ b/packages/auth-service/src/email/client-template.ts
@@ -192,8 +192,13 @@ export async function buildClientBrandedEmail(opts: {
 
   let subject: string
   if (metadata.email_subject_template) {
+    // Expose both {{code}} (raw, e.g. "12345678") and {{code_formatted}}
+    // (grouped, e.g. "1234 5678" for lengths >= 8). Fallback subjects use
+    // the formatted form, so clients that want to match PDS readability
+    // UX can opt in with `{{code_formatted}}` in their template.
     subject = renderSubjectTemplate(metadata.email_subject_template, {
       code,
+      code_formatted: formatOtpPlain(code),
       app_name: appName,
     })
   } else if (isNewUser) {

--- a/packages/auth-service/src/email/client-template.ts
+++ b/packages/auth-service/src/email/client-template.ts
@@ -155,6 +155,8 @@ export async function buildClientBrandedEmail(opts: {
   toEmail: string
   fallbackAppName: string
   fallbackFromName: string
+  pdsName: string
+  pdsDomain: string
   trustedClients: readonly string[]
 }): Promise<(RenderedEmail & { fromName: string }) | null> {
   const {
@@ -164,6 +166,8 @@ export async function buildClientBrandedEmail(opts: {
     toEmail,
     fallbackAppName,
     fallbackFromName,
+    pdsName,
+    pdsDomain,
     trustedClients,
   } = opts
 
@@ -207,7 +211,38 @@ export async function buildClientBrandedEmail(opts: {
     subject = `${formatOtpPlain(code)} is your sign-in code for ${appName}`
   }
 
-  const text = `Your code for ${appName} is: ${code}\n\nThis code expires in 10 minutes.\n\nIf you didn't request this, you can safely ignore this email.`
+  // Plain-text alternative stays PDS-controlled: the remote branded
+  // template only owns the HTML. Mirror buildSignInCodeEmail /
+  // buildWelcomeCodeEmail so clients that see text/plain (mail clients
+  // without HTML, accessibility tools, bounce scanners) get the same
+  // identity and footer as the default path.
+  const text = (
+    isNewUser
+      ? [
+          `Welcome to ${appName}!`,
+          '',
+          `Your verification code:`,
+          '',
+          code,
+          '',
+          `Enter this code to confirm your email and create your account.`,
+          '',
+          `This code expires in 10 minutes.`,
+          '',
+          `If you didn't sign up, you can safely ignore this email.`,
+        ]
+      : [
+          `Your sign-in code for ${appName}:`,
+          '',
+          code,
+          '',
+          `This code expires in 10 minutes.`,
+          '',
+          `If you didn't request this, you can safely ignore this email.`,
+        ]
+  )
+    .concat(['', `--`, `${pdsName} (${pdsDomain})`])
+    .join('\n')
 
   const fromName = metadata.client_name || fallbackFromName
 

--- a/packages/auth-service/src/email/client-template.ts
+++ b/packages/auth-service/src/email/client-template.ts
@@ -1,0 +1,210 @@
+/**
+ * Client-branded email template resolution.
+ *
+ * When an OAuth client advertises `email_template_uri` (and optionally
+ * `email_subject_template`) in its client metadata, we fetch the remote
+ * template and substitute `{{code}}`, `{{app_name}}`, `{{logo_uri}}`,
+ * `{{email}}`, plus conditional `{{#is_new_user}}...{{/is_new_user}}`
+ * blocks. The real sender and the /preview/emails/* routes both go
+ * through `buildClientBrandedEmail` so what the browser previews
+ * matches what production will actually put in the envelope.
+ */
+import {
+  createLogger,
+  escapeHtml,
+  formatOtpPlain,
+  makeSafeFetch,
+} from '@certified-app/shared'
+import { resolveClientMetadata } from '../lib/client-metadata.js'
+import type { RenderedEmail } from './templates.js'
+
+const logger = createLogger('auth:email-template')
+
+const MAX_TEMPLATE_SIZE = 100_000 // 100KB
+const TEMPLATE_CACHE_TTL = 10 * 60 * 1000 // 10 minutes
+
+const templateCache = new Map<string, { html: string; fetchedAt: number }>()
+
+/** Seed the template cache. Intended for tests only. */
+export function _seedTemplateCacheForTest(uri: string, html: string): void {
+  templateCache.set(uri, { html, fetchedAt: Date.now() })
+}
+
+/** Clear the template cache. Intended for tests only. */
+export function _clearTemplateCacheForTest(): void {
+  templateCache.clear()
+}
+
+// SSRF-hardened fetch for email templates: HTTPS-only, no private IPs,
+// 5s timeout, 100KB body cap.
+const safeFetch = makeSafeFetch({
+  timeoutMs: 5_000,
+  maxBodyBytes: MAX_TEMPLATE_SIZE,
+})
+
+export async function fetchTemplate(uri: string): Promise<string | null> {
+  const allowedDomains = process.env.EMAIL_TEMPLATE_ALLOWED_DOMAINS
+  if (allowedDomains) {
+    try {
+      const domains = allowedDomains.split(',').map((d) => d.trim())
+      const hostname = new URL(uri).hostname
+      if (!domains.includes(hostname)) {
+        logger.warn(
+          { uri, hostname },
+          'Email template domain not in allowlist, ignoring',
+        )
+        return null
+      }
+    } catch {
+      return null
+    }
+  }
+
+  const cached = templateCache.get(uri)
+  if (cached && Date.now() - cached.fetchedAt < TEMPLATE_CACHE_TTL) {
+    return cached.html
+  }
+  try {
+    const res = await safeFetch(uri)
+    if (!res.ok) return null
+
+    const html = await res.text()
+    if (html.length > MAX_TEMPLATE_SIZE) {
+      logger.warn(
+        { uri, size: html.length },
+        'Email template too large, ignoring',
+      )
+      return null
+    }
+
+    if (!html.includes('{{code}}')) {
+      logger.warn(
+        { uri },
+        'Email template missing {{code}} placeholder, ignoring',
+      )
+      return null
+    }
+    templateCache.set(uri, { html, fetchedAt: Date.now() })
+    return html
+  } catch (err) {
+    logger.warn({ err, uri }, 'Failed to fetch email template')
+    return null
+  }
+}
+
+export function renderTemplate(
+  template: string,
+  vars: Record<string, string | boolean>,
+): string {
+  let html = template
+
+  // Conditional sections first: {{#key}}...{{/key}} and {{^key}}...{{/key}}
+  for (const [key, value] of Object.entries(vars)) {
+    if (typeof value === 'boolean') {
+      const showRegex = new RegExp(
+        `\\{\\{#${key}\\}\\}([\\s\\S]*?)\\{\\{/${key}\\}\\}`,
+        'g',
+      )
+      const hideRegex = new RegExp(
+        `\\{\\{\\^${key}\\}\\}([\\s\\S]*?)\\{\\{/${key}\\}\\}`,
+        'g',
+      )
+      html = html.replace(showRegex, value ? '$1' : '')
+      html = html.replace(hideRegex, value ? '' : '$1')
+    }
+  }
+
+  // String variables, HTML-escaped.
+  for (const [key, value] of Object.entries(vars)) {
+    if (typeof value === 'string') {
+      html = html.replaceAll(`{{${key}}}`, escapeHtml(value))
+    }
+  }
+
+  return html
+}
+
+export function renderSubjectTemplate(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  let subject = template
+  for (const [key, value] of Object.entries(vars)) {
+    subject = subject.replaceAll(`{{${key}}}`, value)
+  }
+  return subject
+}
+
+/**
+ * Resolve a client's email-branding metadata, fetch the remote template,
+ * and render `{ subject, text, html, fromName }`. Returns null when the
+ * client isn't trusted, has no branded template, the fetch fails, or
+ * the template is invalid — the caller is expected to fall back to the
+ * default.
+ *
+ * Only clients on `trustedClients` are honoured: an untrusted `client_id`
+ * could otherwise cause an outbound fetch to an attacker-controlled URL
+ * and put attacker-authored HTML alongside the PDS's own `From:`
+ * address. This matches the gate on `EmailSender.sendOtpCode` and on
+ * CSS branding injection.
+ */
+export async function buildClientBrandedEmail(opts: {
+  clientId: string
+  code: string
+  isNewUser: boolean
+  toEmail: string
+  fallbackAppName: string
+  fallbackFromName: string
+  trustedClients: readonly string[]
+}): Promise<(RenderedEmail & { fromName: string }) | null> {
+  const {
+    clientId,
+    code,
+    isNewUser,
+    toEmail,
+    fallbackAppName,
+    fallbackFromName,
+    trustedClients,
+  } = opts
+
+  if (!trustedClients.includes(clientId)) return null
+
+  let metadata
+  try {
+    metadata = await resolveClientMetadata(clientId)
+  } catch (err) {
+    logger.warn({ err, clientId }, 'Failed to resolve client metadata')
+    return null
+  }
+  if (!metadata.email_template_uri) return null
+
+  const template = await fetchTemplate(metadata.email_template_uri)
+  if (!template) return null
+
+  const appName = metadata.client_name || fallbackAppName
+  const html = renderTemplate(template, {
+    code,
+    app_name: appName,
+    logo_uri: metadata.logo_uri || '',
+    is_new_user: isNewUser,
+    email: toEmail,
+  })
+
+  let subject: string
+  if (metadata.email_subject_template) {
+    subject = renderSubjectTemplate(metadata.email_subject_template, {
+      code,
+      app_name: appName,
+    })
+  } else if (isNewUser) {
+    subject = `${formatOtpPlain(code)} — Welcome to ${appName}`
+  } else {
+    subject = `${formatOtpPlain(code)} is your sign-in code for ${appName}`
+  }
+
+  const text = `Your code for ${appName} is: ${code}\n\nThis code expires in 10 minutes.\n\nIf you didn't request this, you can safely ignore this email.`
+
+  const fromName = metadata.client_name || fallbackFromName
+
+  return { subject, text, html, fromName }
+}

--- a/packages/auth-service/src/email/client-template.ts
+++ b/packages/auth-service/src/email/client-template.ts
@@ -25,6 +25,31 @@ const TEMPLATE_CACHE_TTL = 10 * 60 * 1000 // 10 minutes
 
 const templateCache = new Map<string, { html: string; fetchedAt: number }>()
 
+// Template URIs can be signed URLs or carry credentials in the query
+// string, so the full URI is treated as sensitive. Log only the parsed
+// hostname/protocol (or a marker when parsing fails) — enough to debug
+// allowlist/fetch problems without leaking secrets into log aggregators.
+function templateLogContext(uri: string): {
+  templateHostname?: string
+  templateProtocol?: string
+  templateUri?: string
+} {
+  try {
+    const url = new URL(uri)
+    return { templateHostname: url.hostname, templateProtocol: url.protocol }
+  } catch {
+    return { templateUri: '<invalid>' }
+  }
+}
+
+// Strip CR/LF from values that end up in SMTP headers (Subject, From
+// display-name). Even trusted clients' remotely-fetched metadata could
+// be compromised; a newline in a header value would let an attacker
+// inject arbitrary headers after it.
+function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ').trim()
+}
+
 /** Seed the template cache. Intended for tests only. */
 export function _seedTemplateCacheForTest(uri: string, html: string): void {
   templateCache.set(uri, { html, fetchedAt: Date.now() })
@@ -50,7 +75,7 @@ export async function fetchTemplate(uri: string): Promise<string | null> {
       const hostname = new URL(uri).hostname
       if (!domains.includes(hostname)) {
         logger.warn(
-          { uri, hostname },
+          { hostname },
           'Email template domain not in allowlist, ignoring',
         )
         return null
@@ -71,7 +96,7 @@ export async function fetchTemplate(uri: string): Promise<string | null> {
     const html = await res.text()
     if (html.length > MAX_TEMPLATE_SIZE) {
       logger.warn(
-        { uri, size: html.length },
+        { ...templateLogContext(uri), size: html.length },
         'Email template too large, ignoring',
       )
       return null
@@ -79,7 +104,7 @@ export async function fetchTemplate(uri: string): Promise<string | null> {
 
     if (!html.includes('{{code}}')) {
       logger.warn(
-        { uri },
+        templateLogContext(uri),
         'Email template missing {{code}} placeholder, ignoring',
       )
       return null
@@ -87,7 +112,10 @@ export async function fetchTemplate(uri: string): Promise<string | null> {
     templateCache.set(uri, { html, fetchedAt: Date.now() })
     return html
   } catch (err) {
-    logger.warn({ err, uri }, 'Failed to fetch email template')
+    logger.warn(
+      { err, ...templateLogContext(uri) },
+      'Failed to fetch email template',
+    )
     return null
   }
 }
@@ -246,5 +274,10 @@ export async function buildClientBrandedEmail(opts: {
 
   const fromName = metadata.client_name || fallbackFromName
 
-  return { subject, text, html, fromName }
+  return {
+    subject: sanitizeHeaderValue(subject),
+    text,
+    html,
+    fromName: sanitizeHeaderValue(fromName),
+  }
 }

--- a/packages/auth-service/src/email/sender.ts
+++ b/packages/auth-service/src/email/sender.ts
@@ -120,6 +120,8 @@ export class EmailSender {
         toEmail: to,
         fallbackAppName: clientAppName,
         fallbackFromName: this.config.fromName,
+        pdsName,
+        pdsDomain,
         trustedClients: this.trustedClients,
       })
       if (branded) {

--- a/packages/auth-service/src/email/sender.ts
+++ b/packages/auth-service/src/email/sender.ts
@@ -1,144 +1,23 @@
 import * as nodemailer from 'nodemailer'
-import {
-  createLogger,
-  makeSafeFetch,
-  escapeHtml,
-  formatOtpPlain,
-} from '@certified-app/shared'
+import { createLogger } from '@certified-app/shared'
 import type { Transporter } from 'nodemailer'
 import type { EmailConfig } from '@certified-app/shared'
-import { resolveClientMetadata } from '../lib/client-metadata.js'
 import {
   buildSignInCodeEmail,
   buildWelcomeCodeEmail,
   buildBackupEmailVerificationEmail,
 } from './templates.js'
+import { buildClientBrandedEmail } from './client-template.js'
 
 const logger = createLogger('auth:email')
 
-// Template cache (separate from client metadata cache)
-const templateCache = new Map<string, { html: string; fetchedAt: number }>()
-const TEMPLATE_CACHE_TTL = 10 * 60 * 1000 // 10 minutes
-
-/** Seed the template cache. Intended for tests only. */
-export function _seedTemplateCacheForTest(uri: string, html: string): void {
-  templateCache.set(uri, { html, fetchedAt: Date.now() })
-}
-
-/** Clear the template cache. Intended for tests only. */
-export function _clearTemplateCacheForTest(): void {
-  templateCache.clear()
-}
-
-const MAX_TEMPLATE_SIZE = 100_000 // 100KB
-
-// SSRF-hardened fetch for email templates: requires HTTPS, blocks private/
-// reserved IPs, enforces a 5s timeout and 100KB Content-Length cap.
-const safeFetch = makeSafeFetch({
-  timeoutMs: 5_000,
-  maxBodyBytes: MAX_TEMPLATE_SIZE,
-})
-
-async function fetchTemplate(uri: string): Promise<string | null> {
-  // Optional domain allowlist via env var (comma-separated).
-  // safeFetch already enforces HTTPS and blocks private IPs; this is an
-  // additional opt-in restriction for operators who want to lock down
-  // which domains can supply email templates.
-  const allowedDomains = process.env.EMAIL_TEMPLATE_ALLOWED_DOMAINS
-  if (allowedDomains) {
-    try {
-      const domains = allowedDomains.split(',').map((d) => d.trim())
-      const hostname = new URL(uri).hostname
-      if (!domains.includes(hostname)) {
-        logger.warn(
-          { uri, hostname },
-          'Email template domain not in allowlist, ignoring',
-        )
-        return null
-      }
-    } catch {
-      return null
-    }
-  }
-
-  const cached = templateCache.get(uri)
-  if (cached && Date.now() - cached.fetchedAt < TEMPLATE_CACHE_TTL) {
-    return cached.html
-  }
-  try {
-    // safeFetch validates the URL (HTTPS only, no private IPs, timeout, size cap)
-    const res = await safeFetch(uri)
-    if (!res.ok) return null
-
-    // Reject oversized responses (post-read defence-in-depth — safeFetch
-    // already checks Content-Length; this catches chunked responses)
-    const html = await res.text()
-    if (html.length > MAX_TEMPLATE_SIZE) {
-      logger.warn(
-        { uri, size: html.length },
-        'Email template too large, ignoring',
-      )
-      return null
-    }
-
-    // Basic validation: must contain {{code}} placeholder
-    if (!html.includes('{{code}}')) {
-      logger.warn(
-        { uri },
-        'Email template missing {{code}} placeholder, ignoring',
-      )
-      return null
-    }
-    templateCache.set(uri, { html, fetchedAt: Date.now() })
-    return html
-  } catch (err) {
-    logger.warn({ err, uri }, 'Failed to fetch email template')
-    return null
-  }
-}
-
-function renderTemplate(
-  template: string,
-  vars: Record<string, string | boolean>,
-): string {
-  let html = template
-
-  // Handle conditional sections first: {{#key}}...{{/key}} and {{^key}}...{{/key}}
-  for (const [key, value] of Object.entries(vars)) {
-    if (typeof value === 'boolean') {
-      const showRegex = new RegExp(
-        `\\{\\{#${key}\\}\\}([\\s\\S]*?)\\{\\{/${key}\\}\\}`,
-        'g',
-      )
-      const hideRegex = new RegExp(
-        `\\{\\{\\^${key}\\}\\}([\\s\\S]*?)\\{\\{/${key}\\}\\}`,
-        'g',
-      )
-      html = html.replace(showRegex, value ? '$1' : '')
-      html = html.replace(hideRegex, value ? '' : '$1')
-    }
-  }
-
-  // Then replace string variables (HTML-escaped)
-  for (const [key, value] of Object.entries(vars)) {
-    if (typeof value === 'string') {
-      html = html.replaceAll(`{{${key}}}`, escapeHtml(value))
-    }
-  }
-
-  return html
-}
-
-function renderSubjectTemplate(
-  template: string,
-  vars: Record<string, string>,
-): string {
-  let subject = template
-  for (const [key, value] of Object.entries(vars)) {
-    subject = subject.replaceAll(`{{${key}}}`, value)
-  }
-  return subject
-}
+// Re-exports so existing tests that reach for the template cache still
+// resolve through sender.js. New code should import directly from
+// ./client-template.js.
+export {
+  _seedTemplateCacheForTest,
+  _clearTemplateCacheForTest,
+} from './client-template.js'
 
 export class EmailSender {
   private transporter: Transporter
@@ -227,67 +106,35 @@ export class EmailSender {
   }): Promise<void> {
     const { to, code, clientAppName, pdsName, pdsDomain, isNewUser } = opts
 
-    // Try to use a client-provided email template. Only trusted clients
-    // are allowed to supply templates: an untrusted client_id could
-    // otherwise (a) cause an outbound fetch to an attacker-controlled
-    // URL on every OTP send, (b) put attacker-chosen HTML alongside the
-    // PDS's own From address (phishing uplift), or (c) override the
-    // From display name via `client_name`. This matches the gate on
-    // CSS branding injection.
-    if (opts.clientId && this.trustedClients.includes(opts.clientId)) {
-      try {
-        const metadata = await resolveClientMetadata(opts.clientId)
-        if (metadata.email_template_uri) {
-          const template = await fetchTemplate(metadata.email_template_uri)
-          if (template) {
-            const appName = metadata.client_name || clientAppName
-
-            const customHtml = renderTemplate(template, {
-              code,
-              app_name: appName,
-              logo_uri: metadata.logo_uri || '',
-              is_new_user: isNewUser ?? false,
-              email: to,
-            })
-
-            let subject: string
-            if (metadata.email_subject_template) {
-              subject = renderSubjectTemplate(metadata.email_subject_template, {
-                code,
-                app_name: appName,
-              })
-            } else if (isNewUser) {
-              subject = `${formatOtpPlain(code)} — Welcome to ${appName}`
-            } else {
-              subject = `${formatOtpPlain(code)} is your sign-in code for ${appName}`
-            }
-
-            const fromName = metadata.client_name || this.config.fromName
-
-            await this.transporter.sendMail({
-              from: `"${fromName}" <${this.config.from}>`,
-              to,
-              subject,
-              text: `Your code for ${appName} is: ${code}\n\nThis code expires in 10 minutes.\n\nIf you didn't request this, you can safely ignore this email.`,
-              html: customHtml,
-            })
-
-            logger.info(
-              {
-                to,
-                clientId: opts.clientId,
-                templateUri: metadata.email_template_uri,
-              },
-              'Sent client-branded OTP email',
-            )
-            return
-          }
-        }
-      } catch (err) {
-        logger.warn(
-          { err, clientId: opts.clientId },
-          'Failed to use client email template, falling back to default',
+    // Try the client-branded path first. `buildClientBrandedEmail`
+    // enforces the trusted-clients gate and returns null if the client
+    // is untrusted, has no `email_template_uri`, or the template fetch /
+    // validation fails. The /preview/emails/* routes go through the
+    // same helper so what the browser previews matches what the real
+    // sender puts in the envelope.
+    if (opts.clientId) {
+      const branded = await buildClientBrandedEmail({
+        clientId: opts.clientId,
+        code,
+        isNewUser: isNewUser ?? false,
+        toEmail: to,
+        fallbackAppName: clientAppName,
+        fallbackFromName: this.config.fromName,
+        trustedClients: this.trustedClients,
+      })
+      if (branded) {
+        await this.transporter.sendMail({
+          from: `"${branded.fromName}" <${this.config.from}>`,
+          to,
+          subject: branded.subject,
+          text: branded.text,
+          html: branded.html,
+        })
+        logger.info(
+          { to, clientId: opts.clientId },
+          'Sent client-branded OTP email',
         )
+        return
       }
     }
 

--- a/packages/auth-service/src/email/sender.ts
+++ b/packages/auth-service/src/email/sender.ts
@@ -4,11 +4,15 @@ import {
   makeSafeFetch,
   escapeHtml,
   formatOtpPlain,
-  formatOtpHtmlGrouped,
 } from '@certified-app/shared'
 import type { Transporter } from 'nodemailer'
 import type { EmailConfig } from '@certified-app/shared'
 import { resolveClientMetadata } from '../lib/client-metadata.js'
+import {
+  buildSignInCodeEmail,
+  buildWelcomeCodeEmail,
+  buildBackupEmailVerificationEmail,
+} from './templates.js'
 
 const logger = createLogger('auth:email')
 
@@ -302,39 +306,8 @@ export class EmailSender {
     pdsName: string
     pdsDomain: string
   }): Promise<void> {
-    const { to, code, clientAppName, pdsName, pdsDomain } = opts
-
-    const subject = `${formatOtpPlain(code)} is your sign-in code for ${pdsName}`
-
-    const text = [
-      `Your sign-in code for ${clientAppName}:`,
-      '',
-      code,
-      '',
-      `This code expires in 10 minutes.`,
-      '',
-      `If you didn't request this, you can safely ignore this email.`,
-      '',
-      `--`,
-      `${pdsName} (${pdsDomain})`,
-    ].join('\n')
-
-    const html = `
-<!DOCTYPE html>
-<html>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #333;">
-  <p>Your sign-in code for <strong>${escapeHtml(clientAppName)}</strong>:</p>
-  <p style="margin: 30px 0; text-align: center;">
-    <span style="font-size: 32px; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; letter-spacing: 6px; background: #f5f5f5; padding: 16px 24px; border-radius: 8px; display: inline-block; font-weight: 600; color: #0f1828;">
-      ${formatOtpHtmlGrouped(code)}
-    </span>
-  </p>
-  <p style="color: #666; font-size: 14px;">This code expires in 10 minutes.</p>
-  <p style="color: #666; font-size: 14px;">If you didn't request this, you can safely ignore this email.</p>
-  <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
-  <p style="color: #999; font-size: 12px;">${escapeHtml(pdsName)} (${escapeHtml(pdsDomain)})</p>
-</body>
-</html>`
+    const { to, ...rest } = opts
+    const { subject, text, html } = buildSignInCodeEmail(rest)
 
     await this.transporter.sendMail({
       from: `"${this.config.fromName}" <${this.config.from}>`,
@@ -351,44 +324,8 @@ export class EmailSender {
     pdsName: string
     pdsDomain: string
   }): Promise<void> {
-    const { to, code, pdsName, pdsDomain } = opts
-
-    const subject = `${formatOtpPlain(code)} — Welcome to ${pdsName}`
-
-    const text = [
-      `Welcome to ${pdsName}!`,
-      '',
-      `Your verification code:`,
-      '',
-      code,
-      '',
-      `Enter this code to confirm your email and create your account.`,
-      '',
-      `This code expires in 10 minutes.`,
-      '',
-      `If you didn't sign up, you can safely ignore this email.`,
-      '',
-      `--`,
-      `${pdsName} (${pdsDomain})`,
-    ].join('\n')
-
-    const html = `
-<!DOCTYPE html>
-<html>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #333;">
-  <h2 style="color: #0f1828; margin-bottom: 8px;">Welcome to ${escapeHtml(pdsName)}</h2>
-  <p>Enter this code to confirm your email and create your account:</p>
-  <p style="margin: 30px 0; text-align: center;">
-    <span style="font-size: 32px; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; letter-spacing: 6px; background: #f5f5f5; padding: 16px 24px; border-radius: 8px; display: inline-block; font-weight: 600; color: #0f1828;">
-      ${formatOtpHtmlGrouped(code)}
-    </span>
-  </p>
-  <p style="color: #666; font-size: 14px;">This code expires in 10 minutes.</p>
-  <p style="color: #666; font-size: 14px;">If you didn't sign up, you can safely ignore this email.</p>
-  <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
-  <p style="color: #999; font-size: 12px;">${escapeHtml(pdsName)} (${escapeHtml(pdsDomain)})</p>
-</body>
-</html>`
+    const { to, ...rest } = opts
+    const { subject, text, html } = buildWelcomeCodeEmail(rest)
 
     await this.transporter.sendMail({
       from: `"${this.config.fromName}" <${this.config.from}>`,
@@ -405,18 +342,15 @@ export class EmailSender {
     pdsName: string
     pdsDomain: string
   }): Promise<void> {
-    const { to, verifyUrl, pdsName, pdsDomain } = opts
+    const { to, ...rest } = opts
+    const { subject, text, html } = buildBackupEmailVerificationEmail(rest)
 
     await this.transporter.sendMail({
       from: `"${this.config.fromName}" <${this.config.from}>`,
       to,
-      subject: `Verify your backup email - ${pdsName}`,
-      text: `Verify your backup email by clicking this link:\n\n${verifyUrl}\n\nThis link expires in 24 hours.\n\n--\n${pdsName} (${pdsDomain})`,
-      html: `
-<p>Verify your backup email by clicking the link below:</p>
-<p style="margin: 20px 0;"><a href="${escapeHtml(verifyUrl)}" style="background-color: #0f1828; color: white; padding: 12px 24px; border-radius: 6px; text-decoration: none;">Verify Email</a></p>
-<p style="color: #666; font-size: 14px;">This link expires in 24 hours.</p>
-<hr style="border: none; border-top: 1px solid #eee;"><p style="color: #999; font-size: 12px;">${escapeHtml(pdsName)} (${escapeHtml(pdsDomain)})</p>`,
+      subject,
+      text,
+      html,
     })
   }
 }

--- a/packages/auth-service/src/email/templates.ts
+++ b/packages/auth-service/src/email/templates.ts
@@ -122,10 +122,16 @@ export function buildBackupEmailVerificationEmail(opts: {
   const text = `Verify your backup email by clicking this link:\n\n${verifyUrl}\n\nThis link expires in 24 hours.\n\n--\n${pdsName} (${pdsDomain})`
 
   const html = `
-<p>Verify your backup email by clicking the link below:</p>
-<p style="margin: 20px 0;"><a href="${escapeHtml(verifyUrl)}" style="background-color: #0f1828; color: white; padding: 12px 24px; border-radius: 6px; text-decoration: none;">Verify Email</a></p>
-<p style="color: #666; font-size: 14px;">This link expires in 24 hours.</p>
-<hr style="border: none; border-top: 1px solid #eee;"><p style="color: #999; font-size: 12px;">${escapeHtml(pdsName)} (${escapeHtml(pdsDomain)})</p>`
+<!DOCTYPE html>
+<html>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #333;">
+  <p>Verify your backup email by clicking the link below:</p>
+  <p style="margin: 20px 0;"><a href="${escapeHtml(verifyUrl)}" style="background-color: #0f1828; color: white; padding: 12px 24px; border-radius: 6px; text-decoration: none;">Verify Email</a></p>
+  <p style="color: #666; font-size: 14px;">This link expires in 24 hours.</p>
+  <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+  <p style="color: #999; font-size: 12px;">${escapeHtml(pdsName)} (${escapeHtml(pdsDomain)})</p>
+</body>
+</html>`
 
   return { subject, text, html }
 }

--- a/packages/auth-service/src/email/templates.ts
+++ b/packages/auth-service/src/email/templates.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure email-template builders. Each function takes the minimal
+ * identity/variable inputs it needs and returns `{ subject, text, html }`.
+ * The EmailSender calls these to produce the payload it passes to
+ * nodemailer; the preview routes call them to render the same HTML
+ * inside a sandboxed iframe without touching SMTP.
+ *
+ * Keeping these pure (no I/O, no sender state) is what lets
+ * /preview/emails/* render exactly what production would send.
+ */
+import {
+  escapeHtml,
+  formatOtpPlain,
+  formatOtpHtmlGrouped,
+} from '@certified-app/shared'
+
+export interface RenderedEmail {
+  subject: string
+  text: string
+  html: string
+}
+
+export function buildSignInCodeEmail(opts: {
+  code: string
+  clientAppName: string
+  pdsName: string
+  pdsDomain: string
+}): RenderedEmail {
+  const { code, clientAppName, pdsName, pdsDomain } = opts
+
+  const subject = `${formatOtpPlain(code)} is your sign-in code for ${pdsName}`
+
+  const text = [
+    `Your sign-in code for ${clientAppName}:`,
+    '',
+    code,
+    '',
+    `This code expires in 10 minutes.`,
+    '',
+    `If you didn't request this, you can safely ignore this email.`,
+    '',
+    `--`,
+    `${pdsName} (${pdsDomain})`,
+  ].join('\n')
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #333;">
+  <p>Your sign-in code for <strong>${escapeHtml(clientAppName)}</strong>:</p>
+  <p style="margin: 30px 0; text-align: center;">
+    <span style="font-size: 32px; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; letter-spacing: 6px; background: #f5f5f5; padding: 16px 24px; border-radius: 8px; display: inline-block; font-weight: 600; color: #0f1828;">
+      ${formatOtpHtmlGrouped(code)}
+    </span>
+  </p>
+  <p style="color: #666; font-size: 14px;">This code expires in 10 minutes.</p>
+  <p style="color: #666; font-size: 14px;">If you didn't request this, you can safely ignore this email.</p>
+  <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+  <p style="color: #999; font-size: 12px;">${escapeHtml(pdsName)} (${escapeHtml(pdsDomain)})</p>
+</body>
+</html>`
+
+  return { subject, text, html }
+}
+
+export function buildWelcomeCodeEmail(opts: {
+  code: string
+  pdsName: string
+  pdsDomain: string
+}): RenderedEmail {
+  const { code, pdsName, pdsDomain } = opts
+
+  const subject = `${formatOtpPlain(code)} — Welcome to ${pdsName}`
+
+  const text = [
+    `Welcome to ${pdsName}!`,
+    '',
+    `Your verification code:`,
+    '',
+    code,
+    '',
+    `Enter this code to confirm your email and create your account.`,
+    '',
+    `This code expires in 10 minutes.`,
+    '',
+    `If you didn't sign up, you can safely ignore this email.`,
+    '',
+    `--`,
+    `${pdsName} (${pdsDomain})`,
+  ].join('\n')
+
+  const html = `
+<!DOCTYPE html>
+<html>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; color: #333;">
+  <h2 style="color: #0f1828; margin-bottom: 8px;">Welcome to ${escapeHtml(pdsName)}</h2>
+  <p>Enter this code to confirm your email and create your account:</p>
+  <p style="margin: 30px 0; text-align: center;">
+    <span style="font-size: 32px; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; letter-spacing: 6px; background: #f5f5f5; padding: 16px 24px; border-radius: 8px; display: inline-block; font-weight: 600; color: #0f1828;">
+      ${formatOtpHtmlGrouped(code)}
+    </span>
+  </p>
+  <p style="color: #666; font-size: 14px;">This code expires in 10 minutes.</p>
+  <p style="color: #666; font-size: 14px;">If you didn't sign up, you can safely ignore this email.</p>
+  <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+  <p style="color: #999; font-size: 12px;">${escapeHtml(pdsName)} (${escapeHtml(pdsDomain)})</p>
+</body>
+</html>`
+
+  return { subject, text, html }
+}
+
+export function buildBackupEmailVerificationEmail(opts: {
+  verifyUrl: string
+  pdsName: string
+  pdsDomain: string
+}): RenderedEmail {
+  const { verifyUrl, pdsName, pdsDomain } = opts
+
+  const subject = `Verify your backup email - ${pdsName}`
+
+  const text = `Verify your backup email by clicking this link:\n\n${verifyUrl}\n\nThis link expires in 24 hours.\n\n--\n${pdsName} (${pdsDomain})`
+
+  const html = `
+<p>Verify your backup email by clicking the link below:</p>
+<p style="margin: 20px 0;"><a href="${escapeHtml(verifyUrl)}" style="background-color: #0f1828; color: white; padding: 12px 24px; border-radius: 6px; text-decoration: none;">Verify Email</a></p>
+<p style="color: #666; font-size: 14px;">This link expires in 24 hours.</p>
+<hr style="border: none; border-top: 1px solid #eee;"><p style="color: #999; font-size: 12px;">${escapeHtml(pdsName)} (${escapeHtml(pdsDomain)})</p>`
+
+  return { subject, text, html }
+}

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -16,6 +16,7 @@ import { createAccountSettingsRouter } from './routes/account-settings.js'
 import { createCompleteRouter } from './routes/complete.js'
 import { createChooseHandleRouter } from './routes/choose-handle.js'
 import { createPreviewRouter } from './routes/preview.js'
+import { createPreviewEmailsRouter } from './routes/preview-emails.js'
 import { resolveAuthPort } from './lib/resolve-port.js'
 
 const logger = createLogger('auth-service')
@@ -92,6 +93,7 @@ export function createAuthService(config: AuthServiceConfig): {
   app.use(createCompleteRouter(ctx, betterAuthInstance))
   app.use(createChooseHandleRouter(ctx, betterAuthInstance))
   app.use(createPreviewRouter(ctx))
+  app.use(createPreviewEmailsRouter(ctx))
 
   // Metrics endpoint (protect with admin auth in production)
   app.get('/metrics', (req, res) => {

--- a/packages/auth-service/src/routes/preview-emails.ts
+++ b/packages/auth-service/src/routes/preview-emails.ts
@@ -1,0 +1,203 @@
+/**
+ * In-browser email previews.
+ *
+ * Renders each of the transactional emails the auth-service sends
+ * (new-user welcome/verify, returning-user sign-in OTP, backup-email
+ * verification) inside a sandboxed iframe so operators and client-app
+ * developers can see exactly what users will receive without hitting
+ * SMTP or walking a real flow.
+ *
+ * The email HTML comes from the same pure builders the real sender uses
+ * (`packages/auth-service/src/email/templates.ts`), so what's rendered
+ * here is bit-for-bit what production would put in the envelope.
+ *
+ * Gated by `AUTH_PREVIEW_ROUTES=1` along with the rest of /preview/*.
+ *
+ * Query params (all optional):
+ *   ?otp=<code>        override the fixture OTP (default: 123456).
+ *   ?client_id=<URL>   render a client-branded template; subject to
+ *                      the trusted-clients gate and the template's
+ *                      `email_template_uri`. Falls back to the default
+ *                      template if the client doesn't define one or
+ *                      isn't trusted — mirrors real-sender behaviour.
+ */
+import { Router, type Request, type Response } from 'express'
+import type { AuthServiceContext } from '../context.js'
+import { escapeHtml } from '@certified-app/shared'
+import {
+  buildSignInCodeEmail,
+  buildWelcomeCodeEmail,
+  buildBackupEmailVerificationEmail,
+  type RenderedEmail,
+} from '../email/templates.js'
+
+const FAKE_OTP = '123456'
+const FAKE_TO = 'alice@example.com'
+const FAKE_APP_NAME = 'Preview Client'
+const FAKE_VERIFY_URL =
+  'https://auth.preview.example/account/verify-backup?token=preview-token-0000'
+
+function queryString(req: Request, name: string): string | undefined {
+  const v = req.query[name]
+  return typeof v === 'string' ? v : undefined
+}
+
+function sendHtml(res: Response, html: string): void {
+  res.setHeader('Content-Type', 'text/html; charset=utf-8')
+  res.setHeader('Cache-Control', 'no-store')
+  res.send(html)
+}
+
+function pdsIdentity(ctx: AuthServiceContext): {
+  pdsName: string
+  pdsDomain: string
+} {
+  return {
+    pdsName: ctx.config.hostname,
+    pdsDomain: ctx.config.pdsHostname,
+  }
+}
+
+/**
+ * Wrap a rendered email in a preview shell: from/to/subject headers and
+ * an iframe with `srcdoc` so the email's CSS cannot bleed into — or read
+ * from — the outer preview page.
+ */
+function renderEmailPreview(opts: {
+  kind: string
+  description: string
+  fromName: string
+  fromAddress: string
+  to: string
+  email: RenderedEmail
+  backHref: string
+}): string {
+  const { kind, description, fromName, fromAddress, to, email, backHref } = opts
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Email preview — ${escapeHtml(kind)}</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 820px; margin: 24px auto; padding: 0 16px; color: #222; }
+    h1 { font-size: 20px; margin: 0 0 4px; }
+    .desc { color: #555; margin: 0 0 16px; }
+    .back { font-size: 13px; }
+    .headers { border: 1px solid #e5e7eb; border-radius: 8px 8px 0 0; background: #f8f9fa; padding: 12px 16px; }
+    .headers dl { display: grid; grid-template-columns: max-content 1fr; column-gap: 12px; row-gap: 4px; margin: 0; font-size: 14px; }
+    .headers dt { color: #666; font-weight: 500; }
+    .headers dd { margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; word-break: break-all; }
+    iframe { width: 100%; height: 640px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 8px 8px; background: white; }
+    details { margin-top: 16px; }
+    summary { cursor: pointer; font-size: 14px; color: #0b5ed7; }
+    pre { background: #f0f0f0; padding: 10px 12px; border-radius: 6px; overflow-x: auto; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <p class="back"><a href="${escapeHtml(backHref)}">&larr; Back to previews</a></p>
+  <h1>${escapeHtml(kind)}</h1>
+  <p class="desc">${escapeHtml(description)}</p>
+  <div class="headers">
+    <dl>
+      <dt>From</dt><dd>${escapeHtml(fromName)} &lt;${escapeHtml(fromAddress)}&gt;</dd>
+      <dt>To</dt><dd>${escapeHtml(to)}</dd>
+      <dt>Subject</dt><dd>${escapeHtml(email.subject)}</dd>
+    </dl>
+  </div>
+  <iframe
+    title="Rendered email body"
+    sandbox=""
+    srcdoc="${escapeHtml(email.html)}"></iframe>
+  <details>
+    <summary>Plain-text alternative</summary>
+    <pre>${escapeHtml(email.text)}</pre>
+  </details>
+</body>
+</html>`
+}
+
+export function createPreviewEmailsRouter(ctx: AuthServiceContext): Router {
+  const router = Router()
+
+  // Match the gate in createPreviewRouter: /preview/* is 404 unless the
+  // flag is on. Checked per-request so the flag can flip without a restart.
+  router.use('/preview/emails', (_req, res, next) => {
+    if (process.env.AUTH_PREVIEW_ROUTES !== '1') {
+      res.status(404).send('Not Found')
+      return
+    }
+    next()
+  })
+
+  const fromName = ctx.config.email.fromName
+  const fromAddress = ctx.config.email.from
+
+  const render = (
+    req: Request,
+    kind: string,
+    description: string,
+    email: RenderedEmail,
+  ): string =>
+    renderEmailPreview({
+      kind,
+      description,
+      fromName,
+      fromAddress,
+      to: queryString(req, 'to') ?? FAKE_TO,
+      email,
+      backHref: '/preview',
+    })
+
+  router.get('/preview/emails/new-user', (req: Request, res: Response) => {
+    const code = queryString(req, 'otp') ?? FAKE_OTP
+    const email = buildWelcomeCodeEmail({ code, ...pdsIdentity(ctx) })
+    sendHtml(
+      res,
+      render(
+        req,
+        'New user — welcome / email verification',
+        'Sent when a user signs up. Contains the OTP they enter to confirm their email and finish creating their account.',
+        email,
+      ),
+    )
+  })
+
+  router.get(
+    '/preview/emails/returning-user',
+    (req: Request, res: Response) => {
+      const code = queryString(req, 'otp') ?? FAKE_OTP
+      const email = buildSignInCodeEmail({
+        code,
+        clientAppName: queryString(req, 'app') ?? FAKE_APP_NAME,
+        ...pdsIdentity(ctx),
+      })
+      sendHtml(
+        res,
+        render(
+          req,
+          'Returning user — sign-in OTP',
+          'Sent when an existing user signs in to a client app. Contains the OTP they enter to complete the sign-in.',
+          email,
+        ),
+      )
+    },
+  )
+
+  router.get('/preview/emails/recovery', (req: Request, res: Response) => {
+    const email = buildBackupEmailVerificationEmail({
+      verifyUrl: queryString(req, 'verify_url') ?? FAKE_VERIFY_URL,
+      ...pdsIdentity(ctx),
+    })
+    sendHtml(
+      res,
+      render(
+        req,
+        'Account recovery — backup email verification',
+        'Sent when a user adds a backup email to their account. Contains the link they click to prove they control the address.',
+        email,
+      ),
+    )
+  })
+
+  return router
+}

--- a/packages/auth-service/src/routes/preview-emails.ts
+++ b/packages/auth-service/src/routes/preview-emails.ts
@@ -15,11 +15,17 @@
  *
  * Query params (all optional):
  *   ?otp=<code>        override the fixture OTP (default: 123456).
- *   ?client_id=<URL>   render a client-branded template; subject to
- *                      the trusted-clients gate and the template's
- *                      `email_template_uri`. Falls back to the default
- *                      template if the client doesn't define one or
- *                      isn't trusted — mirrors real-sender behaviour.
+ *   ?app=<name>        override the fallback app name for the
+ *                      returning-user template (default: Preview Client).
+ *   ?to=<email>        override the rendered "To:" header.
+ *   ?client_id=<URL>   render a client-branded template for the
+ *                      new-user / returning-user routes. Gated on the
+ *                      real trusted-clients list (`PDS_OAUTH_TRUSTED_CLIENTS`)
+ *                      and the client's `email_template_uri`. Falls
+ *                      back to the default template if the client is
+ *                      untrusted, advertises no `email_template_uri`,
+ *                      or the template fetch fails — mirrors real-
+ *                      sender behaviour bit-for-bit.
  */
 import { Router, type Request, type Response } from 'express'
 import type { AuthServiceContext } from '../context.js'
@@ -30,6 +36,7 @@ import {
   buildBackupEmailVerificationEmail,
   type RenderedEmail,
 } from '../email/templates.js'
+import { buildClientBrandedEmail } from '../email/client-template.js'
 
 const FAKE_OTP = '123456'
 const FAKE_TO = 'alice@example.com'
@@ -129,7 +136,7 @@ export function createPreviewEmailsRouter(ctx: AuthServiceContext): Router {
     next()
   })
 
-  const fromName = ctx.config.email.fromName
+  const defaultFromName = ctx.config.email.fromName
   const fromAddress = ctx.config.email.from
 
   const render = (
@@ -137,40 +144,91 @@ export function createPreviewEmailsRouter(ctx: AuthServiceContext): Router {
     kind: string,
     description: string,
     email: RenderedEmail,
+    fromNameOverride?: string,
   ): string =>
     renderEmailPreview({
       kind,
       description,
-      fromName,
+      fromName: fromNameOverride ?? defaultFromName,
       fromAddress,
       to: queryString(req, 'to') ?? FAKE_TO,
       email,
       backHref: '/preview',
     })
 
-  router.get('/preview/emails/new-user', (req: Request, res: Response) => {
-    const code = queryString(req, 'otp') ?? FAKE_OTP
-    const email = buildWelcomeCodeEmail({ code, ...pdsIdentity(ctx) })
-    sendHtml(
-      res,
-      render(
+  /**
+   * If `?client_id=` is present and the client is trusted, render the
+   * branded template it advertises; otherwise (untrusted / no template
+   * / fetch failure) fall through to `fallback`. Mirrors the real
+   * sender's gating exactly.
+   */
+  async function brandedOrFallback(
+    req: Request,
+    code: string,
+    isNewUser: boolean,
+    fallback: RenderedEmail,
+  ): Promise<{ email: RenderedEmail; fromName?: string }> {
+    const clientId = queryString(req, 'client_id')
+    if (!clientId) return { email: fallback }
+    const branded = await buildClientBrandedEmail({
+      clientId,
+      code,
+      isNewUser,
+      toEmail: queryString(req, 'to') ?? FAKE_TO,
+      fallbackAppName: queryString(req, 'app') ?? FAKE_APP_NAME,
+      fallbackFromName: defaultFromName,
+      trustedClients: ctx.config.trustedClients,
+    })
+    if (!branded) return { email: fallback }
+    return {
+      email: {
+        subject: branded.subject,
+        text: branded.text,
+        html: branded.html,
+      },
+      fromName: branded.fromName,
+    }
+  }
+
+  router.get(
+    '/preview/emails/new-user',
+    async (req: Request, res: Response) => {
+      const code = queryString(req, 'otp') ?? FAKE_OTP
+      const fallback = buildWelcomeCodeEmail({ code, ...pdsIdentity(ctx) })
+      const { email, fromName } = await brandedOrFallback(
         req,
-        'New user — welcome / email verification',
-        'Sent when a user signs up. Contains the OTP they enter to confirm their email and finish creating their account.',
-        email,
-      ),
-    )
-  })
+        code,
+        true,
+        fallback,
+      )
+      sendHtml(
+        res,
+        render(
+          req,
+          'New user — welcome / email verification',
+          'Sent when a user signs up. Contains the OTP they enter to confirm their email and finish creating their account.',
+          email,
+          fromName,
+        ),
+      )
+    },
+  )
 
   router.get(
     '/preview/emails/returning-user',
-    (req: Request, res: Response) => {
+    async (req: Request, res: Response) => {
       const code = queryString(req, 'otp') ?? FAKE_OTP
-      const email = buildSignInCodeEmail({
+      const fallback = buildSignInCodeEmail({
         code,
         clientAppName: queryString(req, 'app') ?? FAKE_APP_NAME,
         ...pdsIdentity(ctx),
       })
+      const { email, fromName } = await brandedOrFallback(
+        req,
+        code,
+        false,
+        fallback,
+      )
       sendHtml(
         res,
         render(
@@ -178,6 +236,7 @@ export function createPreviewEmailsRouter(ctx: AuthServiceContext): Router {
           'Returning user — sign-in OTP',
           'Sent when an existing user signs in to a client app. Contains the OTP they enter to complete the sign-in.',
           email,
+          fromName,
         ),
       )
     },

--- a/packages/auth-service/src/routes/preview-emails.ts
+++ b/packages/auth-service/src/routes/preview-emails.ts
@@ -59,8 +59,12 @@ function pdsIdentity(ctx: AuthServiceContext): {
   pdsName: string
   pdsDomain: string
 } {
+  // Mirror better-auth.ts: the real sender uses SMTP_FROM_NAME (which
+  // config.email.fromName is built from), not the auth-service hostname.
+  // Using config.hostname here would diverge the preview subject/footer
+  // from what production actually delivers.
   return {
-    pdsName: ctx.config.hostname,
+    pdsName: ctx.config.email.fromName,
     pdsDomain: ctx.config.pdsHostname,
   }
 }

--- a/packages/auth-service/src/routes/preview-emails.ts
+++ b/packages/auth-service/src/routes/preview-emails.ts
@@ -174,6 +174,7 @@ export function createPreviewEmailsRouter(ctx: AuthServiceContext): Router {
   ): Promise<{ email: RenderedEmail; fromName?: string }> {
     const clientId = queryString(req, 'client_id')
     if (!clientId) return { email: fallback }
+    const { pdsName, pdsDomain } = pdsIdentity(ctx)
     const branded = await buildClientBrandedEmail({
       clientId,
       code,
@@ -181,6 +182,8 @@ export function createPreviewEmailsRouter(ctx: AuthServiceContext): Router {
       toEmail: queryString(req, 'to') ?? FAKE_TO,
       fallbackAppName: queryString(req, 'app') ?? FAKE_APP_NAME,
       fallbackFromName: defaultFromName,
+      pdsName,
+      pdsDomain,
       trustedClients: ctx.config.trustedClients,
     })
     if (!branded) return { email: fallback }

--- a/packages/demo/src/app/client-metadata.json/route.ts
+++ b/packages/demo/src/app/client-metadata.json/route.ts
@@ -55,6 +55,13 @@ export async function GET() {
     dpop_bound_access_tokens: true,
     brand_color: theme?.page.primary ?? '#2563eb',
     background_color: theme?.page.bg ?? '#f8f9fa',
+    // Custom OTP email template, served from this same origin. Only
+    // honoured by auth-service when this client_id is on
+    // PDS_OAUTH_TRUSTED_CLIENTS (see `buildClientBrandedEmail` in
+    // packages/auth-service/src/email/client-template.ts); untrusted
+    // clients get the default PDS template regardless.
+    email_template_uri: `${baseUrl}/email-template.html`,
+    email_subject_template: '{{code}} — your {{app_name}} code',
     ...(process.env.EPDS_SKIP_CONSENT_ON_SIGNUP === 'true' && {
       epds_skip_consent_on_signup: true,
     }),

--- a/packages/demo/src/app/email-template.html/route.ts
+++ b/packages/demo/src/app/email-template.html/route.ts
@@ -1,0 +1,94 @@
+/**
+ * Branded OTP email template served to the auth-service as
+ * `email_template_uri`. The auth-service fetches this URL
+ * (SSRF-hardened, HTTPS-only, 100 KB / 5 s caps) on behalf of
+ * trusted clients and substitutes the following Mustache-like
+ * placeholders before sending:
+ *
+ *   {{code}}                       the OTP code (HTML-escaped)
+ *   {{app_name}}                   `client_name` from this metadata
+ *                                  (HTML-escaped)
+ *   {{logo_uri}}                   `logo_uri` from this metadata
+ *                                  (HTML-escaped)
+ *   {{email}}                      the recipient's email (HTML-escaped)
+ *   {{#is_new_user}}…{{/is_new_user}}  shown only on welcome emails
+ *   {{^is_new_user}}…{{/is_new_user}}  shown only on sign-in emails
+ *
+ * Styling is deliberately inline (no `<style>` block): several
+ * popular email clients strip or mangle `<style>`, and inline
+ * `style="…"` is the lowest common denominator.
+ *
+ * When EPDS_CLIENT_THEME is set, colours follow the same palette as
+ * the rest of the demo (injected CSS on the login page, page
+ * backgrounds in the React app, etc.), so an operator flipping the
+ * theme gets a visually coherent login + email experience with one
+ * env var.
+ */
+
+import { NextResponse } from 'next/server'
+import { getPageTheme } from '@/lib/theme'
+
+export const runtime = 'nodejs'
+
+export function GET() {
+  const theme = getPageTheme()
+  const bg = theme?.bg ?? '#f8f9fa'
+  const surface = theme?.surface ?? '#ffffff'
+  const text = theme?.text ?? '#0f1828'
+  const textMuted = theme?.textMuted ?? '#555555'
+  const textHint = theme?.textHint ?? '#888888'
+  const primary = theme?.primary ?? '#2563eb'
+  const border = theme?.inputBorder ?? '#e5e7eb'
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<body style="margin:0;padding:0;background:${bg};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:${text};">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:${bg};padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="480" cellpadding="0" cellspacing="0" border="0" style="max-width:480px;background:${surface};border:1px solid ${border};border-radius:10px;overflow:hidden;">
+          <tr>
+            <td style="padding:28px 32px 12px;text-align:center;">
+              <img src="{{logo_uri}}" alt="{{app_name}}" width="56" height="56" style="display:inline-block;border:0;border-radius:12px;">
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:0 32px 8px;text-align:center;">
+              <h1 style="margin:0;font-size:20px;font-weight:600;color:${text};">{{#is_new_user}}Welcome to {{app_name}}{{/is_new_user}}{{^is_new_user}}Sign in to {{app_name}}{{/is_new_user}}</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:4px 32px 20px;text-align:center;">
+              <p style="margin:0;font-size:14px;color:${textMuted};">{{#is_new_user}}Confirm your email to finish creating your account.{{/is_new_user}}{{^is_new_user}}Enter this code on the sign-in page to continue.{{/is_new_user}}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:0 32px 28px;text-align:center;">
+              <div style="display:inline-block;padding:16px 24px;background:${bg};border:1px solid ${border};border-radius:8px;font-family:'SF Mono',Menlo,Consolas,monospace;font-size:30px;letter-spacing:6px;color:${primary};font-weight:600;">{{code}}</div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:0 32px 24px;">
+              <p style="margin:0;font-size:13px;color:${textMuted};line-height:1.5;">This code expires in 10 minutes. If you didn't request it, you can safely ignore this email — someone likely typed your address by mistake.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:16px 32px 24px;border-top:1px solid ${border};">
+              <p style="margin:0;font-size:11px;color:${textHint};line-height:1.5;">Sent to {{email}} by {{app_name}}.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`
+
+  return new NextResponse(html, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=300',
+      'Access-Control-Allow-Origin': '*',
+    },
+  })
+}

--- a/packages/shared/src/preview-ui.ts
+++ b/packages/shared/src/preview-ui.ts
@@ -50,6 +50,18 @@ export const AUTH_PREVIEW_ROUTES: readonly PreviewRoute[] = [
   },
   { path: '/preview/recovery', label: 'Recovery — email step' },
   { path: '/preview/recovery-otp', label: 'Recovery — OTP step' },
+  {
+    path: '/preview/emails/new-user',
+    label: 'Email — new-user welcome / verify',
+  },
+  {
+    path: '/preview/emails/returning-user',
+    label: 'Email — returning-user sign-in OTP',
+  },
+  {
+    path: '/preview/emails/recovery',
+    label: 'Email — backup email verification',
+  },
 ] as const
 
 /** Routes served by pds-core. */


### PR DESCRIPTION
## Summary

- Add `/preview/emails/{new-user,returning-user,recovery}` to the auth service — rendering the exact HTML the real sender would deliver, inside a sandboxed iframe so email CSS can't bleed into the outer preview page
- Extract the three transactional email templates (welcome / sign-in OTP / backup-email verification) into a pure `templates.ts` so the preview routes and `EmailSender` share one source of truth
- **Refactor**: extract the client-branded email pipeline (metadata resolve → template fetch → Mustache render) from `sender.ts` into `email/client-template.ts#buildClientBrandedEmail`, so the preview routes render **bit-for-bit** what production sends. Preview's `?client_id=<URL>` now honours the real trusted-clients gate, falling back to the default template if the client is untrusted, has no `email_template_uri`, or the fetch fails.
- **Demo client branding**: the bundled demo client now advertises `email_template_uri` (pointing at `/email-template.html` on its own origin) and `email_subject_template`, so operators running the demo as a trusted client see a coherent login + email experience out of the box. The template is inline-styled HTML (no `<style>` block) that follows the demo's `EPDS_CLIENT_THEME` palette.
- Gated by the existing `AUTH_PREVIEW_ROUTES=1` flag; no new env vars on auth-service; linked from the `/preview` index via three new `AUTH_PREVIEW_ROUTES` entries

## Relationship to #95

#95 (merged) closed the bug that untrusted clients' `email_template_uri` was being honoured. This PR is rebased on top of #95; the new `buildClientBrandedEmail` helper takes the same `trustedClients` list and enforces the gate in both production and preview paths through one code path.

## Test plan

- [x] `pnpm format:check` clean
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 457/457 tests pass, including 5 builder tests in `email-templates.test.ts` and 4 new integration tests in `preview-emails.test.ts` covering the `?client_id` branded path (trusted returning-user, trusted new-user with `{{#is_new_user}}` conditional, untrusted fallback, trusted-without-template fallback)
- [x] Coverage: `preview-emails.ts` 100% stmts, `client-template.ts` 63.88% stmts, `sender.ts` up to 86.66% after refactor
- [ ] With `AUTH_PREVIEW_ROUTES=1` set, hit `/preview/emails/new-user`, `/preview/emails/returning-user`, `/preview/emails/recovery` in a browser and visually check the rendered iframe + headers
- [ ] With `AUTH_PREVIEW_ROUTES` unset, confirm all three routes return 404 like the rest of `/preview/*`
- [ ] `?otp=<code>`, `?app=<name>`, `?verify_url=<url>` overrides render as expected
- [ ] With the demo on `PDS_OAUTH_TRUSTED_CLIENTS`, hit `/preview/emails/returning-user?client_id=<demo-base-url>/client-metadata.json` and confirm the branded template renders with demo theme colours
- [ ] Flip `EPDS_CLIENT_THEME` (e.g. `ocean`) and confirm the branded email preview picks up the new palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-browser preview pages for transactional emails (new-user, returning-user, recovery) — render production-equivalent HTML in a sandboxed iframe and respect the preview flag.
  * Support for client-provided branded email templates and subject templating; demo client now ships a themed OTP template and advertises template/subject URLs.

* **Documentation**
  * Changesets and release notes updated describing preview routes, demo client branding, and template behavior.

* **Tests**
  * Added unit/integration tests for template builders, branded rendering, preview endpoints, and header-injection hardening; updated e2e feature expectations for branded subjects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->