### PR TITLE
ci(e2e): skip the run job on the changesets Release PR

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,7 +72,18 @@ jobs:
     #
     # `always()` is needed because `gate` is skipped on non-PR
     # events, and GitHub would otherwise cascade-skip this job.
-    if: always() && (needs.gate.outputs.relevant == 'true' || github.event_name != 'pull_request')
+    #
+    # Skip the changesets/action "Version Packages" PR (head ref
+    # `changeset-release/main`): no Railway preview is provisioned
+    # for that bot-generated branch, so the "Find Railway preview
+    # deployment" step would always fail with "No Railway
+    # deployments exist for PR #N preview at all". A skipped *job*
+    # still reports conclusion=skipped to branch protection, which
+    # is treated as passing — same pattern as the `gate` job above.
+    if: >-
+      always() &&
+      github.event.pull_request.head.ref != 'changeset-release/main' &&
+      (needs.gate.outputs.relevant == 'true' || github.event_name != 'pull_request')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Summary

- The changesets/action "Version Packages" PR (head ref `changeset-release/main`) is bot-generated; Railway is not configured to spin up a preview for it. The e2e workflow's "Find Railway preview deployment" step then fails fast with `No Railway deployments exist for PR #N preview at all`, so the Release PR carries a spurious red `e2e-tests / run` check that has no useful signal — there is no preview to point e2e at, by design.
- Skip the `run` job when the PR head ref is `changeset-release/main`. Same pattern already used by the `gate` job: a skipped *job* still reports `conclusion=skipped` to branch protection, which is treated as passing.
- Phase 2 of the new auto-tag flow (PR #159) should keep e2e green on Release PRs once this lands; without it, every future Release PR would carry a red e2e check until merged.

## Test plan

- [ ] On the next Release PR (head ref `changeset-release/main`), confirm `e2e-tests / run` reports `conclusion=skipped` rather than failing on the Railway lookup.
- [ ] On a normal feature PR with no Railway changes, confirm `e2e-tests / run` still runs the suite (the existing path-filter / Railway-deploy logic is unchanged).
- [ ] On a normal feature PR that touches only docs, confirm `e2e-tests / run` reports skipped via the existing `gate` filter (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow reliability by refining test execution conditions to prevent unnecessary job failures in automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->