### PR TITLE
security(auth-service): gate branded email templates on trustedClients

### DIFF
--- a/.changeset/gate-email-templates-on-trusted-clients.md
+++ b/.changeset/gate-email-templates-on-trusted-clients.md
@@ -1,0 +1,11 @@
+---
+'ePDS': patch
+---
+
+Security fix: client-supplied email templates now require the client to be on the trusted-clients list.
+
+**Affects:** Client app developers, Operators
+
+**Client app developers:** `email_template_uri`, `email_subject_template`, and the `client_name`-derived `From:` display name on OTP emails are now only honoured for clients whose `client_id` is on the PDS's `PDS_OAUTH_TRUSTED_CLIENTS` list — matching the gate that already applied to CSS branding injection. Untrusted clients receive the default ePDS OTP template with the default `From:` name. If your client isn't on the operator's trust list, advertising these fields in `client-metadata.json` has no effect; ask the operator to add your `client_id` to their trusted list.
+
+**Operators:** `PDS_OAUTH_TRUSTED_CLIENTS` now gates email-template branding as well as CSS injection. No config change is required — the same list is reused. If you have been relying on an untrusted client's `email_template_uri` to style OTP emails (no known such case, but worth checking), add that `client_id` to `PDS_OAUTH_TRUSTED_CLIENTS` to restore the previous behaviour. Without this fix, any registered `client_id` could (a) cause the auth service to fetch an attacker-chosen URL on every OTP send, (b) ship attacker-authored HTML in an email sent from the PDS's own `noreply@` address, and (c) spoof the sender display name via `client_name`. `EMAIL_TEMPLATE_ALLOWED_DOMAINS` still applies as an additional narrowing for trusted-client template hosts.

--- a/features/client-branding.feature
+++ b/features/client-branding.feature
@@ -95,3 +95,17 @@ Feature: Client branding — CSS injection and custom email templates
     Given the user is logging into account settings (no OAuth client context)
     When the user requests an OTP
     Then the default PDS email template is used
+
+  @email @untrusted-client @pending
+  Scenario: Untrusted client's email_template_uri is ignored
+    # Security gate: the email_template_uri / email_subject_template /
+    # client_name-as-From-display-name fields must only be honoured for
+    # clients on PDS_OAUTH_TRUSTED_CLIENTS, matching the CSS-injection
+    # gate. An untrusted client that advertises these fields must get
+    # the default PDS OTP email, not its own template — otherwise any
+    # registered client_id could phish via the PDS's own From: address.
+    Given the untrusted demo client's metadata advertises an "email_template_uri"
+    When a user requests an OTP via the untrusted demo client
+    Then the OTP email in the mail trap uses the default PDS template
+    And the email From display name is the default PDS name
+    And the OTP email subject does not come from the untrusted client's template

--- a/packages/auth-service/.env.example
+++ b/packages/auth-service/.env.example
@@ -40,7 +40,10 @@ PDS_ADMIN_PASSWORD=
 # [shared] Set to 'development' for dev mode (disables secure cookies, etc.)
 # NODE_ENV=development
 
-# [shared] Comma-separated OAuth client_id URLs trusted for CSS branding injection.
+# [shared] Comma-separated OAuth client_id URLs trusted for branding injection.
+# Gates BOTH CSS branding injection AND client-supplied email templates
+# (email_template_uri, email_subject_template, client_name-as-From-display-name).
+# Untrusted clients fall back to default templates for both surfaces.
 # MUST match pds-core.
 # PDS_OAUTH_TRUSTED_CLIENTS=
 

--- a/packages/auth-service/src/__tests__/email-template.test.ts
+++ b/packages/auth-service/src/__tests__/email-template.test.ts
@@ -27,14 +27,14 @@ beforeEach(() => {
 })
 
 /** Create an EmailSender with jsonTransport (captures sent mail as JSON). */
