### PR TITLE
[HYPER-320] style auth error pages

### DIFF
--- a/.changeset/styled-auth-error-pages.md
+++ b/.changeset/styled-auth-error-pages.md
@@ -1,0 +1,11 @@
+---
+'ePDS': patch
+---
+
+Error pages on the sign-in service now match the rest of the signup and login look instead of showing plain default text, and apps calling the sign-in service now receive structured error responses by default instead of HTML pages.
+
+**Affects:** End users, Client app developers
+
+**End users:** When a sign-in URL can't be found or something goes wrong on the sign-in service, the page shown now uses the same branded card layout as the rest of the sign-in flow, rather than the framework's unstyled default error page. The same applies to validation screens inside `/account` settings when a required field is missing or a verification link is malformed.
+
+**Client app developers:** The auth-service 404 and 500 handlers now do proper `Accept` header negotiation. Previously they returned HTML whenever the client would accept it — including `Accept: */*`, which `fetch` and `curl` send by default — so programmatic callers received HTML error bodies. The handlers now use `req.accepts(['json', 'html'])` and only return HTML when the client explicitly prefers it; anything else (including `*/*`) returns the existing JSON shape `{ "error": "not_found" | "internal_error" }`. If you were parsing HTML error responses from auth-service, switch to the JSON shape, or send `Accept: text/html` explicitly to opt back into HTML.

--- a/packages/auth-service/src/__tests__/error-handlers.test.ts
+++ b/packages/auth-service/src/__tests__/error-handlers.test.ts
@@ -1,71 +1,35 @@
 /**
- * Tests for the trailing 404 + 500 middleware in createAuthService. Mirror
- * the real handlers exactly — content negotiation via req.accepts(['json',
- * 'html']), HTML uses renderError, JSON uses a stable error code. Also
- * verifies the headersSent guard delegates to Express's default handler.
+ * Integration tests for the trailing 404 + 500 middleware that
+ * createAuthService mounts. Imports the real handlers and exercises
+ * content negotiation (JSON for Accept: * / *, HTML for browser Accept)
+ * plus the headersSent guard that delegates to Express's default handler.
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import express, { type Express } from 'express'
 import type { AddressInfo } from 'node:net'
 import type { Server } from 'node:http'
-import { renderError } from '../lib/render-error.js'
+import { errorHandler, notFoundHandler } from '../lib/error-middleware.js'
 
 let server: Server
 let baseUrl: string
 
 beforeAll(async () => {
   const app: Express = express()
+  app.disable('x-powered-by')
 
   app.get('/ok', (_req, res) => {
     res.json({ ok: true })
   })
-
   app.get('/boom', (_req, _res, next) => {
     next(new Error('kaboom'))
   })
-
   app.get('/double', (_req, res, next) => {
     res.status(200).json({ partial: true })
     next(new Error('after-send'))
   })
 
-  app.use((req, res) => {
-    if (req.accepts(['json', 'html']) === 'html') {
-      res
-        .status(404)
-        .type('html')
-        .send(
-          renderError(
-            "The page you're looking for doesn't exist.",
-            'Page not found',
-          ),
-        )
-    } else {
-      res.status(404).json({ error: 'not_found' })
-    }
-  })
-
-  app.use(
-    (
-      err: unknown,
-      req: express.Request,
-      res: express.Response,
-      next: express.NextFunction,
-    ) => {
-      if (res.headersSent) {
-        next(err)
-        return
-      }
-      if (req.accepts(['json', 'html']) === 'html') {
-        res
-          .status(500)
-          .type('html')
-          .send(renderError('Something went wrong. Please try again.'))
-      } else {
-        res.status(500).json({ error: 'internal_error' })
-      }
-    },
-  )
+  app.use(notFoundHandler)
+  app.use(errorHandler)
 
   await new Promise<void>((resolve) => {
     server = app.listen(0, '127.0.0.1', () => {
@@ -84,7 +48,7 @@ afterAll(async () => {
   })
 })
 
-describe('404 handler', () => {
+describe('notFoundHandler', () => {
   it('returns JSON for Accept: */* (fetch/curl default)', async () => {
     const res = await fetch(`${baseUrl}/nope`)
     expect(res.status).toBe(404)
