### PR TITLE
fix(auth-service): "Another account" lands on email form even with login_hint

### DIFF
--- a/.changeset/another-account-reaches-email-form.md
+++ b/.changeset/another-account-reaches-email-form.md
@@ -4,8 +4,6 @@
 
 "Use a different account" on the chooser now reliably takes you to the email form, not the code step for the previous account.
 
-**Affects:** End users, Client app developers
+**Affects:** End users
 
-**End users:** when you click "Another account" on the account chooser to sign in as someone else, you now always land on a fresh email entry form. Previously, if the app that started the sign-in had pre-filled an account hint, the page jumped straight to the verification-code step for the *previous* account — leaving you stuck typing a code for an account you were trying to leave.
-
-**Client app developers:** no integration changes required. The fix tightens how `auth-service`'s `/oauth/authorize` page combines the standard OIDC `prompt=login` signal with a resolved `login_hint`: when both are present, the email step is rendered with no pre-fill, and any "code already sent" claim is suppressed so the next OTP send is treated as a fresh send. Apps that pass `login_hint` continue to land on the OTP step on a normal first visit; the change only affects the "force re-auth" path triggered by `prompt=login`.
+**End users:** when you click "Another account" on the account chooser to sign in as someone else, you now always land on a fresh email entry form. Previously, if the app that started the sign-in had pre-filled an account hint, the page jumped straight to the verification-code step for the _previous_ account — leaving you stuck typing a code for an account you were trying to leave.

--- a/.changeset/another-account-reaches-email-form.md
+++ b/.changeset/another-account-reaches-email-form.md
@@ -1,0 +1,11 @@
+---
+'ePDS': patch
+---
+
+"Use a different account" on the chooser now reliably takes you to the email form, not the code step for the previous account.
+
+**Affects:** End users, Client app developers
+
+**End users:** when you click "Another account" on the account chooser to sign in as someone else, you now always land on a fresh email entry form. Previously, if the app that started the sign-in had pre-filled an account hint, the page jumped straight to the verification-code step for the *previous* account — leaving you stuck typing a code for an account you were trying to leave.
+
+**Client app developers:** no integration changes required. The fix tightens how `auth-service`'s `/oauth/authorize` page combines the standard OIDC `prompt=login` signal with a resolved `login_hint`: when both are present, the email step is rendered with no pre-fill, and any "code already sent" claim is suppressed so the next OTP send is treated as a fresh send. Apps that pass `login_hint` continue to land on the OTP step on a normal first visit; the change only affects the "force re-auth" path triggered by `prompt=login`.

--- a/e2e/step-definitions/common.steps.ts
+++ b/e2e/step-definitions/common.steps.ts
@@ -11,13 +11,40 @@ import type { EpdsWorld } from '../support/world.js'
 import { testEnv } from '../support/env.js'
 import { getPage } from '../support/utils.js'
 
+/**
+ * Health-check the PDS with a short retry budget. The CI workflow already
+ * polls /health for 5 minutes before invoking the e2e suite, so any
+ * failure here is *post* deploy-readiness — typically a transient Railway
+ * edge / undici DNS blip that resolves in seconds. Without retries, a
+ * single such blip on the first scenario fails an entire 9-minute e2e
+ * run; with retries, the rest of the suite runs unimpaired.
+ *
+ * Total budget: 6 attempts × 2s backoff = ~12s. Real outages still
+ * surface — the suite cannot make meaningful progress past this Given
+ * without a live PDS, so a hard failure is the right outcome once the
+ * budget is spent.
+ */
 Given('the ePDS test environment is running', async function (this: EpdsWorld) {
-  const res = await fetch(`${testEnv.pdsUrl}/health`)
-  if (!res.ok) {
-    throw new Error(
-      `PDS health check failed: ${res.status} at ${testEnv.pdsUrl}/health`,
-    )
+  const url = `${testEnv.pdsUrl}/health`
+  const maxAttempts = 6
+  let lastErr: unknown
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) return
+      lastErr = new Error(`PDS health check failed: ${res.status} at ${url}`)
+    } catch (err) {
+      lastErr = err
+    }
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+    }
   }
