### PR TITLE
fix(changesets): add **Affects:** line to two changesets

### DIFF
--- a/.changeset/demo-neutral-submitting-copy.md
+++ b/.changeset/demo-neutral-submitting-copy.md
@@ -1,9 +1,0 @@
----
-'ePDS': patch
----
-
-Demo email sign-in button now reads "Redirecting..." while submitting, instead of "Sending verification code...".
-
-**Affects:** Client app developers
-
-**Client app developers:** The demo's email sign-in button now says "Redirecting..." while the form is submitting, rather than "Sending verification code...". The demo is a pure OAuth client — it hands off to the auth service and has no visibility into whether a verification code will actually be sent. In the cross-client session-reuse path, no OTP email goes out at all; showing "Sending verification code..." momentarily was misleading. Matches the copy the handle-mode button (and the shared SignInButton component) already use.

--- a/.changeset/demo-neutral-submitting-copy.md
+++ b/.changeset/demo-neutral-submitting-copy.md
@@ -2,4 +2,8 @@
 'ePDS': patch
 ---
 
+Demo email sign-in button now reads "Redirecting..." while submitting, instead of "Sending verification code...".
+
+**Affects:** Client app developers
+
 **Client app developers:** The demo's email sign-in button now says "Redirecting..." while the form is submitting, rather than "Sending verification code...". The demo is a pure OAuth client — it hands off to the auth service and has no visibility into whether a verification code will actually be sent. In the cross-client session-reuse path, no OTP email goes out at all; showing "Sending verification code..." momentarily was misleading. Matches the copy the handle-mode button (and the shared SignInButton component) already use.

--- a/.changeset/fix-post-flush-headers-sent-crash.md
+++ b/.changeset/fix-post-flush-headers-sent-crash.md
@@ -2,8 +2,8 @@
 'ePDS': patch
 ---
 
-Fix a pds-core crash when response-rewrite middleware ran after upstream had already flushed headers (e.g. on the React account chooser at `/account`).
+Fix a pds-core crash on the account chooser (`/account`) caused by response-rewrite middleware running after upstream had already flushed headers.
 
 **Affects:** Operators
 
-**Operators:** Fix a crash in pds-core triggered by the chooser-enrichment and client-CSS-injection response-rewrite middleware. Upstream `@atproto/oauth-provider` flushes response headers before calling `res.end()` on some routes (notably the React SPA account chooser at `/account`). The wrapped `end()` then called `res.removeHeader('Content-Length')`, which throws `ERR_HTTP_HEADERS_SENT` at Node's HTTP layer. Because the throw escapes Express's error pipeline (it's raised from a method replacement on `res`, not from the middleware body), it lands as an uncaught exception and crashes the process. Docker's `restart: unless-stopped` masked the underlying failure as a transient 502 — users would see a blank page and the container would be restarted in the background. Both middlewares now guard the `removeHeader` calls with a `res.headersSent` check and skip the Content-Length / ETag rewrite when the response has already started. Regression tests in `packages/pds-core/src/__tests__/{chooser-enrichment,client-css-injection}.test.ts` simulate the post-flush state via a mock `removeHeader` that throws, locking in the fix.
+**Operators:** The chooser-enrichment and client-CSS-injection middlewares could crash pds-core with `ERR_HTTP_HEADERS_SENT` on routes where upstream `@atproto/oauth-provider` flushes headers before `res.end()` (notably `/account`). Docker's `restart: unless-stopped` masked this as a transient 502 — users saw a blank page and the container restarted in the background. Both middlewares now skip their Content-Length / ETag rewrites once the response has started. No configuration change required.

--- a/.changeset/fix-post-flush-headers-sent-crash.md
+++ b/.changeset/fix-post-flush-headers-sent-crash.md
@@ -2,4 +2,8 @@
 'ePDS': patch
 ---
 
+Fix a pds-core crash when response-rewrite middleware ran after upstream had already flushed headers (e.g. on the React account chooser at `/account`).
+
+**Affects:** Operators
+
 **Operators:** Fix a crash in pds-core triggered by the chooser-enrichment and client-CSS-injection response-rewrite middleware. Upstream `@atproto/oauth-provider` flushes response headers before calling `res.end()` on some routes (notably the React SPA account chooser at `/account`). The wrapped `end()` then called `res.removeHeader('Content-Length')`, which throws `ERR_HTTP_HEADERS_SENT` at Node's HTTP layer. Because the throw escapes Express's error pipeline (it's raised from a method replacement on `res`, not from the middleware body), it lands as an uncaught exception and crashes the process. Docker's `restart: unless-stopped` masked the underlying failure as a transient 502 — users would see a blank page and the container would be restarted in the background. Both middlewares now guard the `removeHeader` calls with a `res.headersSent` check and skip the Content-Length / ETag rewrite when the response has already started. Regression tests in `packages/pds-core/src/__tests__/{chooser-enrichment,client-css-injection}.test.ts` simulate the post-flush state via a mock `removeHeader` that throws, locking in the fix.


### PR DESCRIPTION
## Summary

Release workflow run [25134494078](https://github.com/hypercerts-org/ePDS/actions/runs/25134494078/job/73669172006) (after #120 merged) failed in `pnpm version-packages`:

\`\`\`
changelog-audience-summary: 2 changeset bullet(s) in the topmost release section have no \`**Affects:**\` line. Every changeset must declare its audiences. Missing on:
  - **Client app developers:** The demo's email sign-in button now says "Redirecting..."  ...
  - **Operators:** Fix a crash in pds-core triggered by ...
\`\`\`

\`scripts/changelog-audience-summary.mjs\` runs in strict mode and aborts when any bullet in the topmost release section lacks an \`**Affects:** ...\` declaration. The two failing changesets jumped straight to a single per-audience section (\`**Client app developers:**\` / \`**Operators:**\`) without a top-level summary line or \`**Affects:**\` line, which is the structure the audit-summary script (and the \`writing-changesets\` skill) require.

This PR adds, to each of the two files:
- a one-line summary at the top
- an \`**Affects:** <audience>\` line

Affected files:
- \`.changeset/demo-neutral-submitting-copy.md\` → \`**Affects:** Client app developers\`
- \`.changeset/fix-post-flush-headers-sent-crash.md\` → \`**Affects:** Operators\`

## Test plan

- [ ] Re-run the Release workflow on \`main\` after merge and confirm \`pnpm version-packages\` succeeds and a release PR is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a server-side crash in response-rewrite middleware that occurred when the system attempted to modify HTTP response headers after they had already been sent to the client.

* **New Features**
  * Updated the sign-in button label in the demo email authentication flow to display "Redirecting..." during form submission, replacing the previous message for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->