### PR TITLE
test(e2e): login-hint-resolution feature scenarios

### DIFF
--- a/e2e/step-definitions/login-hint.steps.ts
+++ b/e2e/step-definitions/login-hint.steps.ts
@@ -1,0 +1,150 @@
+/**
+ * Step definitions for login-hint-resolution.feature.
+ *
+ * All scenarios depend on the Background "a returning user has a PDS account"
+ * step, which populates world.testEmail, world.userHandle, and world.userDid.
+ */
+
+import { Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { testEnv } from '../support/env.js'
+import type { EpdsWorld } from '../support/world.js'
+import { getPage, resetBrowserContext } from '../support/utils.js'
+import { sharedBrowser } from '../support/hooks.js'
+import { clearMailpit, extractOtp, waitForEmail } from '../support/mailpit.js'
+
+interface LoginHintOptions {
+  /** Raw login_hint value (email, handle, or DID). */
+  hint: string
+  /** Where the demo client places the hint. Defaults to 'query'. */
+  location?: 'query' | 'body'
+}
+
+/**
+ * Drive the demo client to initiate OAuth with a raw login_hint, bypassing
+ * the ?email / ?handle query params so we can exercise email, handle, DID,
+ * and "body-only" hint placement uniformly.
+ *
+ * Resets the browser context first — all Background accounts were created
+ * through a prior OAuth flow and the session cookie would short-circuit
+ * login_hint behavior on the next visit.
+ */
+async function initiateOAuthWithLoginHint(
+  world: EpdsWorld,
+  opts: LoginHintOptions,
+): Promise<void> {
+  if (!testEnv.mailpitPass) {
+    throw new Error('initiateOAuthWithLoginHint requires mailpit')
+  }
+  await resetBrowserContext(world, sharedBrowser)
+  const page = getPage(world)
+  const location = opts.location ?? 'query'
+  const url = new URL(testEnv.demoUrl)
+  url.searchParams.set('login_hint', opts.hint)
+  url.searchParams.set('login_hint_location', location)
+  await page.goto(url.toString())
+}
+
+When(
+  'the demo client initiates OAuth with the test email as login_hint',
+  async function (this: EpdsWorld) {
+    if (!testEnv.mailpitPass) return 'pending'
+    if (!this.testEmail) {
+      throw new Error(
+        'No test email — "a returning user has a PDS account" step must run first',
+      )
+    }
+    await clearMailpit(this.testEmail)
+    await initiateOAuthWithLoginHint(this, { hint: this.testEmail })
+  },
+)
+
+When(
+  'the demo client initiates OAuth with the test handle as login_hint',
+  async function (this: EpdsWorld) {
+    if (!testEnv.mailpitPass) return 'pending'
+    if (!this.userHandle || !this.testEmail) {
+      throw new Error(
+        'No userHandle/testEmail — "a returning user has a PDS account" step must run first',
+      )
+    }
+    await clearMailpit(this.testEmail)
+    await initiateOAuthWithLoginHint(this, { hint: this.userHandle })
+  },
+)
+
+When(
+  'the demo client initiates OAuth with the test DID as login_hint',
+  async function (this: EpdsWorld) {
+    if (!testEnv.mailpitPass) return 'pending'
+    if (!this.userDid || !this.testEmail) {
+      throw new Error(
+        'No userDid/testEmail — "a returning user has a PDS account" step must run first',
+      )
+    }
+    await clearMailpit(this.testEmail)
+    await initiateOAuthWithLoginHint(this, { hint: this.userDid })
+  },
+)
+
+When(
+  'the demo client submits the test handle as login_hint in the PAR body only',
+  async function (this: EpdsWorld) {
+    if (!testEnv.mailpitPass) return 'pending'
+    if (!this.userHandle || !this.testEmail) {
+      throw new Error(
+        'No userHandle/testEmail — "a returning user has a PDS account" step must run first',
+      )
+    }
+    await clearMailpit(this.testEmail)
+    await initiateOAuthWithLoginHint(this, {
+      hint: this.userHandle,
+      location: 'body',
+    })
+  },
+)
+
+When(
+  'the demo client initiates OAuth with an unknown handle as login_hint',
+  async function (this: EpdsWorld) {
+    if (!testEnv.mailpitPass) return 'pending'
+    // A handle that resolves to no account. Must be syntactically valid so
+    // the demo's validateHandle check doesn't reject it before PAR.
+    await initiateOAuthWithLoginHint(this, {
+      hint: `nonexistent-${Date.now()}.pds.test`,
+    })
+  },
+)
+
+Then(
+  'the login page renders directly at the OTP verification step',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await expect(page.locator('#step-otp.active')).toBeVisible({
+      timeout: 30_000,
+    })
+    await expect(page.locator('#step-email.hidden')).toBeAttached()
+  },
+)
+
+Then(
+  'an OTP email is auto-sent to the test email',
+  async function (this: EpdsWorld) {
+    if (!testEnv.mailpitPass) return 'pending'
+    if (!this.testEmail) {
+      throw new Error('No testEmail — Background step must run first')
+    }
+    const message = await waitForEmail(`to:${this.testEmail}`)
+    this.lastEmailSubject = message.Subject
+    this.otpCode = await extractOtp(message.ID)
+  },
+)
+
+Then(
+  'the login page shows the email input form',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await expect(page.locator('#email')).toBeVisible({ timeout: 30_000 })
+    await expect(page.locator('#step-otp.active')).toBeHidden()
+  },
+)

