### PR TITLE
chore(changeset): downgrade slow-signin fixes from minor to patch

### DIFF
--- a/.changeset/clean-exit-on-expired-signin.md
+++ b/.changeset/clean-exit-on-expired-signin.md
@@ -1,5 +1,5 @@
 ---
-'ePDS': minor
+'ePDS': patch
 ---
 
 Sign-in pages no longer strand users on a "session expired" dead end, and Resend no longer offers codes that won't work.

--- a/.changeset/par-heartbeat-keeps-slow-signins-alive.md
+++ b/.changeset/par-heartbeat-keeps-slow-signins-alive.md
@@ -1,5 +1,5 @@
 ---
-'ePDS': minor
+'ePDS': patch
 ---
 
 Slow sign-ins are less likely to time out before you finish entering your code.


### PR DESCRIPTION
## Summary

- Both `par-heartbeat-keeps-slow-signins-alive` and `clean-exit-on-expired-signin` were authored on `feat:` commits and got `minor` bumps by reflex. Re-reading them against the bump-type guide in `docs/PUBLISHING.md`, both are user-observable bug fixes rather than additive features.
- The PAR heartbeat is internal mechanism (a `/auth/ping` route + a browser interval) introduced solely to stop a 5-minute upstream `AUTHORIZATION_INACTIVITY_TIMEOUT` from kicking out users who are reading their inbox at human speed. No new env var, no client metadata field, no operator surface — the "feature" is invisible. Visible effect is just "slow sign-ins no longer time out".
- The clean-exit work removes a UX dead-end (broken Resend offer, no way back to the OAuth client) on already-failed sign-ins. Users gain no new capability — they just stop hitting a wall.
- Flip both frontmatter entries to `patch`.

## Test plan

- [ ] Confirm the resulting bump on the next Release PR is `patch` (i.e. `0.6.1` → `0.6.2`), not `minor`.
- [ ] Confirm `scripts/changelog-audience-summary.mjs` still generates the "Who should read this release" block — neither file changed structurally, only the frontmatter `ePDS:` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)