@@ -115,7 +79,7 @@ describe('404 handler', () => {
   })
 })
 
-describe('500 handler', () => {
+describe('errorHandler', () => {
   it('returns JSON for Accept: */*', async () => {
     const res = await fetch(`${baseUrl}/boom`)
     expect(res.status).toBe(500)
@@ -133,10 +97,8 @@ describe('500 handler', () => {
     expect(body).toContain('Something went wrong')
   })
 
-  it('does not crash when headers already sent — delegates to next', async () => {
+  it('delegates to Express default handler when headers already sent', async () => {
     const res = await fetch(`${baseUrl}/double`)
-    // First response already started (200) — Express default handler aborts,
-    // so the client sees the original 200 body.
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ partial: true })
   })

--- a/packages/auth-service/src/__tests__/error-handlers.test.ts
+++ b/packages/auth-service/src/__tests__/error-handlers.test.ts
@@ -4,10 +4,10 @@
  * content negotiation (JSON for Accept: * / *, HTML for browser Accept)
  * plus the headersSent guard that delegates to Express's default handler.
  */
+import type { Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import express, { type Express } from 'express'
-import type { AddressInfo } from 'node:net'
-import type { Server } from 'node:http'
 import { errorHandler, notFoundHandler } from '../lib/error-middleware.js'
 
 let server: Server

--- a/packages/auth-service/src/__tests__/error-handlers.test.ts
+++ b/packages/auth-service/src/__tests__/error-handlers.test.ts
@@ -53,6 +53,7 @@ describe('notFoundHandler', () => {
     const res = await fetch(`${baseUrl}/nope`)
     expect(res.status).toBe(404)
     expect(res.headers.get('content-type')).toMatch(/application\/json/)
+    expect(res.headers.get('vary')).toMatch(/\bAccept\b/i)
     expect(await res.json()).toEqual({ error: 'not_found' })
   })
 
@@ -73,6 +74,7 @@ describe('notFoundHandler', () => {
     })
     expect(res.status).toBe(404)
     expect(res.headers.get('content-type')).toMatch(/text\/html/)
+    expect(res.headers.get('vary')).toMatch(/\bAccept\b/i)
     const body = await res.text()
     expect(body).toContain('<title>Page not found</title>')
     expect(body).toContain("doesn't exist")
@@ -83,6 +85,7 @@ describe('errorHandler', () => {
   it('returns JSON for Accept: */*', async () => {
     const res = await fetch(`${baseUrl}/boom`)
     expect(res.status).toBe(500)
+    expect(res.headers.get('vary')).toMatch(/\bAccept\b/i)
     expect(await res.json()).toEqual({ error: 'internal_error' })
   })
 
@@ -92,6 +95,7 @@ describe('errorHandler', () => {
     })
     expect(res.status).toBe(500)
     expect(res.headers.get('content-type')).toMatch(/text\/html/)
+    expect(res.headers.get('vary')).toMatch(/\bAccept\b/i)
     const body = await res.text()
     expect(body).toContain('<title>Error</title>')
     expect(body).toContain('Something went wrong')

--- a/packages/auth-service/src/__tests__/error-handlers.test.ts
+++ b/packages/auth-service/src/__tests__/error-handlers.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the trailing 404 + 500 middleware in createAuthService. Mirror
+ * the real handlers exactly — content negotiation via req.accepts(['json',
+ * 'html']), HTML uses renderError, JSON uses a stable error code. Also
+ * verifies the headersSent guard delegates to Express's default handler.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import express, { type Express } from 'express'
+import type { AddressInfo } from 'node:net'
+import type { Server } from 'node:http'
+import { renderError } from '../lib/render-error.js'
+
+let server: Server
+let baseUrl: string
+
+beforeAll(async () => {
+  const app: Express = express()
+
+  app.get('/ok', (_req, res) => {
+    res.json({ ok: true })
+  })
+
+  app.get('/boom', (_req, _res, next) => {
+    next(new Error('kaboom'))
+  })
+
+  app.get('/double', (_req, res, next) => {
+    res.status(200).json({ partial: true })
+    next(new Error('after-send'))
+  })
+
+  app.use((req, res) => {
+    if (req.accepts(['json', 'html']) === 'html') {
+      res
+        .status(404)
+        .type('html')
+        .send(
+          renderError(
+            "The page you're looking for doesn't exist.",
+            'Page not found',
+          ),
+        )
+    } else {
+      res.status(404).json({ error: 'not_found' })
+    }
+  })
+
+  app.use(
+    (
+      err: unknown,
+      req: express.Request,
+      res: express.Response,
+      next: express.NextFunction,
+    ) => {
+      if (res.headersSent) {
+        next(err)
+        return
+      }
+      if (req.accepts(['json', 'html']) === 'html') {
+        res
+          .status(500)
+          .type('html')
+          .send(renderError('Something went wrong. Please try again.'))
+      } else {
+        res.status(500).json({ error: 'internal_error' })
+      }
+    },
+  )
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      resolve()
+    })
+  })
+  const addr = server.address() as AddressInfo
+  baseUrl = `http://127.0.0.1:${addr.port}`
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve()
+    })
+  })
+})
+
+describe('404 handler', () => {
+  it('returns JSON for Accept: */* (fetch/curl default)', async () => {
+    const res = await fetch(`${baseUrl}/nope`)
+    expect(res.status).toBe(404)
+    expect(res.headers.get('content-type')).toMatch(/application\/json/)
+    expect(await res.json()).toEqual({ error: 'not_found' })
+  })
+
+  it('returns JSON for explicit Accept: application/json', async () => {
+    const res = await fetch(`${baseUrl}/nope`, {
+      headers: { Accept: 'application/json' },
+    })
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'not_found' })
+  })
+
+  it('returns styled HTML for browser Accept header', async () => {
+    const res = await fetch(`${baseUrl}/nope`, {
+      headers: {
+        Accept:
+          'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      },
+    })
+    expect(res.status).toBe(404)
+    expect(res.headers.get('content-type')).toMatch(/text\/html/)
+    const body = await res.text()
+    expect(body).toContain('<title>Page not found</title>')
+    expect(body).toContain("doesn't exist")
+  })
+})
+
+describe('500 handler', () => {
+  it('returns JSON for Accept: */*', async () => {
+    const res = await fetch(`${baseUrl}/boom`)
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'internal_error' })
+  })
+
+  it('returns styled HTML for browser Accept header', async () => {
+    const res = await fetch(`${baseUrl}/boom`, {
+      headers: { Accept: 'text/html' },
+    })
+    expect(res.status).toBe(500)
+    expect(res.headers.get('content-type')).toMatch(/text\/html/)
+    const body = await res.text()
+    expect(body).toContain('<title>Error</title>')
+    expect(body).toContain('Something went wrong')
+  })
+
+  it('does not crash when headers already sent — delegates to next', async () => {
+    const res = await fetch(`${baseUrl}/double`)
+    // First response already started (200) — Express default handler aborts,
+    // so the client sees the original 200 body.
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ partial: true })
+  })
+})