--- a/e2e/step-definitions/login-hint.steps.ts
+++ b/e2e/step-definitions/login-hint.steps.ts
@@ -25,6 +25,9 @@ interface LoginHintOptions {
  * the ?email / ?handle query params so we can exercise email, handle, DID,
  * and "body-only" hint placement uniformly.
  *
+ * Hits /api/oauth/login directly — the demo home page doesn't forward
+ * query params, and the login route is where rawLoginHint is read.
+ *
  * Resets the browser context first — all Background accounts were created
  * through a prior OAuth flow and the session cookie would short-circuit
  * login_hint behavior on the next visit.
@@ -39,7 +42,7 @@ async function initiateOAuthWithLoginHint(
   await resetBrowserContext(world, sharedBrowser)
   const page = getPage(world)
   const location = opts.location ?? 'query'
-  const url = new URL(testEnv.demoUrl)
+  const url = new URL('/api/oauth/login', testEnv.demoUrl)
   url.searchParams.set('login_hint', opts.hint)
   url.searchParams.set('login_hint_location', location)
   await page.goto(url.toString())

--- a/features/login-hint-resolution.feature
+++ b/features/login-hint-resolution.feature
@@ -1,4 +1,3 @@
-@pending
 Feature: Login hint resolution
   ePDS resolves OAuth login_hint parameters so the auth service can skip
   the email form and go straight to OTP verification. Hints can be emails,
@@ -10,29 +9,28 @@ Feature: Login hint resolution
 
   Background:
     Given the ePDS test environment is running
-    And "alice@example.com" has a PDS account with handle "alice.pds.test"
+    And a returning user has a PDS account
 
   Scenario: Email login hint skips the email form
-    When the demo client initiates OAuth with login_hint="alice@example.com"
+    When the demo client initiates OAuth with the test email as login_hint
     Then the login page renders directly at the OTP verification step
-    And an OTP email is auto-sent to "alice@example.com"
+    And an OTP email is auto-sent to the test email
 
   Scenario: Handle login hint is resolved and skips the email form
-    When the demo client initiates OAuth with login_hint="alice.pds.test"
+    When the demo client initiates OAuth with the test handle as login_hint
     Then the login page renders directly at the OTP verification step
-    And an OTP email is auto-sent to "alice@example.com"
+    And an OTP email is auto-sent to the test email
 
   Scenario: DID login hint is resolved and skips the email form
-    Given alice's DID is "did:plc:alice123"
-    When the demo client initiates OAuth with login_hint="did:plc:alice123"
+    When the demo client initiates OAuth with the test DID as login_hint
     Then the login page renders directly at the OTP verification step
-    And an OTP email is auto-sent to "alice@example.com"
+    And an OTP email is auto-sent to the test email
 
   Scenario: Login hint from PAR body is used when not on query string
-    When the demo client submits login_hint in the PAR request body (not the redirect URL)
-    Then the auth service retrieves the hint from the stored PAR request
-    And the login page renders at the OTP step with the hint resolved
+    When the demo client submits the test handle as login_hint in the PAR body only
+    Then the login page renders directly at the OTP verification step
+    And an OTP email is auto-sent to the test email
 
   Scenario: Unknown login hint falls back to email form
-    When the demo client initiates OAuth with login_hint="unknown.pds.test"
-    Then the login page shows the email input form (hint could not be resolved)
+    When the demo client initiates OAuth with an unknown handle as login_hint
+    Then the login page shows the email input form

--- a/packages/demo/src/app/api/oauth/login/route.ts
+++ b/packages/demo/src/app/api/oauth/login/route.ts
@@ -69,6 +69,16 @@ export async function GET(request: Request) {
     const handleModeParam = handleMode
       ? `&epds_handle_mode=${encodeURIComponent(handleMode)}`
       : ''
+    // Raw login_hint override: accept any identifier (email, handle, DID) and
+    // forward it verbatim. When set, takes precedence over the derived
+    // login_hint from `email`. Used by login-hint-resolution e2e scenarios
+    // that need to exercise handle/DID hints and PAR-body placement, which
+    // the primary ?email= path doesn't produce.
+    const rawLoginHint = url.searchParams.get('login_hint') || ''
+    const loginHintLocationRaw =
+      url.searchParams.get('login_hint_location') || 'query'
+    const loginHintLocation: 'query' | 'body' =
+      loginHintLocationRaw === 'body' ? 'body' : 'query'
 
     // Input validation
     // Note: email and handle are both optional — omitting both triggers Flow 2
@@ -78,6 +88,14 @@ export async function GET(request: Request) {
     }
     if (handle && !validateHandle(handle)) {
       return NextResponse.redirect(new URL('/?error=invalid_handle', baseUrl))
+    }
+    // Lax validation for the raw login_hint override — accepts email,
+    // handle, or DID shapes. Reject only obvious garbage so attackers can't
+    // push arbitrary strings through our PAR body / authorize URL.
+    if (rawLoginHint && !/^[\w.@:+-]{1,256}$/.test(rawLoginHint)) {
+      return NextResponse.redirect(
+        new URL('/?error=invalid_login_hint', baseUrl),
+      )
     }
 
     // Determine endpoints: dynamic for handle, defaults for email.
@@ -126,6 +144,18 @@ export async function GET(request: Request) {
       url: parEndpoint,
     })
 
+    // Effective login_hint: explicit ?login_hint= wins over the derived
+    // email-based hint so callers can inject handle/DID identifiers.
+    const effectiveLoginHint = rawLoginHint || email
+    // When login_hint_location=body, the hint goes in the PAR body only and
+    // is omitted from the authorize redirect URL — this mirrors the
+    // third-party app pattern (e.g. sdsls.dev) that the auth service's
+    // fetchParLoginHint path exists to handle.
+    const loginHintQueryParam =
+      effectiveLoginHint && loginHintLocation === 'query'
+        ? `&login_hint=${encodeURIComponent(effectiveLoginHint)}`
+        : ''
+
     // Push Authorization Request (PAR)
     const parBody = new URLSearchParams({
       client_id: clientId,
@@ -136,6 +166,9 @@ export async function GET(request: Request) {
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
     })
+    if (effectiveLoginHint && loginHintLocation === 'body') {
+      parBody.set('login_hint', effectiveLoginHint)
+    }
 
     // If this demo is configured as a confidential OAuth client
     // (EPDS_CLIENT_PRIVATE_JWK set), sign a client_assertion and add
@@ -231,10 +264,7 @@ export async function GET(request: Request) {
         }
 
         const parData2 = (await parRes2.json()) as { request_uri: string }
-        const loginHint = email
-          ? `&login_hint=${encodeURIComponent(email)}`
-          : ''
-        const authUrl = `${authEndpoint}?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(parData2.request_uri)}${loginHint}${handleModeParam}`
+        const authUrl = `${authEndpoint}?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(parData2.request_uri)}${loginHintQueryParam}${handleModeParam}`
         console.log('[oauth/login] Redirecting to auth (after nonce retry)')
         const resp2 = NextResponse.redirect(authUrl)
         resp2.cookies.set(oauthCookie.name, oauthCookie.value, {
@@ -251,10 +281,7 @@ export async function GET(request: Request) {
     }
 
     const parData = (await parRes.json()) as { request_uri: string }
-    const loginHintParam = email
-      ? `&login_hint=${encodeURIComponent(email)}`
-      : ''
-    const authUrl = `${authEndpoint}?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(parData.request_uri)}${loginHintParam}${handleModeParam}`
+    const authUrl = `${authEndpoint}?client_id=${encodeURIComponent(clientId)}&request_uri=${encodeURIComponent(parData.request_uri)}${loginHintQueryParam}${handleModeParam}`
 
     console.log('[oauth/login] Redirecting to auth')
     const response = NextResponse.redirect(authUrl)

--- a/packages/demo/src/app/components/LoginForm.tsx
+++ b/packages/demo/src/app/components/LoginForm.tsx
@@ -9,6 +9,7 @@ const ERROR_MESSAGES: Record<string, string> = {
     'Could not start login — the PDS rejected the request. Check server logs.',
   invalid_email: 'Please enter a valid email address.',
   invalid_handle: 'Please enter a valid handle (e.g. you.bsky.social).',
+  invalid_login_hint: 'Invalid login hint format.',
   token_failed: 'Login could not be completed — token exchange failed.',
   state_mismatch:
     'Login session expired or was tampered with. Please try again.',


### PR DESCRIPTION
## Summary
- Implement all 5 scenarios in `features/login-hint-resolution.feature` (email/handle/DID hints on query string, hint in PAR body only, unknown hint fallback).
- Rewrite the feature to use the dynamic test account created by the Background — the prior `alice@example.com` / `alice.pds.test` / `did:plc:alice123` literals can't be planted in the live Railway test environment.
- Extend the demo OAuth client with `?login_hint=<raw>` and `?login_hint_location=query|body` so tests can exercise the handle / DID / PAR-body code paths without a bespoke OAuth client. Existing `?email=` / `?handle=` behavior is unchanged; the explicit `?login_hint=` override wins when provided.

## Test plan
- [x] `pnpm lint && pnpm format:check && pnpm typecheck && pnpm test` all pass locally
- [ ] E2E tests on Railway (triggered by push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)