### PR TITLE
ci: run e2e suite with three Cucumber workers

### DIFF
--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -35,6 +35,10 @@ E2E_MAILPIT_PASS=
 # Set to 'true' to run headless (no visible browser window). Default: false.
 # E2E_HEADLESS=false
 
+# Number of Cucumber worker processes for the default e2e profile.
+# Default: 3. Lower this on constrained local machines; set to 0 or 1 for serial debugging.
+# E2E_PARALLEL=3
+
 # Required only by scenarios tagged @otp-expiry. Must match the
 # deployment's EPDS_INTERNAL_SECRET so the test runner can call the
 # auth-service test hooks (e.g. POST /_internal/test/expire-otp). When

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -68,6 +68,7 @@ For OTP scenarios you also need a local Mailpit instance (see
 | `E2E_MAILPIT_USER`       | No       | `karma`   | Mailpit HTTP basic auth username                                                                                                                        |
 | `E2E_MAILPIT_PASS`       | No       | _(empty)_ | Mailpit HTTP basic auth password. Leave empty to skip OTP scenarios.                                                                                    |
 | `E2E_HEADLESS`           | No       | `false`   | Set to `true` to run without a visible browser window                                                                                                   |
+| `E2E_PARALLEL`           | No       | `3`       | Number of Cucumber worker processes for the default profile. Lower this on constrained local machines; use `0` or `1` for serial debugging.             |
 
 ## Two demo clients
 

--- a/e2e/cucumber.mjs
+++ b/e2e/cucumber.mjs
@@ -49,7 +49,14 @@ const shared = {
   strict: true,
 }
 
-const defaultParallel = Number(process.env.E2E_PARALLEL ?? '3')
+const parsedDefaultParallel = Number.parseInt(
+  process.env.E2E_PARALLEL ?? '3',
+  10,
+)
+const defaultParallel =
+  Number.isFinite(parsedDefaultParallel) && parsedDefaultParallel >= 0
+    ? parsedDefaultParallel
+    : 3
 
 // Cucumber supports the `default: () => ({...})` form to declare multiple
 // profiles including names that aren't valid JS identifiers (e.g. hyphenated).

--- a/e2e/cucumber.mjs
+++ b/e2e/cucumber.mjs
@@ -49,6 +49,8 @@ const shared = {
   strict: true,
 }
 
+const defaultParallel = Number(process.env.E2E_PARALLEL ?? '3')
+
 // Cucumber supports the `default: () => ({...})` form to declare multiple
 // profiles including names that aren't valid JS identifiers (e.g. hyphenated).
 // See @cucumber/cucumber's from_file.ts: handleDefaultFunctionDefinition.
@@ -56,6 +58,7 @@ export default () => ({
   default: {
     ...shared,
     format: ['pretty', 'html:reports/e2e.html', 'junit:reports/e2e.junit.xml'],
+    parallel: defaultParallel,
     tags: defaultTagExclusions.join(' and '),
   },
   'session-reuse': {

--- a/e2e/step-definitions/auth.steps.ts
+++ b/e2e/step-definitions/auth.steps.ts
@@ -466,16 +466,19 @@ When(
       )
     }
 
-    // Backdate the auth_flow row so getAuthFlow() filters it out as
-    // expired. The epds_auth_flow cookie is left alone: keeping it lets
-    // the abort gate's /auth/ping call differentiate "auth_flow expired"
+    // Backdate this scenario's auth_flow row so getAuthFlow() filters
+    // it out as expired. Passing request_uri keeps the test hook safe
+    // when multiple Cucumber workers share one preview database.
+    // The epds_auth_flow cookie is left alone: keeping it lets the
+    // abort gate's /auth/ping call differentiate "auth_flow expired"
     // (cookie present but row gone -> reason: flow_expired) from
     // "no_cookie", which is what discriminates this scenario from
     // unrelated dead-session paths.
+    const requestUri = captureRequestUriFromPage(this)
     const flowResult = await callExpiryHook(
       '/_internal/test/expire-auth-flow',
       this.testEmail,
-      {},
+      { request_uri: requestUri },
     )
     if (flowResult.updated < 1) {
       throw new Error(

--- a/packages/auth-service/src/__tests__/test-hooks.test.ts
+++ b/packages/auth-service/src/__tests__/test-hooks.test.ts
@@ -348,6 +348,33 @@ describe('test-hooks router — expire-auth-flow', () => {
     expect(newExpiresAt!).toBeLessThan(Date.now())
   })
 
+  it('backdates only the matching auth_flow when request_uri is supplied', async () => {
+    const future = Date.now() + 600_000
+    seedAuthFlow(dbPath(), 'flow-a', future)
+    seedAuthFlow(dbPath(), 'flow-b', future + 1_000)
+
+    const app = express()
+    app.use(express.json())
+    app.use(createTestHooksRouter(dbPath()))
+
+    const res = await postExpireAuthFlow(
+      app,
+      {
+        email: 'alice@example.com',
+        request_uri: 'urn:ietf:params:oauth:request_uri:flow-b',
+      },
+      { 'x-internal-secret': 'test-secret-1234' },
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.json.updated).toBe(1)
+
+    expect(readAuthFlowExpiresAt(dbPath(), 'flow-a')!).toBeGreaterThan(
+      Date.now(),
+    )
+    expect(readAuthFlowExpiresAt(dbPath(), 'flow-b')!).toBeLessThan(Date.now())
+  })
+
   it('returns updated=0 when there are no live auth_flow rows', async () => {
     // Schema exists (seeded by another flow that is already expired) but
     // no rows match the WHERE clause expires_at > now.
@@ -372,12 +399,11 @@ describe('test-hooks router — expire-auth-flow', () => {
     expect(oldExpiresAt!).toBeGreaterThan(Date.now() - 120_000)
   })
 
-  it('backdates ALL live auth_flow rows when multiple exist (deterministic)', async () => {
-    // The hook deliberately backdates every live flow, not just "the one
-    // for this email", because the auth_flow.email column is rarely
-    // populated in practice. With multiple concurrent flows in test-only
-    // databases (e.g. retried scenarios) this guarantees the flow under
-    // test is always covered.
+  it('backdates ALL live auth_flow rows when request_uri is omitted (legacy fallback)', async () => {
+    // The fallback deliberately backdates every live flow, not just "the
+    // one for this email", because the auth_flow.email column is rarely
+    // populated in practice. E2E callers should pass request_uri so
+    // parallel workers do not interfere with each other.
     const future = Date.now() + 600_000
     seedAuthFlow(dbPath(), 'flow-a', future)
     seedAuthFlow(dbPath(), 'flow-b', future + 1_000)

--- a/packages/auth-service/src/routes/test-hooks.ts
+++ b/packages/auth-service/src/routes/test-hooks.ts
@@ -44,22 +44,14 @@ export function createTestHooksRouter(dbLocation: string): Router {
         return
       }
 
-      // The auth_flow table currently stores a flow's email only as a
-      // (rarely populated) free-form column rather than something we can
-      // key on, so we deliberately backdate ALL non-expired auth_flow
-      // rows. This is safe because:
-      //   * the hook only runs when EPDS_TEST_HOOKS=1 (never in
-      //     production — see the constructor guard above);
-      //   * the e2e suite drives a single browser context against an
-      //     otherwise quiescent preview env, so "all live flows" is
-      //     effectively the one flow under test;
-      //   * the only effect is to make /auth/complete report
-      //     "Authentication session expired" earlier than the 10-minute
-      //     wall-clock TTL, which is exactly what we want to reproduce.
-      // The {email} body field is still required so callers stay
-      // symmetric with /expire-otp and so server logs record which
-      // scenario triggered the backdate.
+      // Prefer targeting by request_uri so parallel e2e workers do not
+      // expire each other's in-flight auth_flow rows. The {email} body
+      // field is still required so callers stay symmetric with
+      // /expire-otp and so server logs record which scenario triggered
+      // the backdate. If request_uri is omitted, keep the legacy
+      // test-only behaviour of backdating all live rows.
       const email = ((req.body?.email as string) || '').trim().toLowerCase()
+      const requestUri = ((req.body?.request_uri as string) || '').trim()
       if (!email) {
         res.status(400).json({ error: 'Missing email' })
         return
@@ -68,11 +60,24 @@ export function createTestHooksRouter(dbLocation: string): Router {
       const db = new Database(dbLocation)
       try {
         const past = Date.now() - 60 * 60 * 1000
-        const result = db
-          .prepare('UPDATE auth_flow SET expires_at = ? WHERE expires_at > ?')
-          .run(past, Date.now())
+        const now = Date.now()
+        const result = requestUri
+          ? db
+              .prepare(
+                'UPDATE auth_flow SET expires_at = ? WHERE request_uri = ? AND expires_at > ?',
+              )
+              .run(past, requestUri, now)
+          : db
+              .prepare(
+                'UPDATE auth_flow SET expires_at = ? WHERE expires_at > ?',
+              )
+              .run(past, now)
         logger.warn(
-          { email, updated: result.changes },
+          {
+            email,
+            requestUri: requestUri ? requestUri.slice(0, 60) : null,
+            updated: result.changes,
+          },
           'Backdated auth_flow.expires_at',
         )
         res.json({ updated: result.changes })


### PR DESCRIPTION
   ## Summary                                                                                                                                                                                                     
                                                                                                                                                                                                                  
   - Run the default Cucumber e2e profile with a validated `E2E_PARALLEL` setting, defaulting to 3 workers.                                                                                                       
   - Sanitize invalid `E2E_PARALLEL` values so `parallel` is always a non-negative integer.                                                                                                                       
   - Document the `E2E_PARALLEL` override in the e2e README and env example.                                                                                                                                      
   - Fix parallel e2e interference by targeting auth-flow expiry test hooks to the current scenario’s `request_uri` instead of expiring every live auth flow.                                                     
   - Add unit coverage for targeted auth-flow expiry.

***Cuts E2E run time from ~10mins to ~3-4mins***

Autoresearch measured this shape at ~216s vs ~680s baseline while preserving the same scenario/step coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * End-to-end tests now support configurable parallelism to optimize execution based on your hardware. Control the number of parallel worker processes via environment configuration (defaults to 3). Useful for machines with limited resources or when performing serial debugging.

* **Documentation**
  * Updated E2E documentation to include new environment variable configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/ePDS/pull/174)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->