--- a/packages/auth-service/src/__tests__/render-error.test.ts
+++ b/packages/auth-service/src/__tests__/render-error.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+
+import { renderError } from '../lib/render-error.js'
+
+describe('renderError', () => {
+  it('produces an HTML document with default title', () => {
+    const html = renderError('Something went wrong')
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true)
+    expect(html).toContain('<title>Error</title>')
+    expect(html).toContain('<h1>Error</h1>')
+    expect(html).toContain('Something went wrong')
+  })
+
+  it('uses the provided title', () => {
+    const html = renderError('Nope', 'Access Denied')
+    expect(html).toContain('<title>Access Denied</title>')
+    expect(html).toContain('<h1>Access Denied</h1>')
+  })
+
+  it('escapes HTML in the message', () => {
+    const html = renderError('<script>alert(1)</script>')
+    expect(html).not.toContain('<script>alert(1)</script>')
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+  })
+
+  it('escapes HTML in the title', () => {
+    const html = renderError('msg', '<img src=x onerror=alert(1)>')
+    expect(html).not.toContain('<img src=x onerror=alert(1)>')
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;')
+  })
+
+  it('includes inline styles', () => {
+    const html = renderError('x')
+    expect(html).toMatch(/<style>[\s\S]*\.container[\s\S]*<\/style>/)
+  })
+})

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -134,7 +134,10 @@ export function createAuthService(config: AuthServiceConfig): {
       next: express.NextFunction,
     ) => {
       logger.error({ err, path: req.path }, 'Unhandled error in auth-service')
-      if (res.headersSent) return next(err)
+      if (res.headersSent) {
+        next(err)
+        return
+      }
       if (req.accepts('html')) {
         res
           .status(500)

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -136,7 +136,9 @@ export function createAuthService(config: AuthServiceConfig): {
       logger.error({ err, path: req.path }, 'Unhandled error in auth-service')
       if (res.headersSent) return next(err)
       if (req.accepts('html')) {
-        res.status(500).send(renderError('Something went wrong. Please try again.'))
+        res
+          .status(500)
+          .send(renderError('Something went wrong. Please try again.'))
       } else {
         res.status(500).json({ error: 'internal_error' })
       }

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -24,7 +24,7 @@ import {
   validateOtpCharset,
   validateOtpLength,
 } from './lib/otp-config-validation.js'
-import { renderError } from './lib/render-error.js'
+import { errorHandler, notFoundHandler } from './lib/error-middleware.js'
 
 const logger = createLogger('auth-service')
 
@@ -108,50 +108,8 @@ export function createAuthService(config: AuthServiceConfig): {
     res.json({ status: 'ok', service: 'auth', version: getEpdsVersion() })
   })
 
-  // Styled 404 for any unmatched HTML route. JSON clients get JSON.
-  // Use accepts(['json', 'html']) so that clients sending Accept: */*
-  // (e.g. fetch, curl) get JSON — only return HTML when the client
-  // explicitly prefers it (browsers list text/html with q=1).
-  app.use((req, res) => {
-    if (req.accepts(['json', 'html']) === 'html') {
-      res
-        .status(404)
-        .type('html')
-        .send(
-          renderError(
-            "The page you're looking for doesn't exist.",
-            'Page not found',
-          ),
-        )
-    } else {
-      res.status(404).json({ error: 'not_found' })
-    }
-  })
-
-  // Styled 500 for any uncaught error. Log the cause, keep the user-facing
-  // message generic to avoid leaking internals.
-  app.use(
-    (
-      err: unknown,
-      req: express.Request,
-      res: express.Response,
-      next: express.NextFunction,
-    ) => {
-      logger.error({ err, path: req.path }, 'Unhandled error in auth-service')
-      if (res.headersSent) {
-        next(err)
-        return
-      }
-      if (req.accepts(['json', 'html']) === 'html') {
-        res
-          .status(500)
-          .type('html')
-          .send(renderError('Something went wrong. Please try again.'))
-      } else {
-        res.status(500).json({ error: 'internal_error' })
-      }
-    },
-  )
+  app.use(notFoundHandler)
+  app.use(errorHandler)
 
   return { app, ctx }
 }

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -24,6 +24,7 @@ import {
   validateOtpCharset,
   validateOtpLength,
 } from './lib/otp-config-validation.js'
+import { renderError } from './lib/render-error.js'
 
 const logger = createLogger('auth-service')
 
@@ -106,6 +107,41 @@ export function createAuthService(config: AuthServiceConfig): {
   app.get('/health', (_req, res) => {
     res.json({ status: 'ok', service: 'auth', version: getEpdsVersion() })
   })
+
+  // Styled 404 for any unmatched HTML route. JSON clients get JSON.
+  app.use((req, res) => {
+    if (req.accepts('html')) {
+      res
+        .status(404)
+        .send(
+          renderError(
+            "The page you're looking for doesn't exist.",
+            'Page not found',
+          ),
+        )
+    } else {
+      res.status(404).json({ error: 'not_found' })
+    }
+  })
+
+  // Styled 500 for any uncaught error. Log the cause, keep the user-facing
+  // message generic to avoid leaking internals.
+  app.use(
+    (
+      err: unknown,
+      req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction,
+    ) => {
+      logger.error({ err, path: req.path }, 'Unhandled error in auth-service')
+      if (res.headersSent) return
+      if (req.accepts('html')) {
+        res.status(500).send(renderError('Something went wrong. Please try again.'))
+      } else {
+        res.status(500).json({ error: 'internal_error' })
+      }
+    },
+  )
 
   return { app, ctx }
 }

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -109,10 +109,14 @@ export function createAuthService(config: AuthServiceConfig): {
   })
 
   // Styled 404 for any unmatched HTML route. JSON clients get JSON.
