### PR TITLE
docs(skill): tighten prompt=login section in epds-login SKILL.md

### DIFF
--- a/.agents/skills/epds-login/SKILL.md
+++ b/.agents/skills/epds-login/SKILL.md
@@ -193,14 +193,7 @@ standard OIDC `prompt=login` parameter.
 
 **Important — where to put it:** ePDS's auth service decides whether to
 engage session reuse by inspecting the **query string** of the
-`/oauth/authorize` redirect, not the PAR body. PAR-body `prompt=login`
-alone is **not** enough.
-
-| Sent in            | Engages ePDS short-circuit? |
-| ------------------ | --------------------------- |
-| Authorize URL only | Yes                         |
-| PAR body only      | No                          |
-| Both               | Yes                         |
+`/oauth/authorize` redirect. PAR-body `prompt=login` is ignored.
 
 If your OAuth library (e.g. `NodeOAuthClient`) only supports passing
 `prompt` via the PAR body, you must also append `&prompt=login` to the


### PR DESCRIPTION
## Summary

Follow-up to PR #103 addressing two unresolved review threads on `.agents/skills/epds-login/SKILL.md`:

- **Line 197 (\"PAR-body alone is not enough\"):** changed to \"PAR-body \`prompt=login\` is ignored\". The original wording understates what's actually happening — auth-service never reads PAR for the session-reuse short-circuit, full stop.
- **Lines 199–203 (3-row table):** removed. The prose already says the URL is what's read; the table added no information and the \"both\" row risked implying dual placement was meaningful.

## Test plan

- [x] \`pnpm format:check\` clean
- [x] Doc-only change to a skill file — no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication login guidance to clarify that session-reuse behavior is determined by inspecting the authorization redirect URL parameter, not the request body. Libraries must append the login parameter to the authorization URL returned for redirect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->