### PR TITLE
fix(login-page): open Terms and Privacy links in a new tab

### DIFF
--- a/.changeset/login-legal-links-new-tab.md
+++ b/.changeset/login-legal-links-new-tab.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+Terms of Use and Privacy Policy links on the sign-in page now open in a new tab.
+
+**Affects:** End users
+
+**End users:** clicking Terms of Use or Privacy Policy on the sign-in page no longer navigates away from the in-progress sign-in. The links open in a new tab instead, so you can read the legal page and come back to finish signing in without restarting.

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -578,8 +578,8 @@ export function renderLoginPage(opts: {
     .step-otp.active { display: block; }
     .step-email.hidden { display: none; }
     .terms { margin-top: 24px; color: var(--muted-foreground); font-size: 13px; font-weight: 400; line-height: 1.5; text-align: center; }
-    .terms-link { color: inherit; text-decoration: underline; }
-    .powered-by { display: flex; align-items: center; justify-content: center; gap: 8px; margin-top: 16px; color: var(--muted-foreground); font-size: 13px; text-decoration: none; }
+    .terms-link { color: inherit; text-decoration: underline; cursor: pointer; }
+    .powered-by { display: flex; align-items: center; justify-content: center; gap: 8px; margin-top: 16px; color: var(--muted-foreground); font-size: 13px; text-decoration: none; cursor: pointer; }
     .powered-by:hover, .powered-by:focus, .powered-by:visited { color: var(--muted-foreground); text-decoration: none; }
     .powered-by .certified-mark { height: 14px; width: auto; display: block; }
     /* Recovery-via-backup-email link. Shown by default; trusted clients

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -494,9 +494,9 @@ export function renderLoginPage(opts: {
         opts.initialStep === 'otp' ? 'none' : 'block'
       };">By signing in, you agree to ${termsLead} <a href="${escapeHtml(
         opts.termsOfServiceUrl as string,
-      )}" class="terms-link">Terms of Use</a> and <a href="${escapeHtml(
+      )}" class="terms-link" target="_blank" rel="noopener noreferrer">Terms of Use</a> and <a href="${escapeHtml(
         opts.privacyPolicyUrl as string,
-      )}" class="terms-link">Privacy Policy</a>.</div>`
+      )}" class="terms-link" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.</div>`
     : ''
 
   const hasGoogle = 'google' in socialProviders


### PR DESCRIPTION
Keep users on the in-progress sign-in flow when they click the legal links — the links now carry target="_blank" rel="noopener noreferrer", matching the existing "Powered by" logo link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legal document links on the sign-in page no longer interrupt the sign-in flow; Terms of Use and Privacy Policy open in a new browser tab so you can review them without losing progress.

* **Style**
  * Link appearance/interaction updated for clearer clickability on the sign-in page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->