### PR TITLE
docs(demo): flag EPDS_CLIENT_THEME as required for client-branding e2e

### DIFF
--- a/packages/demo/.env.example
+++ b/packages/demo/.env.example
@@ -48,6 +48,12 @@ AUTH_ENDPOINT=https://auth.pds.example/oauth/authorize
 # light look, and client-metadata.json ships no branding CSS — the
 # auth-service then renders its default Certified styling. Available
 # presets: ocean, amber.
+#
+# Required (uncomment) to run the @client-branding e2e feature locally:
+# the suite asserts that auth-service inlines the demo's branding CSS,
+# which only happens when client-metadata.json advertises one. Without
+# it, every scenario in features/client-branding.feature fails with
+# "expect(html).toContain('body { background: #1a1208')" mismatches.
 # EPDS_CLIENT_THEME=amber
 
 # Session signing secret (generate with: openssl rand -base64 32)


### PR DESCRIPTION
## Summary

Small doc-only follow-up to PR #141. While running the full e2e suite locally on a fresh worktree at the tail of that PR, all 8 `@client-branding` scenarios failed with mismatches like:

```
expect(html).toContain('body { background: #1a1208')
```

Root cause: `packages/demo/.env.example` already documented `EPDS_CLIENT_THEME=amber` but as a commented-out optional. Without it, the demo's `client-metadata.json` ships no `branding.css`, so auth-service has no theme CSS to inline, so the suite's CSS-injection assertions fail. CI's Railway preview env presumably sets it via Railway service config; locally there's nothing to suggest you need to.

## Change

Add a "Required (uncomment) to run the @client-branding e2e feature locally" note next to the existing `EPDS_CLIENT_THEME=amber` block, with the exact assertion-mismatch message a future contributor would see.

## Test plan

- [x] Confirmed locally: with `EPDS_CLIENT_THEME=amber` set in `packages/demo/.env`, the failing scenarios pass.
- [x] No code changes; doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment setup documentation with instructions for enabling end-to-end tests for branding features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->