+  // Use accepts(['json', 'html']) so that clients sending Accept: */*
+  // (e.g. fetch, curl) get JSON — only return HTML when the client
+  // explicitly prefers it (browsers list text/html with q=1).
   app.use((req, res) => {
-    if (req.accepts('html')) {
+    if (req.accepts(['json', 'html']) === 'html') {
       res
         .status(404)
+        .type('html')
         .send(
           renderError(
             "The page you're looking for doesn't exist.",
@@ -138,9 +142,10 @@ export function createAuthService(config: AuthServiceConfig): {
         next(err)
         return
       }
-      if (req.accepts('html')) {
+      if (req.accepts(['json', 'html']) === 'html') {
         res
           .status(500)
+          .type('html')
           .send(renderError('Something went wrong. Please try again.'))
       } else {
         res.status(500).json({ error: 'internal_error' })

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -131,10 +131,10 @@ export function createAuthService(config: AuthServiceConfig): {
       err: unknown,
       req: express.Request,
       res: express.Response,
-      _next: express.NextFunction,
+      next: express.NextFunction,
     ) => {
       logger.error({ err, path: req.path }, 'Unhandled error in auth-service')
-      if (res.headersSent) return
+      if (res.headersSent) return next(err)
       if (req.accepts('html')) {
         res.status(500).send(renderError('Something went wrong. Please try again.'))
       } else {

--- a/packages/auth-service/src/lib/error-middleware.ts
+++ b/packages/auth-service/src/lib/error-middleware.ts
@@ -1,0 +1,54 @@
+import type express from 'express'
+import { createLogger } from '@certified-app/shared'
+import { renderError } from './render-error.js'
+
+const logger = createLogger('auth:error-middleware')
+
+/**
+ * Trailing 404 handler. Returns JSON for Accept: * / * (fetch/curl default)
+ * and styled HTML only when the client explicitly prefers text/html.
+ */
+export function notFoundHandler(
+  req: express.Request,
+  res: express.Response,
+): void {
+  if (req.accepts(['json', 'html']) === 'html') {
+    res
+      .status(404)
+      .type('html')
+      .send(
+        renderError(
+          "The page you're looking for doesn't exist.",
+          'Page not found',
+        ),
+      )
+  } else {
+    res.status(404).json({ error: 'not_found' })
+  }
+}
+
+/**
+ * Express error handler. Logs the cause, keeps the user-facing message
+ * generic, and delegates to Express's default handler when headers have
+ * already been sent so partial responses are not clobbered.
+ */
+export function errorHandler(
+  err: unknown,
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+): void {
+  logger.error({ err, path: req.path }, 'Unhandled error in auth-service')
+  if (res.headersSent) {
+    next(err)
+    return
+  }
+  if (req.accepts(['json', 'html']) === 'html') {
+    res
+      .status(500)
+      .type('html')
+      .send(renderError('Something went wrong. Please try again.'))
+  } else {
+    res.status(500).json({ error: 'internal_error' })
+  }
+}

--- a/packages/auth-service/src/lib/error-middleware.ts
+++ b/packages/auth-service/src/lib/error-middleware.ts
@@ -12,6 +12,7 @@ export function notFoundHandler(
   req: express.Request,
   res: express.Response,
 ): void {
+  res.vary('Accept')
   if (req.accepts(['json', 'html']) === 'html') {
     res
       .status(404)
@@ -43,6 +44,7 @@ export function errorHandler(
     next(err)
     return
   }
+  res.vary('Accept')
   if (req.accepts(['json', 'html']) === 'html') {
     res
       .status(500)

--- a/packages/auth-service/src/lib/render-error.ts
+++ b/packages/auth-service/src/lib/render-error.ts
@@ -1,0 +1,27 @@
+import { escapeHtml } from '@certified-app/shared'
+
+const ERROR_CSS = `
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 20px; }
+  .container { background: white; border-radius: 12px; padding: 40px; max-width: 420px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
+  h1 { font-size: 24px; margin-bottom: 16px; color: #111; }
+  .error { color: #dc3545; background: #fdf0f0; padding: 12px; border-radius: 8px; font-size: 15px; line-height: 1.5; }
+`
+
+export function renderError(message: string, title = 'Error'): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)}</title>
+  <style>${ERROR_CSS}</style>
+</head>
+<body>
+  <div class="container">
+    <h1>${escapeHtml(title)}</h1>
+    <p class="error">${escapeHtml(message)}</p>
+  </div>
+</body>
+</html>`
+}

--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -11,6 +11,7 @@ import { fromNodeHeaders } from 'better-auth/node'
 import { getDidByEmail } from '../lib/get-did-by-email.js'
 import { getHandleByDid } from '../lib/get-handle-by-did.js'
 import { ensurePdsUrl } from '../lib/pds-url.js'
+import { renderError } from '../lib/render-error.js'
 
 const logger = createLogger('auth:account-settings')
 
@@ -145,7 +146,7 @@ export function createAccountSettingsRouter(
   router.get('/account/backup-email/verify', (req: Request, res: Response) => {
     const token = req.query.token as string | undefined
     if (!token) {
-      res.status(400).send('<p>Missing verification token.</p>')
+      res.status(400).send(renderError('Missing verification token.'))
       return
     }
 
@@ -175,7 +176,7 @@ export function createAccountSettingsRouter(
   router.post('/account/backup-email/verify', (req: Request, res: Response) => {
     const token = ((req.body.token as string) || '').trim()
     if (!token) {
-      res.status(400).send('<p>Missing verification token.</p>')
+      res.status(400).send(renderError('Missing verification token.'))
       return
     }
 

--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -146,7 +146,10 @@ export function createAccountSettingsRouter(
   router.get('/account/backup-email/verify', (req: Request, res: Response) => {
     const token = req.query.token as string | undefined
     if (!token) {
-      res.status(400).send(renderError('Missing verification token.'))
+      res
+        .status(400)
+        .type('html')
+        .send(renderError('Missing verification token.'))
       return
     }
 
@@ -176,7 +179,10 @@ export function createAccountSettingsRouter(
   router.post('/account/backup-email/verify', (req: Request, res: Response) => {
     const token = ((req.body.token as string) || '').trim()
     if (!token) {
-      res.status(400).send(renderError('Missing verification token.'))
+      res
+        .status(400)
+        .type('html')
+        .send(renderError('Missing verification token.'))
       return
     }
 

--- a/packages/auth-service/src/routes/choose-handle.ts
+++ b/packages/auth-service/src/routes/choose-handle.ts
@@ -691,4 +691,3 @@ export function renderChooseHandlePage(
 </body>
 </html>`
 }
-

--- a/packages/auth-service/src/routes/choose-handle.ts
+++ b/packages/auth-service/src/routes/choose-handle.ts
@@ -28,6 +28,7 @@ import { fromNodeHeaders } from 'better-auth/node'
 import { getDidByEmail } from '../lib/get-did-by-email.js'
 import { pingParRequest } from '../lib/ping-par-request.js'
 import { requireInternalEnv } from '../lib/require-internal-env.js'
+import { renderError } from '../lib/render-error.js'
 import { resolveClientBranding } from '../lib/client-metadata.js'
 import { renderOptionalStyleTag } from '../lib/page-helpers.js'
 
@@ -691,10 +692,3 @@ export function renderChooseHandlePage(
 </html>`
 }
 
-function renderError(message: string): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"><title>Error</title></head>
-<body><p style="color:red;padding:20px">${escapeHtml(message)}</p></body>
-</html>`
-}

--- a/packages/auth-service/src/routes/complete.ts
+++ b/packages/auth-service/src/routes/complete.ts
@@ -27,6 +27,7 @@ import { createLogger, signCallback } from '@certified-app/shared'
 import { fromNodeHeaders } from 'better-auth/node'
 import { getDidByEmail } from '../lib/get-did-by-email.js'
 import { pingParRequest } from '../lib/ping-par-request.js'
+import { renderError } from '../lib/render-error.js'
 import { requireInternalEnv } from '../lib/require-internal-env.js'
 import { resolveRecoveryEmail } from '../lib/resolve-recovery-email.js'
 
@@ -50,7 +51,7 @@ export function createCompleteRouter(
       logger.warn('No epds_auth_flow cookie found on /auth/complete')
       res
         .status(400)
-        .send('<p>Authentication session expired. Please try again.</p>')
+        .send(renderError('Authentication session expired. Please try again.'))
       return
     }
 
@@ -61,7 +62,7 @@ export function createCompleteRouter(
       res.clearCookie(AUTH_FLOW_COOKIE)
       res
         .status(400)
-        .send('<p>Authentication session expired. Please try again.</p>')
+        .send(renderError('Authentication session expired. Please try again.'))
       return
     }
 
@@ -74,7 +75,9 @@ export function createCompleteRouter(
       })
     } catch (err) {
       logger.error({ err }, 'Failed to get better-auth session')
-      res.status(500).send('<p>Authentication failed. Please try again.</p>')
+      res
+        .status(500)
+        .send(renderError('Authentication failed. Please try again.'))
       return
     }
 

--- a/packages/auth-service/src/routes/complete.ts
+++ b/packages/auth-service/src/routes/complete.ts
@@ -51,6 +51,7 @@ export function createCompleteRouter(
       logger.warn('No epds_auth_flow cookie found on /auth/complete')
       res
         .status(400)
+        .type('html')
         .send(renderError('Authentication session expired. Please try again.'))
       return
     }
@@ -62,6 +63,7 @@ export function createCompleteRouter(
       res.clearCookie(AUTH_FLOW_COOKIE)
       res
         .status(400)
+        .type('html')
         .send(renderError('Authentication session expired. Please try again.'))
       return
     }
@@ -77,6 +79,7 @@ export function createCompleteRouter(
       logger.error({ err }, 'Failed to get better-auth session')
       res
         .status(500)
+        .type('html')
         .send(renderError('Authentication failed. Please try again.'))
       return
     }

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -43,6 +43,7 @@ import {
 } from '../lib/resolve-login-hint.js'
 import { ensurePdsUrl } from '../lib/pds-url.js'
 import { renderOptionalStyleTag } from '../lib/page-helpers.js'
+import { renderError } from '../lib/render-error.js'
 import {
   buildPdsAuthorizeRedirect,
   shouldReuseSession,
@@ -622,10 +623,3 @@ export function renderLoginPage(opts: {
 </html>`
 }
 
-function renderError(message: string): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"><title>Error</title></head>
-<body><p style="color:red;padding:20px">${escapeHtml(message)}</p></body>
-</html>`
-}

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -622,4 +622,3 @@ export function renderLoginPage(opts: {
 </body>
 </html>`
 }
-

--- a/packages/auth-service/src/routes/recovery.ts
+++ b/packages/auth-service/src/routes/recovery.ts
@@ -20,6 +20,7 @@ import { createLogger, escapeHtml, maskEmail } from '@certified-app/shared'
 import { buildOtpInputProps } from '../otp-input.js'
 import { resolveClientBranding } from '../lib/client-metadata.js'
 import { renderOptionalStyleTag } from '../lib/page-helpers.js'
+import { renderError } from '../lib/render-error.js'
 
 const logger = createLogger('auth:recovery')
 
@@ -189,7 +190,7 @@ export function createRecoveryRouter(
     const requestUri = req.body.request_uri as string
 
     if (!code || !email || !requestUri) {
-      res.status(400).send('<p>Missing required fields.</p>')
+      res.status(400).send(renderError('Missing required fields.'))
       return
     }
 
@@ -343,14 +344,6 @@ export function renderRecoveryOtpForm(opts: {
     <a href="${backHref}" class="btn-secondary">Back to sign in</a>
   </div>
 </body>
-</html>`
-}
-
-function renderError(message: string): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head><meta charset="utf-8"><title>Error</title><style>${CSS}</style></head>
-<body><div class="container"><h1>Error</h1><p class="error">${escapeHtml(message)}</p></div></body>
 </html>`
 }
 

--- a/packages/auth-service/src/routes/recovery.ts
+++ b/packages/auth-service/src/routes/recovery.ts
@@ -57,7 +57,10 @@ export function createRecoveryRouter(
     const requestUri = req.query.request_uri as string | undefined
 
     if (!requestUri) {
-      res.status(400).send(renderError('Missing request_uri parameter'))
+      res
+        .status(400)
+        .type('html')
+        .send(renderError('Missing request_uri parameter'))
       return
     }
 
@@ -190,7 +193,7 @@ export function createRecoveryRouter(
     const requestUri = req.body.request_uri as string
 
     if (!code || !email || !requestUri) {
-      res.status(400).send(renderError('Missing required fields.'))
+      res.status(400).type('html').send(renderError('Missing required fields.'))
       return
     }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,10 +23,10 @@ export default defineConfig({
       // Ratchet thresholds — update these whenever coverage increases.
       // See AGENTS.md for the ratcheting policy.
       thresholds: {
-        statements: 45,
-        branches: 42,
+        statements: 44,
+        branches: 41,
         functions: 63,
-        lines: 44,
+        lines: 43,
       },
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,10 +23,10 @@ export default defineConfig({
       // Ratchet thresholds — update these whenever coverage increases.
       // See AGENTS.md for the ratcheting policy.
       thresholds: {
-        statements: 37,
-        branches: 33,
-        functions: 54,
-        lines: 36,
+        statements: 45,
+        branches: 42,
+        functions: 63,
+        lines: 44,
       },
     },
   },


### PR DESCRIPTION
## Summary

Introduce lib/render-error.ts as a single styled template for all auth-service error pages and route every error response through it.

Replace bare <p>-only error responses across complete.ts, recovery.ts, choose-handle.ts, and account-settings.ts; delete three duplicate local renderError functions (login-page, choose-handle, recovery).

Add catch-all 404 + 500 middleware so unmatched paths and uncaught errors render the same styled card instead of Express's default text output (JSON clients still get JSON).

## Screenshots

Captured from the Railway preview deployment (`certified-appauth-service-epds-pr-97.up.railway.app`):

### 404 — unknown path (`/nonexistent-page`)

![404 page](https://raw.githubusercontent.com/aspiers/ePDS/screenshots/pr-97/404.png)

### 400 — `/oauth/authorize` without `request_uri`

![authorize missing request_uri](https://raw.githubusercontent.com/aspiers/ePDS/screenshots/pr-97/authorize-missing-request-uri.png)

### `/auth/complete` — session expired (missing cookie)

![complete session expired](https://raw.githubusercontent.com/aspiers/ePDS/screenshots/pr-97/complete-session-expired.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 404 and 500 handlers now negotiate Accept and return branded HTML when HTML is preferred, otherwise JSON.

* **Style**
  * Authentication error pages updated to a consistent, branded layout with inline styling.

* **Refactor**
  * Error-page rendering unified into a shared renderer used across auth routes.

* **Bug Fixes**
  * Multiple routes now return proper HTML error responses with correct Content-Type for missing/invalid inputs.

* **Tests**
  * Added tests covering content negotiation, rendered error pages, and error-handler behavior.

* **Chores**
  * Added a changeset documenting these behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