-function makeSender(): EmailSender {
+function makeSender(trustedClients: string[] = []): EmailSender {
   const config: EmailConfig = {
     // Use an invalid provider to trigger jsonTransport fallback
     provider: 'none' as EmailConfig['provider'],
     from: 'noreply@pds.example',
     fromName: 'Test PDS',
   }
-  return new EmailSender(config)
+  return new EmailSender(config, trustedClients)
 }
 
 describe('EmailSender', () => {
@@ -85,29 +85,28 @@ describe('EmailSender', () => {
   })
 
   describe('sendOtpCode (client template)', () => {
-    it('uses client template when available', async () => {
+    const TRUSTED_ID = 'https://branded.app/client-metadata.json'
+
+    it('uses client template when client is trusted', async () => {
       // Seed caches so no real HTTP fetch is needed
-      _seedClientMetadataCacheForTest(
-        'https://branded.app/client-metadata.json',
-        {
-          client_name: 'Branded App',
-          email_template_uri: 'https://branded.app/email-template.html',
-          logo_uri: 'https://branded.app/logo.png',
-        },
-      )
+      _seedClientMetadataCacheForTest(TRUSTED_ID, {
+        client_name: 'Branded App',
+        email_template_uri: 'https://branded.app/email-template.html',
+        logo_uri: 'https://branded.app/logo.png',
+      })
       _seedTemplateCacheForTest(
         'https://branded.app/email-template.html',
         '<html><body>Your code is {{code}} for {{app_name}}</body></html>',
       )
 
-      const sender = makeSender()
+      const sender = makeSender([TRUSTED_ID])
       const sendMailSpy = vi.spyOn(sender['transporter'], 'sendMail')
 
       await sender.sendOtpCode({
         to: 'branded@test.com',
         code: '99999999',
         clientAppName: 'Fallback Name',
-        clientId: 'https://branded.app/client-metadata.json',
+        clientId: TRUSTED_ID,
         pdsName: 'Test PDS',
         pdsDomain: 'pds.example',
       })
@@ -132,7 +131,7 @@ describe('EmailSender', () => {
         },
       )
 
-      const sender = makeSender()
+      const sender = makeSender(['https://plain.app/client-metadata.json'])
       const sendMailSpy = vi.spyOn(sender['transporter'], 'sendMail')
 
       await sender.sendOtpCode({
@@ -154,6 +153,62 @@ describe('EmailSender', () => {
       expect(mailOpts.subject).toContain('Test PDS')
       expect(mailOpts.html).toContain(formatOtpHtmlGrouped('44444444'))
       expect(mailOpts.from).toContain('Test PDS')
+    })
+
+    it('ignores email_template_uri from untrusted clients', async () => {
+      // An untrusted client advertises a full set of branding fields.
+      // The gate must drop all of them — the metadata resolver must
+      // not even be called (no outbound fetch on the hot path), and
+      // the sent mail must use the default PDS template with the
+      // default From name. `clientAppName` is a *caller*-supplied
+      // string (not from the client's own metadata), so the default
+      // template is still free to mention it: the attack we're
+      // blocking is metadata-derived content, not the caller's label.
+      const resolveSpy = vi
+        .spyOn(
+          await import('../lib/client-metadata.js'),
+          'resolveClientMetadata',
+        )
+        .mockResolvedValue({
+          client_name: 'Evil App (from metadata)',
+          email_template_uri: 'https://evil.example/pwn.html',
+          email_subject_template: '{{code}} — pwned',
+          logo_uri: 'https://evil.example/logo.png',
+        })
+
+      const sender = makeSender([
+        // A *different* client_id is trusted. The one in the request is not.
+        'https://other-trusted.app/client-metadata.json',
+      ])
+      const sendMailSpy = vi.spyOn(sender['transporter'], 'sendMail')
+
+      await sender.sendOtpCode({
+        to: 'victim@test.com',
+        code: '77777777',
+        clientAppName: 'Caller App Name',
+        clientId: 'https://evil.example/client-metadata.json',
+        pdsName: 'Test PDS',
+        pdsDomain: 'pds.example',
+      })
+
+      expect(resolveSpy).not.toHaveBeenCalled()
+      expect(sendMailSpy).toHaveBeenCalledOnce()
+      const mailOpts = sendMailSpy.mock.calls[0][0] as {
+        html: string
+        subject: string
+        from: string
+      }
+      // Default subject uses pdsName, not metadata.client_name.
+      expect(mailOpts.subject).toContain('Test PDS')
+      expect(mailOpts.subject).not.toContain('pwned')
+      // From display name stays as the PDS default.
+      expect(mailOpts.from).toContain('Test PDS')
+      expect(mailOpts.from).not.toContain('from metadata')
+      // No metadata-derived HTML — the attacker's template never rendered.
+      expect(mailOpts.html).not.toContain('from metadata')
+      expect(mailOpts.html).toContain(formatOtpHtmlGrouped('77777777'))
+
+      resolveSpy.mockRestore()
     })
   })
 

--- a/packages/auth-service/src/context.ts
+++ b/packages/auth-service/src/context.ts
@@ -22,7 +22,13 @@ export interface AuthServiceConfig {
   dbLocation: string
   otpLength: number
   otpCharset: 'numeric' | 'alphanumeric'
-  /** OAuth client_id URLs trusted for CSS branding injection. */
+  /**
+   * OAuth client_id URLs trusted for branding injection. Used to gate
+   * CSS branding injection AND client-supplied email templates
+   * (`email_template_uri`, `email_subject_template`, `client_name`-as-
+   * From display name). Untrusted clients always receive the default
+   * PDS email templates.
+   */
   trustedClients: string[]
 }
 
@@ -36,7 +42,7 @@ export class AuthServiceContext {
   constructor(config: AuthServiceConfig) {
     this.config = config
     this.db = new EpdsDb(config.dbLocation)
-    this.emailSender = new EmailSender(config.email)
+    this.emailSender = new EmailSender(config.email, config.trustedClients)
 
     // Cleanup expired tokens every 5 minutes
     setInterval(

--- a/packages/auth-service/src/email/sender.ts
+++ b/packages/auth-service/src/email/sender.ts
@@ -139,7 +139,21 @@ function renderSubjectTemplate(
 export class EmailSender {
   private transporter: Transporter
 
-  constructor(private readonly config: EmailConfig) {
+  /**
+   * @param config  SMTP / provider config.
+   * @param trustedClients  OAuth client_id URLs (from
+   *   `PDS_OAUTH_TRUSTED_CLIENTS`) for which we will honour
+   *   `email_template_uri`, `email_subject_template`, and the
+   *   `client_name`-derived From display name. Any other `client_id`
+   *   falls back to the default PDS templates regardless of what its
+   *   metadata advertises — an untrusted third party must not be able
+   *   to cause outbound fetches or put attacker-controlled HTML
+   *   alongside the PDS's own From address.
+   */
+  constructor(
+    private readonly config: EmailConfig,
+    private readonly trustedClients: readonly string[] = [],
+  ) {
     this.transporter = this.createTransporter()
   }
 
@@ -209,8 +223,14 @@ export class EmailSender {
   }): Promise<void> {
     const { to, code, clientAppName, pdsName, pdsDomain, isNewUser } = opts
 
-    // Try to use a client-provided email template
-    if (opts.clientId) {
+    // Try to use a client-provided email template. Only trusted clients
+    // are allowed to supply templates: an untrusted client_id could
+    // otherwise (a) cause an outbound fetch to an attacker-controlled
+    // URL on every OTP send, (b) put attacker-chosen HTML alongside the
+    // PDS's own From address (phishing uplift), or (c) override the
+    // From display name via `client_name`. This matches the gate on
+    // CSS branding injection.
+    if (opts.clientId && this.trustedClients.includes(opts.clientId)) {
       try {
         const metadata = await resolveClientMetadata(opts.clientId)
         if (metadata.email_template_uri) {

--- a/packages/pds-core/.env.example
+++ b/packages/pds-core/.env.example
@@ -73,7 +73,10 @@ PDS_PLC_ROTATION_KEY_K256_PRIVATE_KEY_HEX=
 # Option 2: Disable the requirement entirely (not recommended for production)
 # PDS_INVITE_REQUIRED=false
 
-# [shared] Comma-separated OAuth client_id URLs trusted for CSS branding injection.
+# [shared] Comma-separated OAuth client_id URLs trusted for branding injection.
+# Gates CSS branding injection here; on auth-service also gates client-supplied
+# email templates (email_template_uri, email_subject_template, client_name-as-
+# From-display-name). Untrusted clients fall back to default templates.
 # MUST match auth-service.
 # PDS_OAUTH_TRUSTED_CLIENTS=
 


### PR DESCRIPTION
## Summary

`EmailSender.sendOtpCode` was honouring `email_template_uri`, `email_subject_template`, and `client_name`-as-`From:`-display-name for **any** `client_id` that advertised them — regardless of whether that client was on `PDS_OAUTH_TRUSTED_CLIENTS`. The CSS branding-injection path already gated on `trustedClients`; the email path was missed.

This PR closes the gap by threading `trustedClients` into `EmailSender` via the constructor and requiring `trustedClients.includes(clientId)` before honouring any metadata-derived email branding. The metadata resolver is not even called for untrusted clients — so no outbound fetch either.

## Impact (pre-fix)

Any untrusted `client_id` registered against the PDS could:

1. Cause an outbound fetch to an attacker-controlled URL on every OTP send (recon, outbound traffic correlation).
2. Render attacker-authored HTML in an email sent from the PDS's own `noreply@` `From:` address (phishing uplift).
3. Spoof the `From:` display name via `client_name`.

Existing mitigations (`makeSafeFetch` — HTTPS-only, no private IPs, 5 s timeout, 100 KB cap; `escapeHtml` on substituted variables; optional `EMAIL_TEMPLATE_ALLOWED_DOMAINS`) narrowed the SSRF surface but did **not** block phishing-via-template for any attacker who could get a `client_id` registered.

## Changes

- `EmailSender` constructor now takes a `trustedClients` array. `AuthServiceContext` passes `config.trustedClients` through.
- `sendOtpCode` short-circuits to the default PDS template when `!trustedClients.includes(clientId)`. The metadata resolver is skipped entirely in that case.
- `config.trustedClients` jsdoc and both `.env.example` files (`auth-service`, `pds-core`) updated to reflect the broadened scope of the flag.
- New regression test: an untrusted `client_id` whose mocked metadata advertises all four branding fields produces a default-template email, and `resolveClientMetadata` is never called.
- Existing trusted-path tests updated to pass the trusted URL into the sender.
- New `@pending` cucumber scenario in `client-branding.feature` documenting the behaviour contract end-to-end; the step definitions land in the follow-up email-branding PR that wires the trusted demo client to actually serve an `email_template_uri` (which is what you need in the fixture to exercise the trusted-vs-untrusted split).

`EMAIL_TEMPLATE_ALLOWED_DOMAINS` is unchanged — it stays as an extra narrowing for trusted-client template hosts.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 443 / 443 pass, including the new untrusted-client regression test
- [x] `pnpm test:coverage` — sender.ts coverage rose (new gate branches exercised)
- [ ] E2E scenario documented as `@pending`; unpended and run in the follow-up email-branding PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)