### PR TITLE
ci: trigger CI on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- GitHub's merge queue fires a `merge_group` event (not `push` or `pull_request`) when it builds its internal `gh-readonly-queue/main/pr-<N>-...` branch.
- `ci.yml` hosts the four required status checks (`format`, `lint`, `typecheck`, `test`) but previously only triggered on `push` / `pull_request`, so none of them ran on the queue branch and queue entries sat in `AWAITING_CHECKS` indefinitely (observed live on PR #105 at position 1).
- Adding `merge_group:` to `on:` makes the same jobs run against the queue branch, unblocking the queue.

## Why now
Required to land PR #105 (and any future queued PR) via the merge queue. Without this, every queued PR hangs.

## Test plan
- [ ] Merge this PR directly (queue is broken until it lands).
- [ ] Re-enqueue PR #105; confirm required checks run on the `gh-readonly-queue/main/pr-105-*` branch and the queue progresses past `AWAITING_CHECKS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->