### PR TITLE
fix(login-page): open Terms and Privacy links in a new tab

### DIFF
--- a/.changeset/login-legal-links-new-tab.md
+++ b/.changeset/login-legal-links-new-tab.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+Terms of Use and Privacy Policy links on the sign-in page now open in a new tab.
+
+**Affects:** End users
+
+**End users:** clicking Terms of Use or Privacy Policy on the sign-in page no longer navigates away from the in-progress sign-in. The links open in a new tab instead, so you can read the legal page and come back to finish signing in without restarting.

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -578,8 +578,8 @@ export function renderLoginPage(opts: {
     .step-otp.active { display: block; }
     .step-email.hidden { display: none; }
     .terms { margin-top: 24px; color: var(--muted-foreground); font-size: 13px; font-weight: 400; line-height: 1.5; text-align: center; }
-    .terms-link { color: inherit; text-decoration: underline; }
-    .powered-by { display: flex; align-items: center; justify-content: center; gap: 8px; margin-top: 16px; color: var(--muted-foreground); font-size: 13px; text-decoration: none; }
+    .terms-link { color: inherit; text-decoration: underline; cursor: pointer; }
+    .powered-by { display: flex; align-items: center; justify-content: center; gap: 8px; margin-top: 16px; color: var(--muted-foreground); font-size: 13px; text-decoration: none; cursor: pointer; }
     .powered-by:hover, .powered-by:focus, .powered-by:visited { color: var(--muted-foreground); text-decoration: none; }
     .powered-by .certified-mark { height: 14px; width: auto; display: block; }
     /* Recovery-via-backup-email link. Shown by default; trusted clients

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -494,9 +494,9 @@ export function renderLoginPage(opts: {
         opts.initialStep === 'otp' ? 'none' : 'block'
       };">By signing in, you agree to ${termsLead} <a href="${escapeHtml(
         opts.termsOfServiceUrl as string,
-      )}" class="terms-link">Terms of Use</a> and <a href="${escapeHtml(
+      )}" class="terms-link" target="_blank" rel="noopener noreferrer">Terms of Use</a> and <a href="${escapeHtml(
         opts.privacyPolicyUrl as string,
-      )}" class="terms-link">Privacy Policy</a>.</div>`
+      )}" class="terms-link" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.</div>`
     : ''
 
   const hasGoogle = 'google' in socialProviders


### PR DESCRIPTION
## Summary
- Add `target="_blank" rel="noopener noreferrer"` to the Terms of Use and Privacy Policy anchors on the auth-service login page so end users keep their in-progress sign-in tab open when reading the legal pages.
- The "Powered by" logo link already had this attribute pair; this brings the legal links in line with it.
- Includes a patch-level changeset (`login-legal-links-new-tab.md`) describing the user-visible change.

## Test plan
- [ ] Visit the login page on a configured instance, click "Terms of Use" — opens in a new tab, original sign-in tab unchanged.
- [ ] Same for "Privacy Policy".
- [ ] Confirm no regression on instances where the legal URLs are unset (whole terms line is omitted, no broken anchor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)