### PR TITLE
feat(auth-service): redirect / to /account

### DIFF
--- a/.changeset/root-redirect-to-account.md
+++ b/.changeset/root-redirect-to-account.md
@@ -1,0 +1,11 @@
+---
+'ePDS': patch
+---
+
+Visiting the bare auth service URL now takes you to the account page instead of a blank 404.
+
+**Affects:** End users, Operators
+
+**End users:** Opening the auth service at its root URL (e.g. `https://auth.example.com/`) now redirects to the account dashboard. If you are signed in you land on `/account`; if you are not, `/account` bounces you on to `/account/login` as before. Previously the root path had no handler and returned a 404 "Cannot GET /" page, which was confusing when bookmarking or mistyping a URL.
+
+**Operators:** The auth service now returns a `303 See Other` with `Location: /account` for `GET /`. If you have an external healthcheck pointed at `/` expecting a 404, switch it to `/health` (which already exists and returns a JSON status body). `/health` is unchanged.

--- a/packages/auth-service/src/__tests__/root-redirect.test.ts
+++ b/packages/auth-service/src/__tests__/root-redirect.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Integration test for the root (`/`) redirect. Brings up a minimal
+ * express app with just the root router mounted, listens on an
+ * ephemeral port, and fetches `/` with `redirect: 'manual'` so the
+ * 303 is observable instead of being transparently followed.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import express, { type Express } from 'express'
+import type { AddressInfo } from 'node:net'
+import type { Server } from 'node:http'
+import { createRootRouter } from '../routes/root.js'
+
+let server: Server
+let baseUrl: string
+let app: Express
+
+beforeAll(async () => {
+  app = express()
+  app.use(createRootRouter())
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      resolve()
+    })
+  })
+  const addr = server.address() as AddressInfo
+  baseUrl = `http://127.0.0.1:${addr.port}`
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) reject(err)
+      else resolve()
+    })
+  })
+})
+
+describe('root router', () => {
+  it('redirects GET / to /account with 303 See Other', async () => {
+    const res = await fetch(`${baseUrl}/`, { redirect: 'manual' })
+    expect(res.status).toBe(303)
+    expect(res.headers.get('location')).toBe('/account')
+  })
+})

--- a/packages/auth-service/src/index.ts
+++ b/packages/auth-service/src/index.ts
@@ -17,6 +17,7 @@ import { createCompleteRouter } from './routes/complete.js'
 import { createChooseHandleRouter } from './routes/choose-handle.js'
 import { createPreviewRouter } from './routes/preview.js'
 import { createPreviewEmailsRouter } from './routes/preview-emails.js'
+import { createRootRouter } from './routes/root.js'
 import { resolveAuthPort } from './lib/resolve-port.js'
 import { createSecurityHeadersMiddleware } from './lib/security-headers.js'
 import {
@@ -69,6 +70,7 @@ export function createAuthService(config: AuthServiceConfig): {
   )
 
   // Routes
+  app.use(createRootRouter())
   app.use(createLoginPageRouter(ctx))
   app.use(createRecoveryRouter(ctx, betterAuthInstance))
   app.use(createAccountLoginRouter(betterAuthInstance, ctx))

--- a/packages/auth-service/src/routes/root.ts
+++ b/packages/auth-service/src/routes/root.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express'
+
+/**
+ * Router for the site root (`/`). Redirects unconditionally to
+ * `/account`, which in turn requires auth and will bounce the visitor
+ * to `/account/login` when unauthenticated. 303 See Other matches the
+ * redirect status the rest of the auth service uses.
+ */
+export function createRootRouter(): Router {
+  const router = Router()
+
+  router.get('/', (_req, res) => {
+    res.redirect(303, '/account')
+  })
+
+  return router
+}


### PR DESCRIPTION
## Summary
- `GET /` on the auth service now 303-redirects to `/account` (which in turn bounces unauthenticated users to `/account/login`).
- Previously the root path had no handler and returned Express's default 404, which was confusing for anyone bookmarking or mistyping the auth URL.
- Adds a small `createRootRouter()` in `packages/auth-service/src/routes/root.ts` plus an integration test that spins up a minimal Express app and asserts `status === 303` and `location === '/account'` with `redirect: 'manual'`.

## Operator note
If you have an external healthcheck pointed at `/` expecting a 404, switch it to `/health` (unchanged, returns JSON status).

## Test plan
- [x] \`pnpm lint\` clean
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm test\` — full suite passes (595/595), new test included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Root service URL now redirects (303) to the account page instead of returning an error.
  * Health checks should use the `/health` endpoint instead of the root path.

* **Tests**
  * Added tests validating the redirect functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->