### PR TITLE
feat(auth-service): add Powered by Certified footer to /account/login

### DIFF
--- a/.changeset/account-login-powered-by-footer.md
+++ b/.changeset/account-login-powered-by-footer.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+"Powered by Certified" footer now appears on the Account Settings sign-in pages.
+
+**Affects:** End users
+
+**End users:** the Account Settings sign-in flow at `/account/login` (the email-entry step and the "Enter your code" step) now shows the same "Powered by Certified" footer that the main app sign-in already displays, so the branding is consistent across both sign-in surfaces.

--- a/.changeset/account-login-powered-by-footer.md
+++ b/.changeset/account-login-powered-by-footer.md
@@ -2,8 +2,8 @@
 'ePDS': patch
 ---
 
-"Powered by Certified" footer now appears on the Account Settings sign-in pages.
+"Powered by Certified" footer now appears on every auth-service page.
 
 **Affects:** End users
 
-**End users:** the Account Settings sign-in flow at `/account/login` (the email-entry step and the "Enter your code" step) now shows the same "Powered by Certified" footer that the main app sign-in already displays, so the branding is consistent across both sign-in surfaces.
+**End users:** every page rendered by the auth service now displays the same "Powered by Certified" footer that the main sign-in already shows, so the branding is consistent end-to-end. New surfaces covered: the Account Settings sign-in flow at `/account/login` (email-entry and code-entry steps), the "Choose your handle" page shown to new users after email verification, both Account Recovery steps (backup-email entry and recovery-code entry), the `/account` settings dashboard, the backup-email verification confirmation, the post-deletion confirmation, and the generic error pages used by 404 / 500 / session-expired flows.

--- a/.changeset/handle-recovery-powered-by-footer.md
+++ b/.changeset/handle-recovery-powered-by-footer.md
@@ -2,8 +2,8 @@
 'ePDS': patch
 ---
 
-"Powered by Certified" footer now appears on the handle picker and account recovery pages.
+"Powered by Certified" footer now appears on every remaining auth-service page.
 
 **Affects:** End users
 
-**End users:** the "Choose your handle" page (shown to new users after email verification) and both Account Recovery steps (backup-email entry and recovery-code entry) now display the same "Powered by Certified" footer that the main sign-in and Account Settings sign-in flows already show, so the branding is consistent across every auth-service page.
+**End users:** the "Choose your handle" page (shown to new users after email verification), both Account Recovery steps (backup-email entry and recovery-code entry), the Account Settings dashboard, the backup-email verification confirmation, the post-deletion confirmation, and the generic auth-service error pages (404 / 500 / session-expired) now display the same "Powered by Certified" footer that the sign-in flows already show, so the branding is consistent across every page the auth service renders.

--- a/.changeset/handle-recovery-powered-by-footer.md
+++ b/.changeset/handle-recovery-powered-by-footer.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+"Powered by Certified" footer now appears on the handle picker and account recovery pages.
+
+**Affects:** End users
+
+**End users:** the "Choose your handle" page (shown to new users after email verification) and both Account Recovery steps (backup-email entry and recovery-code entry) now display the same "Powered by Certified" footer that the main sign-in and Account Settings sign-in flows already show, so the branding is consistent across every auth-service page.

--- a/.changeset/handle-recovery-powered-by-footer.md
+++ b/.changeset/handle-recovery-powered-by-footer.md
@@ -1,9 +1,0 @@
----
-'ePDS': patch
----
-
-"Powered by Certified" footer now appears on every remaining auth-service page.
-
-**Affects:** End users
-
-**End users:** the "Choose your handle" page (shown to new users after email verification), both Account Recovery steps (backup-email entry and recovery-code entry), the Account Settings dashboard, the backup-email verification confirmation, the post-deletion confirmation, and the generic auth-service error pages (404 / 500 / session-expired) now display the same "Powered by Certified" footer that the sign-in flows already show, so the branding is consistent across every page the auth service renders.

