### PR TITLE
fix(changesets): use correct package name 'ePDS' (not 'epds')

### DIFF
--- a/.changeset/cross-client-session-reuse.md
+++ b/.changeset/cross-client-session-reuse.md
@@ -1,5 +1,5 @@
 ---
-'epds': patch
+'ePDS': patch
 ---
 
 Signing in once in your browser now works across all apps that use this ePDS.

--- a/.changeset/demo-neutral-submitting-copy.md
+++ b/.changeset/demo-neutral-submitting-copy.md
@@ -1,5 +1,5 @@
 ---
-'epds': patch
+'ePDS': patch
 ---
 
 **Client app developers:** The demo's email sign-in button now says "Redirecting..." while the form is submitting, rather than "Sending verification code...". The demo is a pure OAuth client — it hands off to the auth service and has no visibility into whether a verification code will actually be sent. In the cross-client session-reuse path, no OTP email goes out at all; showing "Sending verification code..." momentarily was misleading. Matches the copy the handle-mode button (and the shared SignInButton component) already use.

--- a/.changeset/fix-post-flush-headers-sent-crash.md
+++ b/.changeset/fix-post-flush-headers-sent-crash.md
@@ -1,5 +1,5 @@
 ---
-'epds': patch
+'ePDS': patch
 ---
 
 **Operators:** Fix a crash in pds-core triggered by the chooser-enrichment and client-CSS-injection response-rewrite middleware. Upstream `@atproto/oauth-provider` flushes response headers before calling `res.end()` on some routes (notably the React SPA account chooser at `/account`). The wrapped `end()` then called `res.removeHeader('Content-Length')`, which throws `ERR_HTTP_HEADERS_SENT` at Node's HTTP layer. Because the throw escapes Express's error pipeline (it's raised from a method replacement on `res`, not from the middleware body), it lands as an uncaught exception and crashes the process. Docker's `restart: unless-stopped` masked the underlying failure as a transient 502 — users would see a blank page and the container would be restarted in the background. Both middlewares now guard the `removeHeader` calls with a `res.headersSent` check and skip the Content-Length / ETag rewrite when the response has already started. Regression tests in `packages/pds-core/src/__tests__/{chooser-enrichment,client-css-injection}.test.ts` simulate the post-flush state via a mock `removeHeader` that throws, locking in the fix.

--- a/.changeset/rate-limit-disable-flag.md
+++ b/.changeset/rate-limit-disable-flag.md
@@ -1,5 +1,5 @@
 ---
-'epds': patch
+'ePDS': patch
 ---
 
 Auth-service rate limiter can now be disabled for single-source-IP test environments.


### PR DESCRIPTION
## Summary

The latest Release workflow run ([25130921933](https://github.com/hypercerts-org/ePDS/actions/runs/25130921933)) failed with:

\`\`\`
🦋  error Error: Found changeset cross-client-session-reuse for package epds which is not in the workspace
\`\`\`

Root \`package.json\` declares \`"name": "ePDS"\` (capitalised). Four pending changesets referenced lowercase \`'epds'\`, which \`@changesets/cli\` treats as a missing package and aborts \`changeset version\`.

This PR rewrites the frontmatter package name in the four offending files to match the workspace: \`'ePDS': patch\`.

Verified locally — \`pnpm changeset status\` now succeeds and reports \`ePDS\` for bump (no "package not in workspace" error).

## Test plan

- [x] \`pnpm changeset status\` runs without error
- [ ] Re-run the Release workflow on \`main\` after merge and confirm it produces the release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package metadata configuration across release management files.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->