### PR TITLE
feat(auth-service): show current handle on account settings page

### DIFF
--- a/.changeset/show-current-handle-on-settings.md
+++ b/.changeset/show-current-handle-on-settings.md
@@ -1,0 +1,9 @@
+---
+'ePDS': minor
+---
+
+Account settings page now shows your current handle.
+
+**Affects:** End users
+
+**End users:** Visiting the account settings dashboard at `/account` on the auth service (not the PDS itself) now displays a "Current Handle:" row above the handle update form, so you can see at a glance what your current AT Protocol handle is before changing it. The auth service resolves the handle by calling the PDS's `com.atproto.repo.describeRepo` XRPC on every request, so the row reflects the authoritative value — including any pending rename that hasn't propagated to a local cache. If the PDS can't be reached the row displays `(unknown)` and the rest of the page still renders.

--- a/features/account-settings.feature
+++ b/features/account-settings.feature
@@ -28,12 +28,10 @@ Scenario: User views their account information
   When they view the /account page
   Then the page displays their DID
   And the page displays their primary email
-  # And the page displays their current handle
+  And the page displays their current handle
 
   # --- Handle management ---
 
-# Known gap: handle update on /account is not implemented yet.
-@pending
 Scenario: User changes their handle
   Given the user is logged into account settings
   And their current handle is a random subdomain of the PDS domain

--- a/packages/auth-service/src/__tests__/get-handle-by-did.test.ts
+++ b/packages/auth-service/src/__tests__/get-handle-by-did.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { getHandleByDid } from '../lib/get-handle-by-did.js'
 
-const PDS_URL = 'http://core:3000'
+const PDS_URL = 'https://core:3000'
 const DID = 'did:plc:abc123'
 
 let fetchSpy: ReturnType<typeof vi.spyOn>

--- a/packages/auth-service/src/__tests__/get-handle-by-did.test.ts
+++ b/packages/auth-service/src/__tests__/get-handle-by-did.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for getHandleByDid().
+ *
+ * This helper calls the PDS's public describeRepo XRPC endpoint to look
+ * up the current handle for a DID. Used by the account-settings page to
+ * show the user their authoritative handle before offering the update
+ * form. Must degrade to null on any error — the settings page falls back
+ * to `(unknown)` rather than breaking the whole page.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getHandleByDid } from '../lib/get-handle-by-did.js'
+
+const PDS_URL = 'http://core:3000'
+const DID = 'did:plc:abc123'
+
+let fetchSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  fetchSpy = vi.spyOn(globalThis, 'fetch')
+})
+
+afterEach(() => {
+  fetchSpy.mockRestore()
+})
+
+describe('getHandleByDid', () => {
+  it('returns the handle when describeRepo succeeds', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ did: DID, handle: 'alice.pds.test' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const result = await getHandleByDid(DID, PDS_URL)
+
+    expect(result).toBe('alice.pds.test')
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${PDS_URL}/xrpc/com.atproto.repo.describeRepo?repo=did%3Aplc%3Aabc123`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('returns null when describeRepo returns no handle field', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ did: DID }), { status: 200 }),
+    )
+
+    const result = await getHandleByDid(DID, PDS_URL)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when handle field is not a string', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ did: DID, handle: 42 }), { status: 200 }),
+    )
+
+    const result = await getHandleByDid(DID, PDS_URL)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null on non-OK HTTP response', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response('Bad Request', { status: 400 }))
+
+    const result = await getHandleByDid(DID, PDS_URL)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the repo is not found (404)', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response('Not Found', { status: 404 }))
+
+    const result = await getHandleByDid(DID, PDS_URL)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null on 500 server error', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('Internal Server Error', { status: 500 }),
+    )
+
+    const result = await getHandleByDid(DID, PDS_URL)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null on network error (fetch throws)', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+    const result = await getHandleByDid(DID, PDS_URL)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null on timeout', async () => {
+    fetchSpy.mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'))
+
+    const result = await getHandleByDid(DID, PDS_URL)
+
+    expect(result).toBeNull()
+  })
+
+  it('URL-encodes the DID in the query string', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ handle: 'x.pds.test' }), { status: 200 }),
+    )
+
+    await getHandleByDid('did:web:example.com:user', PDS_URL)
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${PDS_URL}/xrpc/com.atproto.repo.describeRepo?repo=did%3Aweb%3Aexample.com%3Auser`,
+      expect.anything(),
+    )
+  })
+
+  it('works with different PDS URLs', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ handle: 'bob.example.com' }), {
+        status: 200,
+      }),
+    )
+
+    const result = await getHandleByDid(DID, 'https://pds.example.com')
+
+    expect(result).toBe('bob.example.com')
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://pds.example.com/xrpc/com.atproto.repo.describeRepo?repo=did%3Aplc%3Aabc123',
+      expect.anything(),
+    )
+  })
+
+  it('includes AbortSignal with timeout in request', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ handle: 'x.pds.test' }), { status: 200 }),
+    )
+
+    await getHandleByDid(DID, PDS_URL)
+
+    const callArgs = fetchSpy.mock.calls[0]
+    const options = callArgs[1] as RequestInit
+    expect(options.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('returns null when response body is not JSON', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('<html>not json</html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    )
+
+    const result = await getHandleByDid(DID, PDS_URL)
+
+    expect(result).toBeNull()
+  })
+})