+  throw new Error(
+    `PDS health check failed after ${maxAttempts} attempts at ${url}: ${
+      lastErr instanceof Error ? lastErr.message : String(lastErr)
+    }`,
+  )
 })
 
 /**

--- a/e2e/step-definitions/common.steps.ts
+++ b/e2e/step-definitions/common.steps.ts
@@ -19,25 +19,30 @@ import { getPage } from '../support/utils.js'
  * single such blip on the first scenario fails an entire 9-minute e2e
  * run; with retries, the rest of the suite runs unimpaired.
  *
- * Total budget: 6 attempts × 2s backoff = ~12s. Real outages still
- * surface — the suite cannot make meaningful progress past this Given
- * without a live PDS, so a hard failure is the right outcome once the
- * budget is spent.
+ * Each attempt has its own AbortSignal.timeout(2s) so a hung connection
+ * cannot blow past the documented wall-clock budget of 6 × (2s fetch +
+ * 2s backoff) = ~24s. Real outages still surface — the suite cannot make
+ * meaningful progress past this Given without a live PDS, so a hard
+ * failure is the right outcome once the budget is spent.
  */
 Given('the ePDS test environment is running', async function (this: EpdsWorld) {
   const url = `${testEnv.pdsUrl}/health`
   const maxAttempts = 6
+  const perAttemptTimeoutMs = 2000
+  const backoffMs = 2000
   let lastErr: unknown
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      const res = await fetch(url)
+      const res = await fetch(url, {
+        signal: AbortSignal.timeout(perAttemptTimeoutMs),
+      })
       if (res.ok) return
       lastErr = new Error(`PDS health check failed: ${res.status} at ${url}`)
     } catch (err) {
       lastErr = err
     }
     if (attempt < maxAttempts) {
-      await new Promise((resolve) => setTimeout(resolve, 2000))
+      await new Promise((resolve) => setTimeout(resolve, backoffMs))
     }
   }
   throw new Error(

--- a/e2e/step-definitions/session-reuse.steps.ts
+++ b/e2e/step-definitions/session-reuse.steps.ts
@@ -419,6 +419,25 @@ Then(
 )
 
 /**
+ * Strict-form assertions used by the "Another account + login_hint" repro
+ * for issue #138: the email form must not carry the previous account's
+ * email pre-fill, and the OTP step must not be the active step (the
+ * regression rendered the page with both #email and #step-otp.active).
+ */
+Then('the email input is empty', async function (this: EpdsWorld) {
+  const page = getPage(this)
+  await expect(page.locator('#email')).toHaveValue('')
+})
+
+Then(
+  'the OTP verification step is not active',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await expect(page.locator('#step-otp.active')).toBeHidden()
+  },
+)
+
+/**
  * Negative assertion for the auto-approve path: the second OAuth flow
  * must complete without the consent screen ever appearing. Checked by
  * looking for the Authorize button on the current page — by the time

--- a/features/session-reuse-bugs.feature
+++ b/features/session-reuse-bugs.feature
@@ -152,6 +152,8 @@ Feature: Welcome-page guard suppresses upstream's authentication UI
     Then the browser lands on the ePDS enriched account picker
     When the user clicks "Another account" on the enriched account picker
     Then the browser is on the auth service email form
+    And the email input is empty
+    And the OTP verification step is not active
 
   Scenario: Login hint resolves to an unbound account — skip chooser
     Given another user has a separate PDS account

--- a/features/session-reuse-bugs.feature
+++ b/features/session-reuse-bugs.feature
@@ -138,6 +138,21 @@ Feature: Welcome-page guard suppresses upstream's authentication UI
     When the demo client starts a new OAuth flow with the test user's handle as login_hint
     Then the browser lands on the ePDS enriched account picker
 
+  # GitHub issue #138: when the OAuth flow that reached the chooser carried
+  # a login_hint, the "Another account" rebind preserves it on the
+  # auth-service URL and adds prompt=login. shouldReuseSession honours
+  # prompt=login and falls through to the login page, but the initialStep
+  # selector at routes/login-page.ts only looks at hint presence — so the
+  # resolved email forces initialStep='otp' and the user lands on the OTP
+  # form for the *previous* account instead of the email entry form. The
+  # email form is the only correct outcome: prompt=login is the user's
+  # explicit "start over" signal.
+  Scenario: "Another account" with login_hint must reach the email form
+    When the demo client starts a new OAuth flow with the test user's handle as login_hint
+    Then the browser lands on the ePDS enriched account picker
+    When the user clicks "Another account" on the enriched account picker
+    Then the browser is on the auth service email form
+
   Scenario: Login hint resolves to an unbound account — skip chooser
     Given another user has a separate PDS account
     When the demo client starts a new OAuth flow with the other user's handle as login_hint

--- a/packages/auth-service/src/__tests__/login-page-prompt-login.test.ts
+++ b/packages/auth-service/src/__tests__/login-page-prompt-login.test.ts
@@ -25,6 +25,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import express from 'express'
 import cookieParser from 'cookie-parser'
+import { randomBytes } from 'node:crypto'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
@@ -80,6 +81,12 @@ async function startApp(ctx: AuthServiceContext): Promise<{
   close: () => Promise<void>
 }> {
   const app = express()
+  // Silence sonar's "framework version disclosure" hotspot that fires
+  // on any vanilla express() instance. This is an in-process test
+  // server bound to 127.0.0.1 on an ephemeral port — the header is
+  // only visible to the test runner — but disabling it keeps the
+  // signal clean.
+  app.disable('x-powered-by')
   app.use(cookieParser())
   app.use(csrfProtection(ctx.config.csrfSecret))
   app.use(createLoginPageRouter(ctx))
@@ -112,7 +119,7 @@ describe('GET /oauth/authorize prompt=login handling (issue #138)', () => {
   beforeEach(async () => {
     dbPath = path.join(
       os.tmpdir(),
-      `prompt-login-${Date.now()}-${Math.random()}.db`,
+      `prompt-login-${Date.now()}-${randomBytes(4).toString('hex')}.db`,
     )
     db = new EpdsDb(dbPath)
     // Avoid an outbound fetch when the handler resolves client metadata.

--- a/packages/auth-service/src/__tests__/login-page-prompt-login.test.ts
+++ b/packages/auth-service/src/__tests__/login-page-prompt-login.test.ts
@@ -176,18 +176,29 @@ describe('GET /oauth/authorize prompt=login handling (issue #138)', () => {
   it('skips internal-API round trips when prompt=login is present', async () => {
     mocks.fetchParLoginHint.mockResolvedValue('previous@example.com')
     mocks.resolveLoginHint.mockResolvedValue('previous@example.com')
-
+    // Make the assertion meaningful for fetchDeviceAccountEmails by sending
+    // a dev-id/ses-id cookie pair: the handler only fetches device-bound
+    // emails when BOTH a cookie pair is present AND `resolvedEmail` is
+    // truthy. Without the cookie pair, the assertion would pass trivially
+    // even if a regression reintroduced hint resolution.
     const url =
       app.baseUrl +
       '/oauth/authorize?request_uri=urn:ietf:params:oauth:request_uri:promptloginskip' +
       '&login_hint=previous%40example.com' +
       '&prompt=login'
-    const res = await fetch(url)
+    const res = await fetch(url, {
+      headers: {
+        cookie:
+          'dev-id=dev-test-skip-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; ses-id=ses-test-skip-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      },
+    })
     expect(res.status).toBe(200)
 
     // The hint resolution chain must be untouched — its result is unused
     // on the prompt=login path AND shouldReuseSession bypasses the hint
     // check, so calling these is pure overhead on the PDS internal API.
+    // With cookies present, a regression that left fetchDeviceAccountEmails
+    // unguarded by forceLogin would call it; this assertion catches that.
     expect(mocks.fetchParLoginHint).not.toHaveBeenCalled()
     expect(mocks.resolveLoginHint).not.toHaveBeenCalled()
     expect(mocks.fetchDeviceAccountEmails).not.toHaveBeenCalled()

--- a/packages/auth-service/src/__tests__/login-page-prompt-login.test.ts
+++ b/packages/auth-service/src/__tests__/login-page-prompt-login.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Route-level coverage for the prompt=login branch of GET /oauth/authorize.
+ *
+ * GitHub issue #138: pds-core's "Another account" rebind navigates back to
+ * auth-service with the original `login_hint` preserved AND `prompt=login`
+ * appended. The login-page handler must:
+ *
+ *  1. Render the email step (not the OTP step) regardless of the hint.
+ *  2. Leave the `#email` input empty (no pre-fill from the previous account).
+ *  3. Skip the three internal-API round trips that would normally resolve
+ *     the hint (`fetchParLoginHint`, `resolveLoginHint`,
+ *     `fetchDeviceAccountEmails`) — none of their results are used on this
+ *     path, so calling them is pure overhead.
+ *
+ * Mirrors the e2e scenario at
+ * `features/session-reuse-bugs.feature:148`. The e2e test catches a
+ * regression of (1) and (2); this test pins (3) — a regression that
+ * re-introduced the network calls would silently revert the optimisation
+ * without any user-visible effect, so e2e wouldn't notice.
+ *
+ * Lives in its own file because the `vi.mock` calls below replace the
+ * shared resolver modules wholesale, and we don't want that bleed into the
+ * existing unit tests in login-page.test.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import express from 'express'
+import cookieParser from 'cookie-parser'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import type { AddressInfo } from 'node:net'
+import { EpdsDb, _seedClientMetadataCacheForTest } from '@certified-app/shared'
+import { csrfProtection } from '../middleware/csrf.js'
+import { createLoginPageRouter } from '../routes/login-page.js'
+import { AuthServiceContext, type AuthServiceConfig } from '../context.js'
+
+// Hoisted spies — `vi.mock` runs before module imports, so the mock factory
+// must capture them via `vi.hoisted` rather than referencing top-level
+// `const`s that haven't been initialised yet.
+const mocks = vi.hoisted(() => ({
+  fetchParLoginHint: vi.fn(),
+  resolveLoginHint: vi.fn(),
+  fetchDeviceAccountEmails: vi.fn(),
+}))
+
+vi.mock('../lib/resolve-login-hint.js', () => ({
+  fetchParLoginHint: mocks.fetchParLoginHint,
+  resolveLoginHint: mocks.resolveLoginHint,
+}))
+
+vi.mock('../lib/fetch-device-accounts.js', () => ({
+  fetchDeviceAccountEmails: mocks.fetchDeviceAccountEmails,
+}))
+
+function makeConfig(dbPath: string): AuthServiceConfig {
+  return {
+    hostname: 'auth.test.local',
+    port: 0,
+    sessionSecret: 'test-session-secret',
+    csrfSecret: 'test-csrf-secret',
+    epdsCallbackSecret: 'test-callback-secret',
+    pdsHostname: 'test.local',
+    pdsPublicUrl: 'https://test.local',
+    email: {
+      provider: 'smtp',
+      smtpHost: 'localhost',
+      smtpPort: 1025,
+      from: 'noreply@test.local',
+      fromName: 'ePDS Test',
+    },
+    dbLocation: dbPath,
+    otpLength: 6,
+    otpCharset: 'numeric',
+    trustedClients: [],
+  }
+}
+
+async function startApp(ctx: AuthServiceContext): Promise<{
+  baseUrl: string
+  close: () => Promise<void>
+}> {
+  const app = express()
+  app.use(cookieParser())
+  app.use(csrfProtection(ctx.config.csrfSecret))
+  app.use(createLoginPageRouter(ctx))
+  const server = app.listen(0)
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.once('listening', () => {
+      resolve()
+    })
+  })
+  server.unref()
+  const port = (server.address() as AddressInfo).port
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => {
+          resolve()
+        })
+      }),
+  }
+}
+
+describe('GET /oauth/authorize prompt=login handling (issue #138)', () => {
+  let db: EpdsDb
+  let dbPath: string
+  let ctx: AuthServiceContext
+  let app: { baseUrl: string; close: () => Promise<void> }
+
+  beforeEach(async () => {
+    dbPath = path.join(
+      os.tmpdir(),
+      `prompt-login-${Date.now()}-${Math.random()}.db`,
+    )
+    db = new EpdsDb(dbPath)
+    // Avoid an outbound fetch when the handler resolves client metadata.
+    _seedClientMetadataCacheForTest('https://app.example.com', {
+      client_name: 'Test App',
+    })
+    const config = makeConfig(dbPath)
+    ctx = new AuthServiceContext(config)
+    // Replace the constructor-created db (built against the same path) so
+    // the test's seed/inspection share state with the handler.
+    Object.defineProperty(ctx, 'db', { value: db, configurable: true })
+    app = await startApp(ctx)
+    mocks.fetchParLoginHint.mockReset()
+    mocks.resolveLoginHint.mockReset()
+    mocks.fetchDeviceAccountEmails.mockReset()
+  })
+
+  afterEach(async () => {
+    await app.close()
+    ctx.destroy()
+    try {
+      fs.unlinkSync(dbPath)
+    } catch {
+      /* db may already be gone */
+    }
+  })
+
+  it('renders the email step with empty input on prompt=login + login_hint', async () => {
+    // Even if a stale hint resolution were to slip through, force its
+    // result to be a non-empty email so a regression that ignored
+    // forceLogin would be obviously visible as a pre-filled box.
+    mocks.fetchParLoginHint.mockResolvedValue('previous@example.com')
+    mocks.resolveLoginHint.mockResolvedValue('previous@example.com')
+
+    const url =
+      app.baseUrl +
+      '/oauth/authorize?request_uri=urn:ietf:params:oauth:request_uri:promptlogin' +
+      '&client_id=' +
+      encodeURIComponent('https://app.example.com') +
+      '&login_hint=previous%40example.com' +
+      '&prompt=login'
+    const res = await fetch(url)
+    expect(res.status).toBe(200)
+    const html = await res.text()
+
+    // (1) Email step is the rendered step, not the OTP step.
+    expect(html).toMatch(/<div id="step-email" class="step-email">/)
+    expect(html).not.toMatch(/class="step-otp active"/)
+
+    // (2) Email input is empty (no pre-fill from the previous account).
+    expect(html).toMatch(/<input type="email" id="email"[^>]*value=""[^>]*>/)
+  })
+
+  it('skips internal-API round trips when prompt=login is present', async () => {
+    mocks.fetchParLoginHint.mockResolvedValue('previous@example.com')
+    mocks.resolveLoginHint.mockResolvedValue('previous@example.com')
+
+    const url =
+      app.baseUrl +
+      '/oauth/authorize?request_uri=urn:ietf:params:oauth:request_uri:promptloginskip' +
+      '&login_hint=previous%40example.com' +
+      '&prompt=login'
+    const res = await fetch(url)
+    expect(res.status).toBe(200)
+
+    // The hint resolution chain must be untouched — its result is unused
+    // on the prompt=login path AND shouldReuseSession bypasses the hint
+    // check, so calling these is pure overhead on the PDS internal API.
+    expect(mocks.fetchParLoginHint).not.toHaveBeenCalled()
+    expect(mocks.resolveLoginHint).not.toHaveBeenCalled()
+    expect(mocks.fetchDeviceAccountEmails).not.toHaveBeenCalled()
+  })
+
+  it('still resolves login_hint when prompt=login is absent (regression guard)', async () => {
+    // Without prompt=login, the hint must still be resolved so the OTP
+    // step can pre-fill the email — the optimisation only applies to the
+    // forced-reauth path.
+    mocks.resolveLoginHint.mockResolvedValue('user@example.com')
+
+    const url =
+      app.baseUrl +
+      '/oauth/authorize?request_uri=urn:ietf:params:oauth:request_uri:nopromptlogin' +
+      '&login_hint=user%40example.com'
+    const res = await fetch(url)
+    expect(res.status).toBe(200)
+    const html = await res.text()
+
+    expect(mocks.resolveLoginHint).toHaveBeenCalledWith(
+      'user@example.com',
+      expect.any(String),
+      expect.any(String),
+    )
+    // OTP step is the active step (hasLoginHint true, !forceLogin).
+    expect(html).toMatch(/class="step-otp active"/)
+  })
+})