--- a/packages/auth-service/src/lib/page-helpers.ts
+++ b/packages/auth-service/src/lib/page-helpers.ts
@@ -1,4 +1,44 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { escapeHtml } from '@certified-app/shared'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CERTIFIED_MARK_SVG = readFileSync(
+  path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'public',
+    'certified-text-monochrome.svg',
+  ),
+  'utf8',
+)
+  .replace(/fill="#726A60"/g, 'fill="currentColor"')
+  .replace(
+    '<svg ',
+    '<svg class="certified-mark" aria-label="Certified" role="img" ',
+  )
+
+/**
+ * "Powered by Certified" footer rendered below the auth pages' card. Place
+ * inside a flex-column wrapper alongside `.container`; the wrapper sets the
+ * shared max-width so the footer lines up with the card edges.
+ */
+export const POWERED_BY_HTML = `<a class="powered-by" href="https://certified.app/" target="_blank" rel="noopener noreferrer">
+      <span>Powered by</span>
+      ${CERTIFIED_MARK_SVG}
+    </a>`
+
+/**
+ * CSS rules for the `.powered-by` link + Certified wordmark. Each page is
+ * still responsible for its own `.page-wrap` width since card widths differ.
+ */
+export const POWERED_BY_CSS = `
+  .powered-by { display: flex; align-items: center; justify-content: center; gap: 8px; margin-top: 16px; color: #999; font-size: 13px; text-decoration: none; }
+  .powered-by:hover, .powered-by:focus, .powered-by:visited { color: #999; text-decoration: none; }
+  .powered-by .certified-mark { height: 14px; width: auto; display: block; }
+`
 
 export function renderOptionalStyleTag(css?: string | null): string {
   if (!css) return ''

--- a/packages/auth-service/src/lib/render-error.ts
+++ b/packages/auth-service/src/lib/render-error.ts
@@ -1,9 +1,12 @@
 import { escapeHtml } from '@certified-app/shared'
+import { POWERED_BY_CSS, POWERED_BY_HTML } from './page-helpers.js'
 
 const ERROR_CSS = `
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 20px; }
-  .container { background: white; border-radius: 12px; padding: 40px; max-width: 420px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
+  .page-wrap { display: flex; flex-direction: column; align-items: stretch; max-width: 420px; width: 100%; }
+  ${POWERED_BY_CSS}
+  .container { background: white; border-radius: 12px; padding: 40px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
   h1 { font-size: 24px; margin-bottom: 16px; color: #111; }
   .error { color: #dc3545; background: #fdf0f0; padding: 12px; border-radius: 8px; font-size: 15px; line-height: 1.5; }
 `
@@ -20,9 +23,12 @@ export function renderError(message: string, title = 'Error'): string {
   <style>${ERROR_CSS}</style>
 </head>
 <body>
-  <div class="container">
-    <h1>${escapeHtml(title)}</h1>
-    <p class="error">${escapeHtml(message)}</p>
+  <div class="page-wrap">
+    <div class="container">
+      <h1>${escapeHtml(title)}</h1>
+      <p class="error">${escapeHtml(message)}</p>
+    </div>
+    ${POWERED_BY_HTML}
   </div>
 </body>
 </html>`

--- a/packages/auth-service/src/routes/account-login.ts
+++ b/packages/auth-service/src/routes/account-login.ts
@@ -14,38 +14,14 @@
  * forms that orchestrate those calls.
  */
 import { Router, type Request, type Response } from 'express'
-import { readFileSync } from 'node:fs'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { escapeHtml, maskEmail, createLogger } from '@certified-app/shared'
 import { fromNodeHeaders } from 'better-auth/node'
 import type { AuthServiceContext } from '../context.js'
 import { buildOtpInputProps } from '../otp-input.js'
 import type { BetterAuthInstance } from '../better-auth.js'
+import { POWERED_BY_CSS, POWERED_BY_HTML } from '../lib/page-helpers.js'
 
 const logger = createLogger('auth:account-login')
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const CERTIFIED_MARK_SVG = readFileSync(
-  path.resolve(
-    __dirname,
-    '..',
-    '..',
-    'public',
-    'certified-text-monochrome.svg',
-  ),
-  'utf8',
-)
-  .replace(/fill="#726A60"/g, 'fill="currentColor"')
-  .replace(
-    '<svg ',
-    '<svg class="certified-mark" aria-label="Certified" role="img" ',
-  )
-
-const POWERED_BY_HTML = `<a class="powered-by" href="https://certified.app/" target="_blank" rel="noopener noreferrer">
-      <span>Powered by</span>
-      ${CERTIFIED_MARK_SVG}
-    </a>`
 
 export function createAccountLoginRouter(
   auth: BetterAuthInstance,
@@ -252,9 +228,7 @@ const CSS = `
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
   .page-wrap { display: flex; flex-direction: column; align-items: stretch; max-width: 420px; width: 100%; }
-  .powered-by { display: flex; align-items: center; justify-content: center; gap: 8px; margin-top: 16px; color: #999; font-size: 13px; text-decoration: none; }
-  .powered-by:hover, .powered-by:focus, .powered-by:visited { color: #999; text-decoration: none; }
-  .powered-by .certified-mark { height: 14px; width: auto; display: block; }
+  ${POWERED_BY_CSS}
   .container { background: white; border-radius: 12px; padding: 40px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
   h1 { font-size: 24px; margin-bottom: 8px; color: #111; }
   .subtitle { color: #666; margin-bottom: 20px; font-size: 15px; line-height: 1.5; }

--- a/packages/auth-service/src/routes/account-login.ts
+++ b/packages/auth-service/src/routes/account-login.ts
@@ -14,6 +14,9 @@
  * forms that orchestrate those calls.
  */
 import { Router, type Request, type Response } from 'express'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { escapeHtml, maskEmail, createLogger } from '@certified-app/shared'
 import { fromNodeHeaders } from 'better-auth/node'
 import type { AuthServiceContext } from '../context.js'
@@ -21,6 +24,28 @@ import { buildOtpInputProps } from '../otp-input.js'
 import type { BetterAuthInstance } from '../better-auth.js'
 
 const logger = createLogger('auth:account-login')
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CERTIFIED_MARK_SVG = readFileSync(
+  path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'public',
+    'certified-text-monochrome.svg',
+  ),
+  'utf8',
+)
+  .replace(/fill="#726A60"/g, 'fill="currentColor"')
+  .replace(
+    '<svg ',
+    '<svg class="certified-mark" aria-label="Certified" role="img" ',
+  )
+
+const POWERED_BY_HTML = `<a class="powered-by" href="https://certified.app/" target="_blank" rel="noopener noreferrer">
+      <span>Powered by</span>
+      ${CERTIFIED_MARK_SVG}
+    </a>`
 
 export function createAccountLoginRouter(
   auth: BetterAuthInstance,
@@ -146,19 +171,22 @@ function renderLoginForm(opts: { csrfToken: string; error?: string }): string {
   <style>${CSS}</style>
 </head>
 <body>
-  <div class="container">
-    <h1>Account Settings</h1>
-    <p class="subtitle">Sign in to manage your account</p>
-    ${opts.error ? '<p class="error">' + escapeHtml(opts.error) + '</p>' : ''}
-    <form method="POST" action="/account/send-otp">
-      <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
-      <div class="field">
-        <label for="email">Email address</label>
-        <input type="email" id="email" name="email" required autofocus
-               placeholder="you@example.com">
-      </div>
-      <button type="submit" class="btn-primary">Continue with email</button>
-    </form>
+  <div class="page-wrap">
+    <div class="container">
+      <h1>Account Settings</h1>
+      <p class="subtitle">Sign in to manage your account</p>
+      ${opts.error ? '<p class="error">' + escapeHtml(opts.error) + '</p>' : ''}
+      <form method="POST" action="/account/send-otp">
+        <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
+        <div class="field">
+          <label for="email">Email address</label>
+          <input type="email" id="email" name="email" required autofocus
+                 placeholder="you@example.com">
+        </div>
+        <button type="submit" class="btn-primary">Continue with email</button>
+      </form>
+    </div>
+    ${POWERED_BY_HTML}
   </div>
 </body>
 </html>`
@@ -185,33 +213,36 @@ function renderOtpForm(opts: {
   <style>${CSS}</style>
 </head>
 <body>
-  <div class="container">
-    <h1>Enter your code</h1>
-    <p id="otp-help" class="subtitle">We sent a ${opts.otpLength}-${opts.otpCharset === 'alphanumeric' ? 'character' : 'digit'} code to <strong>${escapeHtml(maskedEmail)}</strong></p>
-    ${opts.error ? '<p class="error">' + escapeHtml(opts.error) + '</p>' : ''}
-    <form method="POST" action="/account/verify-otp">
-      <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
-      <input type="hidden" name="email" value="${escapeHtml(opts.email)}">
-      <div class="field">
-        <input type="text" id="otp" name="otp" required autofocus
-               aria-label="One-time code"
-               aria-describedby="otp-help"
-               maxlength="${opts.otpLength}"
-               pattern="${inputProps.pattern}"
-               inputmode="${inputProps.inputmode}"
-               autocomplete="one-time-code"
-               autocapitalize="${inputProps.autocapitalize}"
-               placeholder="${inputProps.placeholder}"
-               class="otp-input"
-               style="letter-spacing: ${Math.max(2, Math.round(32 / opts.otpLength))}px">
-      </div>
-      <button type="submit" class="btn-primary">Verify</button>
-    </form>
-    <form method="POST" action="/account/send-otp" style="margin-top: 12px;">
-      <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
-      <input type="hidden" name="email" value="${escapeHtml(opts.email)}">
-      <button type="submit" class="btn-secondary">Resend code</button>
-    </form>
+  <div class="page-wrap">
+    <div class="container">
+      <h1>Enter your code</h1>
+      <p id="otp-help" class="subtitle">We sent a ${opts.otpLength}-${opts.otpCharset === 'alphanumeric' ? 'character' : 'digit'} code to <strong>${escapeHtml(maskedEmail)}</strong></p>
+      ${opts.error ? '<p class="error">' + escapeHtml(opts.error) + '</p>' : ''}
+      <form method="POST" action="/account/verify-otp">
+        <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
+        <input type="hidden" name="email" value="${escapeHtml(opts.email)}">
+        <div class="field">
+          <input type="text" id="otp" name="otp" required autofocus
+                 aria-label="One-time code"
+                 aria-describedby="otp-help"
+                 maxlength="${opts.otpLength}"
+                 pattern="${inputProps.pattern}"
+                 inputmode="${inputProps.inputmode}"
+                 autocomplete="one-time-code"
+                 autocapitalize="${inputProps.autocapitalize}"
+                 placeholder="${inputProps.placeholder}"
+                 class="otp-input"
+                 style="letter-spacing: ${Math.max(2, Math.round(32 / opts.otpLength))}px">
+        </div>
+        <button type="submit" class="btn-primary">Verify</button>
+      </form>
+      <form method="POST" action="/account/send-otp" style="margin-top: 12px;">
+        <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
+        <input type="hidden" name="email" value="${escapeHtml(opts.email)}">
+        <button type="submit" class="btn-secondary">Resend code</button>
+      </form>
+    </div>
+    ${POWERED_BY_HTML}
   </div>
 </body>
 </html>`
@@ -219,8 +250,12 @@ function renderOtpForm(opts: {
 
 const CSS = `
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
-  .container { background: white; border-radius: 12px; padding: 40px; max-width: 420px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .page-wrap { display: flex; flex-direction: column; align-items: stretch; max-width: 420px; width: 100%; }
+  .powered-by { display: flex; align-items: center; justify-content: center; gap: 8px; margin-top: 16px; color: #999; font-size: 13px; text-decoration: none; }
+  .powered-by:hover, .powered-by:focus, .powered-by:visited { color: #999; text-decoration: none; }
+  .powered-by .certified-mark { height: 14px; width: auto; display: block; }
+  .container { background: white; border-radius: 12px; padding: 40px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
   h1 { font-size: 24px; margin-bottom: 8px; color: #111; }
   .subtitle { color: #666; margin-bottom: 20px; font-size: 15px; line-height: 1.5; }
   .field { margin-bottom: 20px; text-align: left; }

--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -12,6 +12,7 @@ import { getDidByEmail } from '../lib/get-did-by-email.js'
 import { getHandleByDid } from '../lib/get-handle-by-did.js'
 import { ensurePdsUrl } from '../lib/pds-url.js'
 import { renderError } from '../lib/render-error.js'
+import { POWERED_BY_CSS, POWERED_BY_HTML } from '../lib/page-helpers.js'
 
 const logger = createLogger('auth:account-settings')
 
@@ -164,14 +165,17 @@ export function createAccountSettingsRouter(
   <style>${SETTINGS_CSS}</style>
 </head>
 <body>
-  <div class="container" style="max-width: 420px; text-align: center;">
-    <h1>Verify Backup Email</h1>
-    <p style="color: #666; margin: 16px 0;">Click the button below to confirm your backup email.</p>
-    <form method="POST" action="/account/backup-email/verify">
-      <input type="hidden" name="csrf" value="${escapeHtml(res.locals.csrfToken)}">
-      <input type="hidden" name="token" value="${escapeHtml(token)}">
-      <button type="submit" class="btn-primary-sm" style="padding: 12px 24px; font-size: 16px;">Confirm verification</button>
-    </form>
+  <div class="page-wrap" style="max-width: 420px;">
+    <div class="container" style="max-width: 420px; text-align: center;">
+      <h1>Verify Backup Email</h1>
+      <p style="color: #666; margin: 16px 0;">Click the button below to confirm your backup email.</p>
+      <form method="POST" action="/account/backup-email/verify">
+        <input type="hidden" name="csrf" value="${escapeHtml(res.locals.csrfToken)}">
+        <input type="hidden" name="token" value="${escapeHtml(token)}">
+        <button type="submit" class="btn-primary-sm" style="padding: 12px 24px; font-size: 16px;">Confirm verification</button>
+      </form>
+    </div>
+    ${POWERED_BY_HTML}
   </div>
 </body>
 </html>`)
@@ -475,7 +479,8 @@ function renderSettingsPage(opts: {
   <style>${SETTINGS_CSS}</style>
 </head>
 <body>
-  <div class="container">
+  <div class="page-wrap">
+    <div class="container">
     <div class="header">
       <h1>Account Settings</h1>
       <form method="POST" action="/account/logout" style="display:inline">
@@ -537,6 +542,8 @@ function renderSettingsPage(opts: {
         <button type="submit" class="btn-danger">Revoke all sessions</button>
       </form>
     </section>
+    </div>
+    ${POWERED_BY_HTML}
   </div>
 </body>
 </html>`
@@ -553,16 +560,21 @@ function renderDeletedPage(): string {
   <title>Account Deleted</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
-    .container { background: white; border-radius: 12px; padding: 40px; max-width: 420px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+    .page-wrap { display: flex; flex-direction: column; align-items: stretch; max-width: 420px; width: 100%; }
+    ${POWERED_BY_CSS}
+    .container { background: white; border-radius: 12px; padding: 40px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
     h1 { font-size: 24px; margin-bottom: 12px; color: #111; }
     p { color: #666; font-size: 15px; line-height: 1.5; }
   </style>
 </head>
 <body>
-  <div class="container">
-    <h1>Account Deleted</h1>
-    <p>Your account and all associated data have been permanently deleted.</p>
+  <div class="page-wrap">
+    <div class="container">
+      <h1>Account Deleted</h1>
+      <p>Your account and all associated data have been permanently deleted.</p>
+    </div>
+    ${POWERED_BY_HTML}
   </div>
 </body>
 </html>`
@@ -571,6 +583,8 @@ function renderDeletedPage(): string {
 const SETTINGS_CSS = `
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; padding: 40px 20px; }
+  .page-wrap { display: flex; flex-direction: column; align-items: stretch; max-width: 640px; margin: 0 auto; }
+  ${POWERED_BY_CSS}
   .container { background: white; border-radius: 12px; padding: 32px; max-width: 640px; margin: 0 auto; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
   .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 16px; }
   h1 { font-size: 24px; color: #111; }

--- a/packages/auth-service/src/routes/choose-handle.ts
+++ b/packages/auth-service/src/routes/choose-handle.ts
@@ -33,6 +33,8 @@ import { resolveClientBranding } from '../lib/client-metadata.js'
 import {
   renderOptionalStyleTag,
   renderFaviconTag,
+  POWERED_BY_CSS,
+  POWERED_BY_HTML,
 } from '../lib/page-helpers.js'
 
 const logger = createLogger('auth:choose-handle')
@@ -465,8 +467,10 @@ export function renderChooseHandlePage(
   <title>Choose your handle</title>
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
-    .container { background: white; border-radius: 12px; padding: 40px; max-width: max(420px, min(90vw, 600px)); width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+    .page-wrap { display: flex; flex-direction: column; align-items: stretch; max-width: max(420px, min(90vw, 600px)); width: 100%; }
+    ${POWERED_BY_CSS}
+    .container { background: white; border-radius: 12px; padding: 40px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
     h1 { font-size: 24px; margin-bottom: 8px; color: #111; }
     .subtitle { color: #666; margin-bottom: 24px; font-size: 15px; line-height: 1.5; }
     .field { margin-bottom: 16px; }
@@ -496,35 +500,38 @@ export function renderChooseHandlePage(
   </style>${renderOptionalStyleTag(customCss)}
 </head>
 <body>
-  <div class="container">
-    <h1>Choose your handle</h1>
-    <p class="subtitle">Your handle is your public username on the AT Protocol network.</p>
+  <div class="page-wrap">
+    <div class="container">
+      <h1>Choose your handle</h1>
+      <p class="subtitle">Your handle is your public username on the AT Protocol network.</p>
 
-    ${errorHtml}
+      ${errorHtml}
 
-    <form method="POST" action="/auth/choose-handle" id="handle-form">
-      <input type="hidden" name="csrf" value="${escapeHtml(csrfToken || '')}">
-      <div class="field">
-        <label for="handle-input">Handle</label>
-        <div class="handle-row">
-          <input
-            type="text"
-            id="handle-input"
-            name="handle"
-            placeholder="yourname"
-            autocomplete="off"
-            autocapitalize="none"
-            spellcheck="false"
-            minlength="5"
-            maxlength="20"
-          >
-          <span class="handle-suffix">.${escapeHtml(handleDomain)}</span>
+      <form method="POST" action="/auth/choose-handle" id="handle-form">
+        <input type="hidden" name="csrf" value="${escapeHtml(csrfToken || '')}">
+        <div class="field">
+          <label for="handle-input">Handle</label>
+          <div class="handle-row">
+            <input
+              type="text"
+              id="handle-input"
+              name="handle"
+              placeholder="yourname"
+              autocomplete="off"
+              autocapitalize="none"
+              spellcheck="false"
+              minlength="5"
+              maxlength="20"
+            >
+            <span class="handle-suffix">.${escapeHtml(handleDomain)}</span>
+          </div>
+          <div class="status" id="handle-status"></div>
         </div>
-        <div class="status" id="handle-status"></div>
-      </div>
-      ${showRandomButton ? `<button type="button" id="random-btn" class="btn-secondary">Generate random handle</button>` : ''}
-      <button type="submit" id="submit-btn" class="btn-primary">Create</button>
-    </form>
+        ${showRandomButton ? `<button type="button" id="random-btn" class="btn-secondary">Generate random handle</button>` : ''}
+        <button type="submit" id="submit-btn" class="btn-primary">Create</button>
+      </form>
+    </div>
+    ${POWERED_BY_HTML}
   </div>
 
   <script>

--- a/packages/auth-service/src/routes/recovery.ts
+++ b/packages/auth-service/src/routes/recovery.ts
@@ -22,6 +22,8 @@ import { resolveClientBranding } from '../lib/client-metadata.js'
 import {
   renderOptionalStyleTag,
   renderFaviconTag,
+  POWERED_BY_CSS,
+  POWERED_BY_HTML,
 } from '../lib/page-helpers.js'
 import { renderError } from '../lib/render-error.js'
 import { AUTH_FLOW_COOKIE, AUTH_FLOW_TTL_MS } from '../lib/auth-flow.js'
@@ -304,21 +306,24 @@ export function renderRecoveryForm(opts: {
   <style>${CSS}</style>${renderOptionalStyleTag(opts.customCss)}
 </head>
 <body>
-  <div class="container">
-    <h1>Account Recovery</h1>
-    <p class="subtitle">Enter the backup email address associated with your account.</p>
-    ${opts.error ? '<p class="error">' + escapeHtml(opts.error) + '</p>' : ''}
-    <form method="POST" action="/auth/recover">
-      <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
-      <input type="hidden" name="request_uri" value="${escapeHtml(opts.requestUri)}">
-      <div class="field">
-        <label for="email">Backup email address</label>
-        <input type="email" id="email" name="email" required autofocus
-               placeholder="backup@example.com">
-      </div>
-      <button type="submit" class="btn-primary">Send recovery code</button>
-    </form>
-    <a href="${backHref}" class="btn-secondary">Back to sign in</a>
+  <div class="page-wrap">
+    <div class="container">
+      <h1>Account Recovery</h1>
+      <p class="subtitle">Enter the backup email address associated with your account.</p>
+      ${opts.error ? '<p class="error">' + escapeHtml(opts.error) + '</p>' : ''}
+      <form method="POST" action="/auth/recover">
+        <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
+        <input type="hidden" name="request_uri" value="${escapeHtml(opts.requestUri)}">
+        <div class="field">
+          <label for="email">Backup email address</label>
+          <input type="email" id="email" name="email" required autofocus
+                 placeholder="backup@example.com">
+        </div>
+        <button type="submit" class="btn-primary">Send recovery code</button>
+      </form>
+      <a href="${backHref}" class="btn-secondary">Back to sign in</a>
+    </div>
+    ${POWERED_BY_HTML}
   </div>
 </body>
 </html>`
@@ -353,37 +358,40 @@ export function renderRecoveryOtpForm(opts: {
   <style>${CSS}</style>${renderOptionalStyleTag(opts.customCss)}
 </head>
 <body>
-  <div class="container">
-    <h1>Enter recovery code</h1>
-    <p id="code-help" class="subtitle">If a backup email matches, we sent a ${opts.otpLength}-${opts.otpCharset === 'alphanumeric' ? 'character' : 'digit'} code to <strong>${escapeHtml(maskedEmail)}</strong></p>
-    ${opts.error ? '<p class="error">' + escapeHtml(opts.error) + '</p>' : ''}
-    <form method="POST" action="/auth/recover/verify">
-      <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
-      <input type="hidden" name="request_uri" value="${escapeHtml(opts.requestUri)}">
-      <input type="hidden" name="email" value="${escapeHtml(opts.email)}">
-      <div class="field">
-        <input type="text" id="code" name="code" required autofocus
-               aria-label="One-time code"
-               aria-describedby="code-help"
-               maxlength="${opts.otpLength}"
-               pattern="${inputProps.pattern}"
-               inputmode="${inputProps.inputmode}"
-               autocomplete="one-time-code"
-               autocapitalize="${inputProps.autocapitalize}"
-               placeholder="${inputProps.placeholder}"
-               class="otp-input"
-                oninput="this.value=this.value.replace(/[\\s-]/g,'')"
-               style="letter-spacing: ${Math.max(2, Math.round(32 / opts.otpLength))}px">
-      </div>
-      <button type="submit" class="btn-primary">Verify</button>
-    </form>
-    <form method="POST" action="/auth/recover" style="margin-top: 12px;">
-      <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
-      <input type="hidden" name="request_uri" value="${escapeHtml(opts.requestUri)}">
-      <input type="hidden" name="email" value="${escapeHtml(opts.email)}">
-      <button type="submit" class="btn-secondary">Resend code</button>
-    </form>
-    <a href="${backHref}" class="btn-secondary">Back to sign in</a>
+  <div class="page-wrap">
+    <div class="container">
+      <h1>Enter recovery code</h1>
+      <p id="code-help" class="subtitle">If a backup email matches, we sent a ${opts.otpLength}-${opts.otpCharset === 'alphanumeric' ? 'character' : 'digit'} code to <strong>${escapeHtml(maskedEmail)}</strong></p>
+      ${opts.error ? '<p class="error">' + escapeHtml(opts.error) + '</p>' : ''}
+      <form method="POST" action="/auth/recover/verify">
+        <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
+        <input type="hidden" name="request_uri" value="${escapeHtml(opts.requestUri)}">
+        <input type="hidden" name="email" value="${escapeHtml(opts.email)}">
+        <div class="field">
+          <input type="text" id="code" name="code" required autofocus
+                 aria-label="One-time code"
+                 aria-describedby="code-help"
+                 maxlength="${opts.otpLength}"
+                 pattern="${inputProps.pattern}"
+                 inputmode="${inputProps.inputmode}"
+                 autocomplete="one-time-code"
+                 autocapitalize="${inputProps.autocapitalize}"
+                 placeholder="${inputProps.placeholder}"
+                 class="otp-input"
+                  oninput="this.value=this.value.replace(/[\\s-]/g,'')"
+                 style="letter-spacing: ${Math.max(2, Math.round(32 / opts.otpLength))}px">
+        </div>
+        <button type="submit" class="btn-primary">Verify</button>
+      </form>
+      <form method="POST" action="/auth/recover" style="margin-top: 12px;">
+        <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
+        <input type="hidden" name="request_uri" value="${escapeHtml(opts.requestUri)}">
+        <input type="hidden" name="email" value="${escapeHtml(opts.email)}">
+        <button type="submit" class="btn-secondary">Resend code</button>
+      </form>
+      <a href="${backHref}" class="btn-secondary">Back to sign in</a>
+    </div>
+    ${POWERED_BY_HTML}
   </div>
 </body>
 </html>`
@@ -391,8 +399,10 @@ export function renderRecoveryOtpForm(opts: {
 
 const CSS = `
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; }
-  .container { background: white; border-radius: 12px; padding: 40px; max-width: 420px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .page-wrap { display: flex; flex-direction: column; align-items: stretch; max-width: 420px; width: 100%; }
+  ${POWERED_BY_CSS}
+  .container { background: white; border-radius: 12px; padding: 40px; width: 100%; box-shadow: 0 2px 8px rgba(0,0,0,0.08); text-align: center; }
   h1 { font-size: 24px; margin-bottom: 8px; color: #111; }
   .subtitle { color: #666; margin-bottom: 20px; font-size: 15px; line-height: 1.5; }
   .field { margin-bottom: 20px; text-align: left; }


### PR DESCRIPTION
## Summary

**Requested by Ma Earth to be done before launch**

- Renders the same "Powered by Certified" wordmark footer on the Account Settings sign-in flow (`/account/login`) — both the email-entry step and the "Enter your code" step.
- Matches the footer already shown on the main OAuth sign-in page, so branding is consistent across both sign-in surfaces.
- Inlines the wordmark SVG (no extra static request) and wraps each form's `.container` in a `.page-wrap` so the footer sits below the card.

## Test plan

- [x] Visit `/account/login` and confirm the "Powered by Certified" footer is visible below the card.
- [x] Submit any email on `/account/login`, land on the "Enter your code" page, and confirm the footer is visible there too.
- [x] Confirm the wordmark click opens https://certified.app in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Powered by Certified" footer branding across all authentication pages, including login, account settings, account recovery, and error pages.

* **Style**
  * Improved page layout with unified wrapper structure for consistent visual presentation across all auth surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


***Manually tested on auth.epds1.test.certified.app by @Kzoeps and it works***