--- a/packages/auth-service/src/lib/get-handle-by-did.ts
+++ b/packages/auth-service/src/lib/get-handle-by-did.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolve the current handle for a DID via the PDS's public describeRepo
+ * XRPC endpoint (`com.atproto.repo.describeRepo`). Returns null if the PDS
+ * can't be reached or returns an unexpected shape — callers are expected to
+ * degrade gracefully (e.g. show `(unknown)` on the settings page).
+ */
+import { createLogger } from '@certified-app/shared'
+
+const logger = createLogger('auth:get-handle-by-did')
+
+export async function getHandleByDid(
+  did: string,
+  pdsUrl: string,
+): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `${pdsUrl}/xrpc/com.atproto.repo.describeRepo?repo=${encodeURIComponent(did)}`,
+      { signal: AbortSignal.timeout(3000) },
+    )
+    if (!res.ok) return null
+    const data = (await res.json()) as { handle?: string }
+    return typeof data.handle === 'string' ? data.handle : null
+  } catch (err) {
+    logger.warn({ err, did }, 'Failed to resolve handle by DID from PDS')
+    return null
+  }
+}

--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -9,32 +9,10 @@ import {
 } from '@certified-app/shared'
 import { fromNodeHeaders } from 'better-auth/node'
 import { getDidByEmail } from '../lib/get-did-by-email.js'
+import { getHandleByDid } from '../lib/get-handle-by-did.js'
 import { ensurePdsUrl } from '../lib/pds-url.js'
 
 const logger = createLogger('auth:account-settings')
-
-/**
- * Resolve the current handle for a DID via the PDS's public describeRepo
- * XRPC endpoint. Returns null if the PDS can't be reached or returns an
- * unexpected shape — the settings page falls back to showing just the DID.
- */
-async function getHandleByDid(
-  did: string,
-  pdsUrl: string,
-): Promise<string | null> {
-  try {
-    const res = await fetch(
-      `${pdsUrl}/xrpc/com.atproto.repo.describeRepo?repo=${encodeURIComponent(did)}`,
-      { signal: AbortSignal.timeout(3000) },
-    )
-    if (!res.ok) return null
-    const data = (await res.json()) as { handle?: string }
-    return typeof data.handle === 'string' ? data.handle : null
-  } catch (err) {
-    logger.warn({ err, did }, 'Failed to resolve handle by DID from PDS')
-    return null
-  }
-}
 
 /**
  * Middleware that validates a better-auth session and injects it into res.locals.

--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -14,6 +14,29 @@ import { ensurePdsUrl } from '../lib/pds-url.js'
 const logger = createLogger('auth:account-settings')
 
 /**
+ * Resolve the current handle for a DID via the PDS's public describeRepo
+ * XRPC endpoint. Returns null if the PDS can't be reached or returns an
+ * unexpected shape — the settings page falls back to showing just the DID.
+ */
+async function getHandleByDid(
+  did: string,
+  pdsUrl: string,
+): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `${pdsUrl}/xrpc/com.atproto.repo.describeRepo?repo=${encodeURIComponent(did)}`,
+      { signal: AbortSignal.timeout(3000) },
+    )
+    if (!res.ok) return null
+    const data = (await res.json()) as { handle?: string }
+    return typeof data.handle === 'string' ? data.handle : null
+  } catch (err) {
+    logger.warn({ err, did }, 'Failed to resolve handle by DID from PDS')
+    return null
+  }
+}
+
+/**
  * Middleware that validates a better-auth session and injects it into res.locals.
  * If not authenticated, redirects to /account/login.
  */
@@ -63,6 +86,7 @@ export function createAccountSettingsRouter(
     // Look up DID from PDS
     const did = await getDidByEmail(email, pdsUrl, internalSecret)
     const backupEmails = did ? ctx.db.getBackupEmails(did) : []
+    const currentHandle = did ? await getHandleByDid(did, pdsUrl) : null
 
     // Get all better-auth sessions for this user
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- better-auth session type not exported
@@ -81,6 +105,7 @@ export function createAccountSettingsRouter(
         did: did ?? '(unknown)',
         email,
         handleDomain,
+        currentHandle,
         backupEmails,
         sessions,
         currentSessionToken: session.session.token,
@@ -401,6 +426,7 @@ function renderSettingsPage(opts: {
   did: string
   email: string
   handleDomain: string
+  currentHandle: string | null
   backupEmails: Array<{ email: string; verified: number; id: number }>
   sessions: Array<{
     token: string
@@ -478,6 +504,7 @@ function renderSettingsPage(opts: {
     <section class="section">
       <h2>Handle</h2>
       <p class="info">Your handle is your public username on the AT Protocol network.</p>
+      <div class="setting-row"><strong>Current Handle:</strong> <code>${escapeHtml(opts.currentHandle ?? '(unknown)')}</code></div>
       <form method="POST" action="/account/handle" class="inline-form">
         <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
         <input type="text" name="handle" placeholder="yourname" autocomplete="off" autocapitalize="none" spellcheck="false" required>


### PR DESCRIPTION
## Summary

- Adds a "Current Handle:" row to the `/account` settings page, resolved from the PDS via `com.atproto.repo.describeRepo`. The row displays the authoritative handle and gracefully falls back to `(unknown)` if the PDS describeRepo call fails.
- Un-pends the `User changes their handle` scenario in `features/account-settings.feature`. Its step definitions already existed (introduced alongside PR #91's account-settings E2E work) and asserted that the page shows `Current Handle:` — the missing UI on the server side is what was keeping the scenario gated.
- Removes the stale "Known gap: handle update on /account is not implemented yet" comment — the `POST /account/handle` route has been in place for a while; what was actually missing was the display, not the update.

Also includes a changeset describing the user-visible change.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` / `pnpm lint` pass
- [x] `pnpm test` — all 443 unit tests pass
- [x] `pnpm test:e2e --dry-run features/account-settings.feature` shows no undefined/ambiguous steps
- [ ] E2E on Railway preview: `User views their account information` now shows the handle row; `User changes their handle` runs end-to-end (handle rename → settings reflect it → resolveHandle returns expected DID)
- [ ] Visual check of the settings page handle row (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)