### PR TITLE
ci(e2e): bump Railway deploy poll timeout from 3 to 6 minutes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -296,7 +296,7 @@ jobs:
           # walk depth (we also hard-fail).
 
           GRACE_ATTEMPTS=4   # 4 × 5s = 20 seconds
-          MAX_ATTEMPTS=36    # 36 × 5s = 3 minutes
+          MAX_ATTEMPTS=72    # 72 × 5s = 6 minutes
           FALLBACK_WALK=10   # max depth when walking back to find a success
 
           # Event-type-specific query configuration.


### PR DESCRIPTION
## Summary
- Bump `MAX_ATTEMPTS` from 36 to 72 in `.github/workflows/e2e-tests.yml` so the Railway deployment poll waits up to 6 minutes instead of 3.
- Railway preview builds occasionally exceed the previous 3-minute window, causing Phase 1 (SHA-specific lookup) or the Phase 2 in-progress wait to fail with `"did not reach success"` even though the deploy ultimately succeeds.
- Job-level `timeout-minutes: 20` is unchanged and still bounds the run.

## Test plan
- [ ] CI: e2e workflow runs against this PR's Railway preview without timing out.