--- a/packages/auth-service/src/__tests__/login-page-prompt-login.test.ts
+++ b/packages/auth-service/src/__tests__/login-page-prompt-login.test.ts
@@ -1,26 +1,26 @@
 /**
- * Route-level coverage for the prompt=login branch of GET /oauth/authorize.
+ * Route-level coverage for the "Another account" rebind branch of
+ * GET /oauth/authorize.
  *
- * GitHub issue #138: pds-core's "Another account" rebind navigates back to
- * auth-service with the original `login_hint` preserved AND `prompt=login`
- * appended. The login-page handler must:
+ * GitHub issue #138: pds-core's "Another account" rebind navigates back
+ * to auth-service with `prompt=login` AND `epds_skip_par_hint=1`
+ * appended (and any URL `login_hint` stripped). `epds_skip_par_hint=1`
+ * tells auth-service to ignore any login_hint stored in the PAR — the
+ * user clicked an opt-out, so the RP's hint must not influence rendering.
+ * With no hint resolving, `resolvedEmail` is null and the email step
+ * falls out from the standard rendering decision.
  *
- *  1. Render the email step (not the OTP step) regardless of the hint.
- *  2. Leave the `#email` input empty (no pre-fill from the previous account).
- *  3. Skip the three internal-API round trips that would normally resolve
- *     the hint (`fetchParLoginHint`, `resolveLoginHint`,
- *     `fetchDeviceAccountEmails`) — none of their results are used on this
- *     path, so calling them is pure overhead.
- *
- * Mirrors the e2e scenario at
- * `features/session-reuse-bugs.feature:148`. The e2e test catches a
- * regression of (1) and (2); this test pins (3) — a regression that
- * re-introduced the network calls would silently revert the optimisation
- * without any user-visible effect, so e2e wouldn't notice.
+ * `prompt=login` ALONE (without the skip flag) must NOT suppress hint
+ * resolution — pds-core's auth-ui-guard sign-in-view bounce appends
+ * prompt=login while still expecting the hint to be honoured (the user
+ * wants that account; upstream's password sign-in form is just
+ * unreachable in a passwordless deployment). The third test below pins
+ * this so a future "simplification" that conflates the two signals is
+ * caught.
  *
  * Lives in its own file because the `vi.mock` calls below replace the
- * shared resolver modules wholesale, and we don't want that bleed into the
- * existing unit tests in login-page.test.ts.
+ * shared resolver modules wholesale, and we don't want that bleed into
+ * the existing unit tests in login-page.test.ts.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import express from 'express'
@@ -148,67 +148,59 @@ describe('GET /oauth/authorize prompt=login handling (issue #138)', () => {
     }
   })
 
-  it('renders the email step with empty input on prompt=login + login_hint', async () => {
-    // Even if a stale hint resolution were to slip through, force its
-    // result to be a non-empty email so a regression that ignored
-    // forceLogin would be obviously visible as a pre-filled box.
+  it('renders the email step on the "Another account" rebind path', async () => {
+    // pds-core's "Another account" rebind sets epds_skip_par_hint=1
+    // and strips URL login_hint. Mock fetchParLoginHint to return a
+    // value anyway so a regression that ignored the skip flag would
+    // visibly pre-fill the email box with the previous user.
     mocks.fetchParLoginHint.mockResolvedValue('previous@example.com')
     mocks.resolveLoginHint.mockResolvedValue('previous@example.com')
 
     const url =
       app.baseUrl +
-      '/oauth/authorize?request_uri=urn:ietf:params:oauth:request_uri:promptlogin' +
+      '/oauth/authorize?request_uri=urn:ietf:params:oauth:request_uri:rebind' +
       '&client_id=' +
       encodeURIComponent('https://app.example.com') +
-      '&login_hint=previous%40example.com' +
+      '&prompt=login' +
+      '&epds_skip_par_hint=1'
+    const res = await fetch(url)
+    expect(res.status).toBe(200)
+    const html = await res.text()
+
+    // PAR hint resolution is skipped: fetchParLoginHint must NOT be called.
+    expect(mocks.fetchParLoginHint).not.toHaveBeenCalled()
+    // Email step rendered, OTP step not active, input empty.
+    expect(html).toMatch(/<div id="step-email" class="step-email">/)
+    expect(html).not.toMatch(/class="step-otp active"/)
+    expect(html).toMatch(/<input type="email" id="email"[^>]*value=""[^>]*>/)
+  })
+
+  it('honours PAR login_hint when prompt=login arrives without the skip flag', async () => {
+    // pds-core's auth-ui-guard sign-in-view bounce appends prompt=login
+    // (no epds_skip_par_hint) and expects auth-service to resolve any
+    // PAR login_hint and serve the OTP step. A regression that
+    // conflated prompt=login with the rebind semantics would re-break
+    // the @session-reuse e2e scenario "login_hint narrows to a stale
+    // binding on a multi-account device".
+    mocks.fetchParLoginHint.mockResolvedValue('hinted@example.com')
+    mocks.resolveLoginHint.mockResolvedValue('hinted@example.com')
+
+    const url =
+      app.baseUrl +
+      '/oauth/authorize?request_uri=urn:ietf:params:oauth:request_uri:guardbounce' +
       '&prompt=login'
     const res = await fetch(url)
     expect(res.status).toBe(200)
     const html = await res.text()
 
-    // (1) Email step is the rendered step, not the OTP step.
-    expect(html).toMatch(/<div id="step-email" class="step-email">/)
-    expect(html).not.toMatch(/class="step-otp active"/)
-
-    // (2) Email input is empty (no pre-fill from the previous account).
-    expect(html).toMatch(/<input type="email" id="email"[^>]*value=""[^>]*>/)
-  })
-
-  it('skips internal-API round trips when prompt=login is present', async () => {
-    mocks.fetchParLoginHint.mockResolvedValue('previous@example.com')
-    mocks.resolveLoginHint.mockResolvedValue('previous@example.com')
-    // Make the assertion meaningful for fetchDeviceAccountEmails by sending
-    // a dev-id/ses-id cookie pair: the handler only fetches device-bound
-    // emails when BOTH a cookie pair is present AND `resolvedEmail` is
-    // truthy. Without the cookie pair, the assertion would pass trivially
-    // even if a regression reintroduced hint resolution.
-    const url =
-      app.baseUrl +
-      '/oauth/authorize?request_uri=urn:ietf:params:oauth:request_uri:promptloginskip' +
-      '&login_hint=previous%40example.com' +
-      '&prompt=login'
-    const res = await fetch(url, {
-      headers: {
-        cookie:
-          'dev-id=dev-test-skip-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; ses-id=ses-test-skip-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-      },
-    })
-    expect(res.status).toBe(200)
-
-    // The hint resolution chain must be untouched — its result is unused
-    // on the prompt=login path AND shouldReuseSession bypasses the hint
-    // check, so calling these is pure overhead on the PDS internal API.
-    // With cookies present, a regression that left fetchDeviceAccountEmails
-    // unguarded by forceLogin would call it; this assertion catches that.
-    expect(mocks.fetchParLoginHint).not.toHaveBeenCalled()
-    expect(mocks.resolveLoginHint).not.toHaveBeenCalled()
-    expect(mocks.fetchDeviceAccountEmails).not.toHaveBeenCalled()
+    expect(mocks.fetchParLoginHint).toHaveBeenCalled()
+    expect(mocks.resolveLoginHint).toHaveBeenCalled()
+    expect(html).toMatch(/class="step-otp active"/)
   })
 
   it('still resolves login_hint when prompt=login is absent (regression guard)', async () => {
-    // Without prompt=login, the hint must still be resolved so the OTP
-    // step can pre-fill the email — the optimisation only applies to the
-    // forced-reauth path.
+    // Without prompt=login at all, the hint must resolve normally and
+    // the OTP step pre-fills with the email.
     mocks.resolveLoginHint.mockResolvedValue('user@example.com')
 
     const url =
@@ -224,7 +216,7 @@ describe('GET /oauth/authorize prompt=login handling (issue #138)', () => {
       expect.any(String),
       expect.any(String),
     )
-    // OTP step is the active step (hasLoginHint true, !forceLogin).
+    // OTP step is the active step (hasLoginHint true).
     expect(html).toMatch(/class="step-otp active"/)
   })
 })

--- a/packages/auth-service/src/__tests__/login-page-prompt-login.test.ts
+++ b/packages/auth-service/src/__tests__/login-page-prompt-login.test.ts
@@ -30,7 +30,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as os from 'node:os'
 import type { AddressInfo } from 'node:net'
-import { EpdsDb, _seedClientMetadataCacheForTest } from '@certified-app/shared'
+import { _seedClientMetadataCacheForTest } from '@certified-app/shared'
 import { csrfProtection } from '../middleware/csrf.js'
 import { createLoginPageRouter } from '../routes/login-page.js'
 import { AuthServiceContext, type AuthServiceConfig } from '../context.js'
@@ -111,7 +111,6 @@ async function startApp(ctx: AuthServiceContext): Promise<{
 }
 
 describe('GET /oauth/authorize prompt=login handling (issue #138)', () => {
-  let db: EpdsDb
   let dbPath: string
   let ctx: AuthServiceContext
   let app: { baseUrl: string; close: () => Promise<void> }
@@ -121,16 +120,16 @@ describe('GET /oauth/authorize prompt=login handling (issue #138)', () => {
       os.tmpdir(),
       `prompt-login-${Date.now()}-${randomBytes(4).toString('hex')}.db`,
     )
-    db = new EpdsDb(dbPath)
     // Avoid an outbound fetch when the handler resolves client metadata.
     _seedClientMetadataCacheForTest('https://app.example.com', {
       client_name: 'Test App',
     })
-    const config = makeConfig(dbPath)
-    ctx = new AuthServiceContext(config)
-    // Replace the constructor-created db (built against the same path) so
-    // the test's seed/inspection share state with the handler.
-    Object.defineProperty(ctx, 'db', { value: db, configurable: true })
+    // AuthServiceContext opens its own EpdsDb against config.dbLocation;
+    // we use ctx.db throughout (rather than constructing a parallel
+    // instance and overwriting) so there's exactly one open SQLite handle
+    // per test — `ctx.destroy()` in afterEach closes it cleanly and
+    // releases the WAL/SHM companion files for the unlink to remove.
+    ctx = new AuthServiceContext(makeConfig(dbPath))
     app = await startApp(ctx)
     mocks.fetchParLoginHint.mockReset()
     mocks.resolveLoginHint.mockReset()
@@ -140,10 +139,12 @@ describe('GET /oauth/authorize prompt=login handling (issue #138)', () => {
   afterEach(async () => {
     await app.close()
     ctx.destroy()
-    try {
-      fs.unlinkSync(dbPath)
-    } catch {
-      /* db may already be gone */
+    // Best-effort cleanup of the temp DB and its WAL/SHM companions.
+    // SQLite in WAL mode writes alongside the main file; rmSync(force)
+    // tolerates the missing companions when WAL was checkpointed before
+    // close, and avoids the empty try/catch antipattern.
+    for (const suffix of ['', '-wal', '-shm']) {
+      fs.rmSync(dbPath + suffix, { force: true })
     }
   })
 

