### PR TITLE
ci: report deployments to Linear releases

### DIFF
--- a/.github/workflows/linear-releases.yml
+++ b/.github/workflows/linear-releases.yml
@@ -24,7 +24,7 @@ jobs:
 
       # This reports what reached staging to Linear. Release-note generation
       # stays in the existing Changesets/GitHub Release flow.
-      - uses: linear/linear-release-action@v0.10.0
+      - uses: linear/linear-release-action@0917777589db006387af296dde440385f88d6ac4 # v0.10.0
         with:
           access_key: ${{ secrets.LINEAR_STAGING_ACCESS_KEY }}
           name: staging-${{ github.event.deployment.sha }}
@@ -46,7 +46,7 @@ jobs:
 
       # This reports what reached production to Linear. Release-note generation
       # stays in the existing Changesets/GitHub Release flow.
-      - uses: linear/linear-release-action@v0.10.0
+      - uses: linear/linear-release-action@0917777589db006387af296dde440385f88d6ac4 # v0.10.0
         with:
           access_key: ${{ secrets.LINEAR_PRODUCTION_ACCESS_KEY }}
           name: production-${{ github.event.deployment.sha }}

--- a/.github/workflows/linear-releases.yml
+++ b/.github/workflows/linear-releases.yml
@@ -12,6 +12,7 @@ jobs:
     name: staging
     if: >-
       github.event.deployment_status.state == 'success' &&
+      github.event.deployment.creator.login == 'railway-app[bot]' &&
       github.event.deployment.environment == 'ePDS / pr-base'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
@@ -34,6 +35,7 @@ jobs:
     name: production
     if: >-
       github.event.deployment_status.state == 'success' &&
+      github.event.deployment.creator.login == 'railway-app[bot]' &&
       github.event.deployment.environment == 'ePDS / production'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:

--- a/.github/workflows/linear-releases.yml
+++ b/.github/workflows/linear-releases.yml
@@ -1,0 +1,53 @@
+name: Linear releases
+
+on:
+  deployment_status:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.deployment.environment }}-${{ github.event.deployment.sha }}
+  cancel-in-progress: false
+
+jobs:
+  staging:
+    name: staging
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'ePDS / pr-base'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.deployment.sha }}
+          fetch-depth: 0
+
+      # This reports what reached staging to Linear. Release-note generation
+      # stays in the existing Changesets/GitHub Release flow.
+      - uses: linear/linear-release-action@v0.10.0
+        with:
+          access_key: ${{ secrets.LINEAR_STAGING_ACCESS_KEY }}
+          name: staging-${{ github.event.deployment.sha }}
+          version: staging-${{ github.event.deployment.sha }}
+
+  production:
+    name: production
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'ePDS / production'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.deployment.sha }}
+          fetch-depth: 0
+
+      # This reports what reached production to Linear. Release-note generation
+      # stays in the existing Changesets/GitHub Release flow.
+      - uses: linear/linear-release-action@v0.10.0
+        with:
+          access_key: ${{ secrets.LINEAR_PRODUCTION_ACCESS_KEY }}
+          name: production-${{ github.event.deployment.sha }}
+          version: production-${{ github.event.deployment.sha }}


### PR DESCRIPTION
## Summary
- add a separate deployment_status workflow for Linear Releases
- sync successful Railway pr-base deployments to the staging Linear pipeline
- sync successful Railway production deployments to the production Linear pipeline
- keep existing Changesets/GitHub Release release-note generation unchanged

## Required setup
- create Linear continuous release pipelines for staging and production
- add repository secrets LINEAR_STAGING_ACCESS_KEY and LINEAR_PRODUCTION_ACCESS_KEY with the corresponding Linear pipeline access keys

## Validation
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm test:coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated release tracking that creates Linear releases when staging or production deployments complete. Releases are environment-specific (staging and production), include the deployment identifier in their name/version, and enforce per-deployment concurrency to avoid overlapping release runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/ePDS/pull/171)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->