### PR TITLE
docs(demo): tighten EPDS_CLIENT_THEME e2e note per PR #145 review

### DIFF
--- a/packages/demo/.env.example
+++ b/packages/demo/.env.example
@@ -49,11 +49,12 @@ AUTH_ENDPOINT=https://auth.pds.example/oauth/authorize
 # auth-service then renders its default Certified styling. Available
 # presets: ocean, amber.
 #
-# Required (uncomment) to run the @client-branding e2e feature locally:
-# the suite asserts that auth-service inlines the demo's branding CSS,
-# which only happens when client-metadata.json advertises one. Without
-# it, every scenario in features/client-branding.feature fails with
-# "expect(html).toContain('body { background: #1a1208')" mismatches.
+# Required (uncomment) to run the client-branding e2e feature locally
+# (see features/client-branding.feature): the suite asserts that
+# auth-service inlines the demo's branding CSS, which only happens
+# when client-metadata.json advertises one. Without it, the scenarios
+# in that feature file fail with playwright errors containing
+# `Expected substring: "body { background: #1a1208"`.
 # EPDS_CLIENT_THEME=amber
 
 # Session signing secret (generate with: openssl rand -base64 32)


### PR DESCRIPTION
## Summary

Two cosmetic fixes to the `EPDS_CLIENT_THEME` note added in PR #145, raised by review bots after that PR had already merged. Doc-only.

- **copilot:** the note referenced an `@client-branding` tag, but no such tag exists in the repo. `features/client-branding.feature` scenarios use `@untrusted-client` and `@pending` only. Reworded to "the client-branding e2e feature locally (see features/client-branding.feature)" so a contributor can find it directly.
- **coderabbit:** the quoted `expect(html).toContain('body { background: \`#1a1208\`')` snippet had quote/paren mismatch and wouldn't match a real failure log anyway. Replaced with the actual playwright error substring: `Expected substring: "body { background: #1a1208"` — what a contributor actually sees and would grep for.

## Test plan

- [x] No code changes; doc-only.
- [x] Verified `features/client-branding.feature` carries no `@client-branding` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration documentation with corrected feature references and improved test error message examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->