--- a/packages/auth-service/src/__tests__/session-reuse.test.ts
+++ b/packages/auth-service/src/__tests__/session-reuse.test.ts
@@ -180,10 +180,39 @@ describe('isForceLoginPrompt (HYPER-268)', () => {
     expect(isForceLoginPrompt(makeReq())).toBe(false)
   })
 
-  it('returns false when prompt is an array', () => {
+  // OIDC Core 1.0 §3.1.2.1: `prompt` is a space-delimited list. The
+  // single-token cases above must continue to work, AND multi-token /
+  // repeated-key forms that include `login` must also be honoured —
+  // otherwise a client passing `prompt=login consent` (or two `prompt=`
+  // query keys) would re-trigger #138 even after the per-step gate
+  // landed.
+  it('returns true when prompt is a space-delimited list containing login', () => {
+    expect(
+      isForceLoginPrompt(makeReq({ query: { prompt: 'login consent' } })),
+    ).toBe(true)
+    expect(
+      isForceLoginPrompt(makeReq({ query: { prompt: 'consent login' } })),
+    ).toBe(true)
+  })
+
+  it('returns true when prompt is an array containing login', () => {
+    // Express's req.query parser surfaces repeated query keys as arrays:
+    // `?prompt=login&prompt=consent` becomes `['login', 'consent']`.
     expect(isForceLoginPrompt(makeReq({ query: { prompt: ['login'] } }))).toBe(
-      false,
+      true,
     )
+    expect(
+      isForceLoginPrompt(makeReq({ query: { prompt: ['consent', 'login'] } })),
+    ).toBe(true)
+  })
+
+  it('returns false when prompt is a list of other tokens', () => {
+    expect(
+      isForceLoginPrompt(makeReq({ query: { prompt: 'consent none' } })),
+    ).toBe(false)
+    expect(
+      isForceLoginPrompt(makeReq({ query: { prompt: ['consent', 'none'] } })),
+    ).toBe(false)
   })
 })
 

--- a/packages/auth-service/src/context.ts
+++ b/packages/auth-service/src/context.ts
@@ -51,14 +51,18 @@ export class AuthServiceContext {
   public readonly db: EpdsDb
   public readonly emailSender: EmailSender
   public readonly config: AuthServiceConfig
+  private readonly cleanupInterval: ReturnType<typeof setInterval>
 
   constructor(config: AuthServiceConfig) {
     this.config = config
     this.db = new EpdsDb(config.dbLocation)
     this.emailSender = new EmailSender(config.email, config.trustedClients)
 
-    // Cleanup expired tokens every 5 minutes
-    setInterval(
+    // Cleanup expired tokens every 5 minutes. unref() so a process that
+    // owns this context (e.g. a vitest worker constructing a context per
+    // test) isn't held alive by the timer alone — destroy() still
+    // explicitly clears it for prompt teardown of the cleanup callback.
+    this.cleanupInterval = setInterval(
       () => {
         const flows = this.db.cleanupExpiredAuthFlows()
         if (flows > 0) {
@@ -69,9 +73,11 @@ export class AuthServiceContext {
       },
       5 * 60 * 1000,
     )
+    this.cleanupInterval.unref()
   }
 
   destroy(): void {
+    clearInterval(this.cleanupInterval)
     this.db.close()
   }
 }

--- a/packages/auth-service/src/lib/session-reuse.ts
+++ b/packages/auth-service/src/lib/session-reuse.ts
@@ -10,6 +10,7 @@
  * then either auto-selects a matching session (flow 1 with login_hint)
  * or renders the account chooser (flow 2).
  */
+import { promptHasLogin } from '@certified-app/shared'
 
 /** Shape of the request data the helpers consume. Intentionally narrow
  *  so we can unit-test without an Express instance. Mirrors the fields
@@ -117,10 +118,15 @@ export function hasOrphanDeviceCookie(req: SessionReuseRequest): {
  *  #AuthRequest): "The Authorization Server SHOULD prompt the End-User
  *  for reauthentication". The capture-phase rebind of upstream's
  *  "Another account" button injected into the chooser in pds-core uses
- *  this to opt out of session reuse. */
+ *  this to opt out of session reuse.
+ *
+ *  Delegates to the shared `promptHasLogin` so this check matches
+ *  pds-core's auth-ui-guard exactly: both the space-delimited token
+ *  case (`prompt=login consent`) and the array-of-strings case that
+ *  Express produces from repeated query keys (`?prompt=login&prompt=consent`)
+ *  are honoured. */
 export function isForceLoginPrompt(req: SessionReuseRequest): boolean {
-  const p = req.query.prompt
-  return typeof p === 'string' && p === 'login'
+  return promptHasLogin(req.query.prompt)
 }
 
 /** Optional context for the hint-vs-bindings check that gates Flow 1

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -173,6 +173,15 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
       query: req.query as Record<string, unknown>,
     }
 
+    // GitHub issue #138: prompt=login is the user's explicit "start fresh"
+    // signal — emitted by pds-core's "Another account" rebind injected into
+    // the chooser. On this path the resolved hint is never used for
+    // rendering (initialStep is forced to email and the prefill is
+    // suppressed) and shouldReuseSession bypasses its hint check, so the
+    // PAR/handle/device-account internal API round trips below would all be
+    // pure overhead. Compute it here so they can be skipped.
+    const forceLogin = isForceLoginPrompt(sessionReuseReq)
+
     // Resolve the login_hint up-front so we can decide whether the
     // device session is a match before redirecting to pds-core. The
     // resolution result is also reused below for the email/OTP form.
@@ -183,25 +192,27 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
     const internalSecret = process.env.EPDS_INTERNAL_SECRET ?? ''
 
     let effectiveLoginHint = loginHint ?? null
-    if (!effectiveLoginHint && requestUri) {
+    if (!forceLogin && !effectiveLoginHint && requestUri) {
       effectiveLoginHint = await fetchParLoginHint(
         pdsInternalUrl,
         requestUri,
         internalSecret,
       )
     }
-    const resolvedEmail = effectiveLoginHint
-      ? await resolveLoginHint(
-          effectiveLoginHint,
-          pdsInternalUrl,
-          internalSecret,
-        )
-      : null
+    const resolvedEmail =
+      !forceLogin && effectiveLoginHint
+        ? await resolveLoginHint(
+            effectiveLoginHint,
+            pdsInternalUrl,
+            internalSecret,
+          )
+        : null
 
     // Only fetch device-bound emails when we actually need them: the
     // cookie pair is present AND a hint resolved. Otherwise the existing
     // cookie-only reuse logic stands and the round trip to pds-core is
-    // pure overhead.
+    // pure overhead. forceLogin already short-circuited resolvedEmail to
+    // null, so the cookie-only branch covers the prompt=login path here.
     let deviceBoundEmails: string[] | null | undefined
     const cookiePair = readDeviceSessionCookies(sessionReuseReq)
     if (resolvedEmail && cookiePair) {
@@ -369,23 +380,16 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
     //   c) Only in the stored PAR request (third-party apps that put the
     //      handle in the PAR body but don't duplicate it on the redirect URL)
     // The hint was already resolved above for the session-reuse decision; we
-    // reuse `resolvedEmail` here rather than re-fetching.
-    //
-    // GitHub issue #138: prompt=login is the user's explicit "start fresh"
-    // signal — emitted by pds-core's "Another account" rebind injected into
-    // the chooser. The rebind preserves the original login_hint on the URL
-    // (so the OAuth flow can resume cleanly afterwards), but the user has
-    // just told us they want to sign in as a different account, so we must
-    // surface the email form regardless of the hint.
+    // reuse `resolvedEmail` here rather than re-fetching. On prompt=login
+    // (issue #138) `resolvedEmail` is forced to null up front so hasLoginHint
+    // is false and the email step always wins.
     const hasLoginHint = !!resolvedEmail
-    const forceLogin = isForceLoginPrompt(sessionReuseReq)
-    const initialStep = hasLoginHint && !forceLogin ? 'otp' : 'email'
+    const initialStep = hasLoginHint ? 'otp' : 'email'
 
     // Pillar 3 — Idempotency (Option A): when this is a duplicate GET for an
     // existing flow (e.g. browser extension, StayFocusd), tell the client-side
-    // script that OTP was already sent so it skips the auto-send. Skipped on
-    // prompt=login: a forced re-auth must always re-send.
-    const otpAlreadySent = hasLoginHint && !forceLogin && !!existingFlow
+    // script that OTP was already sent so it skips the auto-send.
+    const otpAlreadySent = hasLoginHint && !!existingFlow
 
     logger.info(
       {
@@ -401,9 +405,9 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
 
     // Use the resolved email (not the raw loginHint) for pre-filling forms.
     // This ensures handle-based hints get resolved to the correct email.
-    // On prompt=login the user is opting out of the hinted account (issue
-    // #138), so suppress the pre-fill and start with an empty email box.
-    const emailHint = forceLogin ? '' : (resolvedEmail ?? '')
+    // resolvedEmail is already null on the prompt=login path (issue #138),
+    // so the email box starts empty for "Another account".
+    const emailHint = resolvedEmail ?? ''
 
     res.type('html').send(
       renderLoginPage({

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -58,6 +58,7 @@ import {
   buildPdsAuthorizeRedirect,
   deriveSharedCookieDomain,
   hasOrphanDeviceCookie,
+  isForceLoginPrompt,
   readDeviceSessionCookies,
   shouldReuseSession,
 } from '../lib/session-reuse.js'
@@ -369,13 +370,22 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
     //      handle in the PAR body but don't duplicate it on the redirect URL)
     // The hint was already resolved above for the session-reuse decision; we
     // reuse `resolvedEmail` here rather than re-fetching.
+    //
+    // GitHub issue #138: prompt=login is the user's explicit "start fresh"
+    // signal — emitted by pds-core's "Another account" rebind injected into
+    // the chooser. The rebind preserves the original login_hint on the URL
+    // (so the OAuth flow can resume cleanly afterwards), but the user has
+    // just told us they want to sign in as a different account, so we must
+    // surface the email form regardless of the hint.
     const hasLoginHint = !!resolvedEmail
-    const initialStep = hasLoginHint ? 'otp' : 'email'
+    const forceLogin = isForceLoginPrompt(sessionReuseReq)
+    const initialStep = hasLoginHint && !forceLogin ? 'otp' : 'email'
 
     // Pillar 3 — Idempotency (Option A): when this is a duplicate GET for an
     // existing flow (e.g. browser extension, StayFocusd), tell the client-side
-    // script that OTP was already sent so it skips the auto-send.
-    const otpAlreadySent = hasLoginHint && !!existingFlow
+    // script that OTP was already sent so it skips the auto-send. Skipped on
+    // prompt=login: a forced re-auth must always re-send.
+    const otpAlreadySent = hasLoginHint && !forceLogin && !!existingFlow
 
     logger.info(
       {
@@ -391,7 +401,9 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
 
     // Use the resolved email (not the raw loginHint) for pre-filling forms.
     // This ensures handle-based hints get resolved to the correct email.
-    const emailHint = resolvedEmail ?? ''
+    // On prompt=login the user is opting out of the hinted account (issue
+    // #138), so suppress the pre-fill and start with an empty email box.
+    const emailHint = forceLogin ? '' : (resolvedEmail ?? '')
 
     res.type('html').send(
       renderLoginPage({

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -58,7 +58,6 @@ import {
   buildPdsAuthorizeRedirect,
   deriveSharedCookieDomain,
   hasOrphanDeviceCookie,
-  isForceLoginPrompt,
   readDeviceSessionCookies,
   shouldReuseSession,
 } from '../lib/session-reuse.js'
@@ -173,18 +172,19 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
       query: req.query as Record<string, unknown>,
     }
 
-    // GitHub issue #138: prompt=login is the user's explicit "start fresh"
-    // signal — emitted by pds-core's "Another account" rebind injected into
-    // the chooser. On this path the resolved hint is never used for
-    // rendering (initialStep is forced to email and the prefill is
-    // suppressed) and shouldReuseSession bypasses its hint check, so the
-    // PAR/handle/device-account internal API round trips below would all be
-    // pure overhead. Compute it here so they can be skipped.
-    const forceLogin = isForceLoginPrompt(sessionReuseReq)
-
     // Resolve the login_hint up-front so we can decide whether the
     // device session is a match before redirecting to pds-core. The
     // resolution result is also reused below for the email/OTP form.
+    //
+    // pds-core's "Another account" rebind sets epds_skip_par_hint=1
+    // (issue #138) — the user clicked an opt-out, so any login_hint
+    // stored in the PAR by the RP at OAuth init must be ignored. The
+    // rebind also strips URL login_hint, so on that path effectiveLoginHint
+    // ends up null and the spec-correct decision below renders the email
+    // form. This skip flag does NOT affect prompt=login alone: pds-core's
+    // sign-in-view bounce also sets prompt=login (without the skip flag)
+    // and expects the hint to resolve normally so the OTP step renders.
+    const skipParHint = req.query.epds_skip_par_hint === '1'
     const pdsInternalUrl = ensurePdsUrl(
       process.env.PDS_INTERNAL_URL,
       ctx.config.pdsPublicUrl,
@@ -192,27 +192,25 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
     const internalSecret = process.env.EPDS_INTERNAL_SECRET ?? ''
 
     let effectiveLoginHint = loginHint ?? null
-    if (!forceLogin && !effectiveLoginHint && requestUri) {
+    if (!skipParHint && !effectiveLoginHint && requestUri) {
       effectiveLoginHint = await fetchParLoginHint(
         pdsInternalUrl,
         requestUri,
         internalSecret,
       )
     }
-    const resolvedEmail =
-      !forceLogin && effectiveLoginHint
-        ? await resolveLoginHint(
-            effectiveLoginHint,
-            pdsInternalUrl,
-            internalSecret,
-          )
-        : null
+    const resolvedEmail = effectiveLoginHint
+      ? await resolveLoginHint(
+          effectiveLoginHint,
+          pdsInternalUrl,
+          internalSecret,
+        )
+      : null
 
     // Only fetch device-bound emails when we actually need them: the
     // cookie pair is present AND a hint resolved. Otherwise the existing
     // cookie-only reuse logic stands and the round trip to pds-core is
-    // pure overhead. forceLogin already short-circuited resolvedEmail to
-    // null, so the cookie-only branch covers the prompt=login path here.
+    // pure overhead.
     let deviceBoundEmails: string[] | null | undefined
     const cookiePair = readDeviceSessionCookies(sessionReuseReq)
     if (resolvedEmail && cookiePair) {
@@ -380,9 +378,10 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
     //   c) Only in the stored PAR request (third-party apps that put the
     //      handle in the PAR body but don't duplicate it on the redirect URL)
     // The hint was already resolved above for the session-reuse decision; we
-    // reuse `resolvedEmail` here rather than re-fetching. On prompt=login
-    // (issue #138) `resolvedEmail` is forced to null up front so hasLoginHint
-    // is false and the email step always wins.
+    // reuse `resolvedEmail` here rather than re-fetching. On the "Another
+    // account" rebind path (issue #138) `epds_skip_par_hint=1` upstream
+    // suppresses both URL and PAR hint resolution, so resolvedEmail is null
+    // and the email step falls out without a special case here.
     const hasLoginHint = !!resolvedEmail
     const initialStep = hasLoginHint ? 'otp' : 'email'
 
@@ -405,8 +404,6 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
 
     // Use the resolved email (not the raw loginHint) for pre-filling forms.
     // This ensures handle-based hints get resolved to the correct email.
-    // resolvedEmail is already null on the prompt=login path (issue #138),
-    // so the email box starts empty for "Another account".
     const emailHint = resolvedEmail ?? ''
 
     res.type('html').send(

--- a/packages/pds-core/src/auth-ui-guard.ts
+++ b/packages/pds-core/src/auth-ui-guard.ts
@@ -41,7 +41,24 @@ import {
   SESSION_ID_PREFIX,
 } from '@atproto/oauth-provider'
 import type { Logger } from 'pino'
+import {
+  parsePromptTokens as parsePromptTokensShared,
+  promptHasLogin as promptHasLoginShared,
+} from '@certified-app/shared'
 import { loadDeviceBindings } from './lib/device-accounts.js'
+
+/** Re-export of the shared implementation. The canonical home is
+ *  `@certified-app/shared`; this re-export exists so internal callers
+ *  in pds-core (and the existing `auth-ui-guard.test.ts` import site)
+ *  don't have to be touched on every refactor. New callers should
+ *  import from `@certified-app/shared` directly. */
+export const parsePromptTokens = parsePromptTokensShared
+/** Re-export of the shared implementation. The canonical home is
+ *  `@certified-app/shared`; this re-export exists so internal callers
+ *  in pds-core (and the existing `auth-ui-guard.test.ts` import site)
+ *  don't have to be touched on every refactor. New callers should
+ *  import from `@certified-app/shared` directly. */
+export const promptHasLogin = promptHasLoginShared
 
 const DEVICE_ID_RE = new RegExp(
   `^${DEVICE_ID_PREFIX}[0-9a-f]{${DEVICE_ID_BYTES_LENGTH * 2}}$`,
@@ -367,22 +384,4 @@ function filterCandidateBindings(
       account.sub === loginHint || account.preferred_username === loginHint,
   )
   return matched.length === 1 ? matched : bindings
-}
-
-/** Tokenise an OIDC `prompt` parameter value into its space-delimited set.
- *  Per OpenID Connect Core 1.0 §3.1.2.1, `prompt` is a space-delimited list
- *  of values (e.g. `"login consent"`), not a single literal — so an exact
- *  string check would miss `login` when it appears alongside other tokens.
- *  Returns an empty Set for null/undefined/non-string input. */
-export function parsePromptTokens(value: unknown): Set<string> {
-  if (typeof value !== 'string') return new Set()
-  return new Set(value.split(/\s+/).filter(Boolean))
-}
-
-/** True when the given OIDC prompt value contains the `login` token. Both
- *  the auth-ui-guard and epds-callback's PAR mutation use this — they must
- *  agree on what counts as "forced login" so the guard's bounce condition
- *  and the callback's prompt-strip apply to exactly the same requests. */
-export function promptHasLogin(value: unknown): boolean {
-  return parsePromptTokens(value).has('login')
 }

--- a/packages/pds-core/src/chooser-enrichment.ts
+++ b/packages/pds-core/src/chooser-enrichment.ts
@@ -109,6 +109,14 @@ export function buildChooserEnrichmentScript(): string {
   // request_uri / client_id / scope etc. so the OAuth flow resumes
   // after the new account signs in.
   //
+  // Adds epds_skip_par_hint=1 — an ePDS-private signal that tells
+  // auth-service "ignore the login_hint stored in the PAR for this
+  // request" (issue #138). The user clicked "Another account", so
+  // they're overriding any hint the RP supplied at OAuth init: with
+  // no hint resolved, the spec-correct rendering decision is the
+  // email form. URL login_hint is also dropped; the PAR-body hint
+  // can't be mutated from here, hence the explicit skip flag.
+  //
   // Returns '' when there is no request_uri in the current URL
   // (standalone /account navigation, bookmark, direct URL) — auth-service
   // rejects /oauth/authorize without request_uri with a 400, so letting
@@ -118,6 +126,8 @@ export function buildChooserEnrichmentScript(): string {
     var params = new URLSearchParams(window.location.search || '');
     if (!params.has('request_uri')) return '';
     params.set('prompt', 'login');
+    params.set('epds_skip_par_hint', '1');
+    params.delete('login_hint');
     return authOrigin + '/oauth/authorize?' + params.toString();
   }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -71,6 +71,7 @@ export type {
   PreviewCheck,
   PreviewValidationResult,
 } from './preview-validation.js'
+export { parsePromptTokens, promptHasLogin } from './oidc-prompt.js'
 export { getEpdsVersion } from './version.js'
 export { makeSafeFetch } from './safe-fetch.js'
 export type { SafeFetchOptions } from './safe-fetch.js'

--- a/packages/shared/src/oidc-prompt.ts
+++ b/packages/shared/src/oidc-prompt.ts
@@ -1,0 +1,44 @@
+/**
+ * Helpers for parsing the OIDC `prompt` parameter.
+ *
+ * Per OpenID Connect Core 1.0 §3.1.2.1, `prompt` is a space-delimited
+ * list of values (e.g. `"login consent"`), not a single literal. An
+ * exact string check (`p === 'login'`) misses every multi-token value
+ * that includes `login`. Both pds-core's auth-ui-guard and
+ * auth-service's session-reuse layer must agree on what counts as
+ * "the client asked for forced re-authentication", so the parsing
+ * lives here in shared rather than being duplicated per package.
+ *
+ * Express's `req.query` parser also surfaces repeated query keys as
+ * arrays (`?prompt=login&prompt=consent` → `['login', 'consent']`), so
+ * we accept both string and string-array shapes.
+ */
+
+/** Tokenise an OIDC `prompt` parameter value into its space-delimited
+ *  set. Returns an empty Set for null/undefined/non-string-or-array
+ *  input. Array shapes (from repeated query keys) are joined with a
+ *  space before tokenising so `?prompt=login&prompt=consent` produces
+ *  the same set as `prompt=login%20consent`. */
+export function parsePromptTokens(value: unknown): Set<string> {
+  let raw: string
+  if (typeof value === 'string') {
+    raw = value
+  } else if (
+    Array.isArray(value) &&
+    value.every((v): v is string => typeof v === 'string')
+  ) {
+    raw = value.join(' ')
+  } else {
+    return new Set()
+  }
+  return new Set(raw.split(/\s+/).filter(Boolean))
+}
+
+/** True when the given OIDC prompt value contains the `login` token.
+ *  Both the auth-ui-guard and the auth-service login-page route use
+ *  this — they must agree on what counts as "forced login" so the
+ *  guard's bounce condition and the auth-service's session-reuse /
+ *  initial-step decisions apply to exactly the same requests. */
+export function promptHasLogin(value: unknown): boolean {
+  return parsePromptTokens(value).has('login')
+}


### PR DESCRIPTION
## Summary

- Fixes #138 — clicking "Another account" on the chooser now reliably reaches the email entry form, instead of the OTP form for the previous account, even when the OAuth flow that reached the chooser carried a `login_hint`.
- Adds a new in-band signal (`epds_skip_par_hint=1`) set by `pds-core`'s "Another account" rebind, so `auth-service` knows to ignore any PAR-stored `login_hint` on that specific path. `prompt=login` alone keeps its existing semantics (used by the auth-ui-guard's sign-in-view bounce, where the hint must still resolve and the OTP step must still render).
- Hardens `isForceLoginPrompt()` to handle space-delimited (`prompt=login consent`) and array (`prompt=['login']`) forms via a shared `oidc-prompt` module, lifted from pds-core's existing `parsePromptTokens` so both packages consume the same canonical implementation.
- Adds an E2E repro under `features/session-reuse-bugs.feature` (verified failing pre-fix, passing post-fix) plus route-level unit tests pinning the two distinguishable cases.

## Why

`pds-core/chooser-enrichment.ts`'s "Another account" rebind navigates back to `auth-service/oauth/authorize`, preserving the OAuth request_uri so the flow can resume after the new sign-in. The pre-fix rebind only appended `prompt=login`. That worked for `shouldReuseSession()` (which honoured `prompt=login` to skip the chooser redirect) but the login-page handler still resolved the original PAR-body `login_hint`, set `initialStep='otp'` and pre-filled with the previous account's email — exactly the bug from issue #138.

A first-cut fix gated `initialStep` / `otpAlreadySent` / email-prefill on `isForceLoginPrompt(req)`. Local e2e revealed that broke the `@session-reuse` scenario "login_hint narrows to a stale binding on a multi-account device": `pds-core`'s auth-ui-guard sign-in-view bounce ALSO appends `prompt=login` (to defeat session reuse) while still relying on the PAR-body `login_hint` resolving so the OTP step renders. The two paths needed disambiguating.

## Fix

**Two distinct signals, two distinct meanings:**

- `prompt=login` (OIDC standard, kept verbatim) — bypass session reuse. Set by both the chooser's "Another account" rebind AND the auth-ui-guard's sign-in-view bounce.
- `epds_skip_par_hint=1` (new, ePDS-private) — ignore any `login_hint` stored in the PAR for this request. Set ONLY by the chooser's "Another account" rebind.

In `auth-service`'s `/oauth/authorize` handler, `fetchParLoginHint` is gated on the absence of `epds_skip_par_hint=1`. With the PAR hint suppressed and the URL `login_hint` already stripped by the rebind, `resolvedEmail` ends up null on the "Another account" path and the spec-correct rendering decision (`hasLoginHint` → `initialStep`) drops out: email form for issue #138, OTP form for the auth-ui-guard bounce. No `forceEmailForm` override needed.

`isForceLoginPrompt()` now delegates to a shared `promptHasLogin()` in `@certified-app/shared`, which correctly handles the OIDC space-delimited list shape and Express's array-of-strings shape from repeated query keys. The auth-ui-guard's existing `parsePromptTokens` was lifted to the shared module to keep one canonical implementation.

## Test plan

- [x] New E2E scenario `"Another account" with login_hint must reach the email form` in `features/session-reuse-bugs.feature` — fails pre-fix, passes post-fix; tightened with `email input is empty` and `OTP verification step is not active` assertions.
- [x] Sibling scenarios still pass: `"Another account" on the chooser goes to the email form` (no-hint path), `Signed-in user can sign in as a different account from the chooser`, `Login hint matches a bound account — chooser still wins`, and crucially `login_hint narrows to a stale binding on a multi-account device` (pinned the case-B regression).
- [x] PR #128's PAR-callback scenario `Expired PAR shows a styled HTML page instead of leaking JSON` still passes locally.
- [x] Route-level unit tests in `packages/auth-service/src/__tests__/login-page-prompt-login.test.ts` pin: "rebind path renders email step with empty input AND skips fetchParLoginHint" + "prompt=login without skip flag still resolves the PAR hint and serves OTP" + "no prompt=login still resolves hint normally". Verified by local sabotage.
- [x] `session-reuse.test.ts` extended for space-delimited + array `prompt` shapes.
- [x] Local: `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test` (897/897), full local e2e in 3 phases (issue #138 scenarios, PR #128 PAR scenario, full session-reuse profile 20/20).
- [ ] Manual smoke against the deployed preview after CI lights up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Another account" reliably opens a fresh email entry (no leftover prefilled email or immediate OTP) and skips PAR-derived hints when requested.
  * OIDC prompt=login is correctly recognized across repeated and space-delimited forms, ensuring a true fresh sign-in.