### PR TITLE
feat(shared): preview validation flags missing epds_handle_login_url

### DIFF
--- a/.changeset/preview-validate-handle-login-url.md
+++ b/.changeset/preview-validate-handle-login-url.md
@@ -1,0 +1,15 @@
+---
+'ePDS': patch
+---
+
+The `/preview/validate` page now checks the ATProto/Bluesky hand-off URL on your client metadata.
+
+**Affects:** Client app developers
+
+**Client app developers:** if your client metadata declares `epds_handle_login_url` (used to render the "Or sign in with ATProto/Bluesky" button on the login page), the preview validation page now surfaces a `handle-login-url` row alongside the existing field checks.
+
+- Missing or empty → warn ("Optional. Without it, the login page doesn't render the ATProto/Bluesky button…") so you notice if you forgot to declare it.
+- Present and `http(s)://` → ok. Both schemes are accepted because the real `isSafeHttpUrl` gate in the login page also accepts `http://` for localhost dev clients.
+- Present but `javascript:`, `file:`, or otherwise unparseable → error. This mirrors how the login page silently refuses to render the button on real flows, so the validator now points it out instead of letting you discover it the hard way during an OAuth round-trip.
+
+No new metadata fields, env vars, or response shapes — only an additional row in the existing `/preview/validate` JSON output.

--- a/.changeset/preview-validate-handle-login-url.md
+++ b/.changeset/preview-validate-handle-login-url.md
@@ -2,14 +2,12 @@
 'ePDS': patch
 ---
 
-The `/preview/validate` page now checks the ATProto/Bluesky hand-off URL on your client metadata.
+The `/preview/validate` page now checks `epds_handle_login_url` on your client metadata.
 
 **Affects:** Client app developers
 
-**Client app developers:** if your client metadata declares `epds_handle_login_url` (used to render the "Or sign in with ATProto/Bluesky" button on the login page), the preview validation page now surfaces a `handle-login-url` row alongside the existing field checks.
+**Client app developers:** a new `handle-login-url` row joins the existing field checks.
 
-- Missing or empty → warn ("Optional. Without it, the login page doesn't render the ATProto/Bluesky button…") so you notice if you forgot to declare it.
-- Present and `http(s)://` → ok. Both schemes are accepted because the real `isSafeHttpUrl` gate in the login page also accepts `http://` for localhost dev clients.
-- Present but `javascript:`, `file:`, or otherwise unparseable → error. This mirrors how the login page silently refuses to render the button on real flows, so the validator now points it out instead of letting you discover it the hard way during an OAuth round-trip.
-
-No new metadata fields, env vars, or response shapes — only an additional row in the existing `/preview/validate` JSON output.
+- Missing or empty value warns you that the "Or sign in with ATProto/Bluesky" button won't render.
+- An `http(s)://` value is ok, matching the `isSafeHttpUrl` gate that renders the button at runtime (`http://` accepted so localhost dev clients still pass).
+- Any other value (`javascript:`, `file:`, unparseable) errors, because the runtime gate would silently drop the button on real flows.

--- a/packages/shared/src/__tests__/preview-validation.test.ts
+++ b/packages/shared/src/__tests__/preview-validation.test.ts
@@ -68,6 +68,7 @@ describe('validateClientMetadataForPreview', () => {
       branding: { css: 'body { color: red; }' },
       tos_uri: 'https://good.example/terms',
       policy_uri: 'https://good.example/privacy',
+      epds_handle_login_url: 'https://good.example/api/oauth/login',
     })
     const result = await validateClientMetadataForPreview(url, [url])
     expect(result.fetched).toBe(true)
@@ -80,6 +81,7 @@ describe('validateClientMetadataForPreview', () => {
     expect(byId['branding-css'].severity).toBe('ok')
     expect(byId['tos-uri'].severity).toBe('ok')
     expect(byId['policy-uri'].severity).toBe('ok')
+    expect(byId['handle-login-url'].severity).toBe('ok')
     expect(byId['trusted-client'].severity).toBe('ok')
   })
 
@@ -123,6 +125,7 @@ describe('validateClientMetadataForPreview', () => {
     expect(byId['branding-css'].severity).toBe('warn')
     expect(byId['tos-uri'].severity).toBe('warn')
     expect(byId['policy-uri'].severity).toBe('warn')
+    expect(byId['handle-login-url'].severity).toBe('warn')
     // trust check also warn, not error
     expect(byId['trusted-client'].severity).toBe('warn')
     // No error-level checks on an otherwise-valid metadata:
@@ -141,6 +144,51 @@ describe('validateClientMetadataForPreview', () => {
     const byId = Object.fromEntries(result.checks.map((c) => [c.id, c]))
     expect(byId['tos-uri'].severity).toBe('error')
     expect(byId['policy-uri'].severity).toBe('error')
+  })
+
+  it('flags epds_handle_login_url ok for http:// (dev) and https:// values', async () => {
+    // Mirrors the real isSafeHttpUrl gate in auth-service's login-page:
+    // both schemes pass so that localhost dev clients keep working.
+    for (const handleUrl of [
+      'http://localhost:3000/api/oauth/login',
+      'https://client.example/api/oauth/login',
+    ]) {
+      const url = `https://${handleUrl.includes('localhost') ? 'dev' : 'prod'}.example/client-metadata.json`
+      mockFetchOnce({
+        client_id: url,
+        redirect_uris: [
+          `https://${handleUrl.includes('localhost') ? 'dev' : 'prod'}.example/cb`,
+        ],
+        epds_handle_login_url: handleUrl,
+      })
+      const result = await validateClientMetadataForPreview(url, null)
+      const check = result.checks.find((c) => c.id === 'handle-login-url')
+      expect(check?.severity).toBe('ok')
+    }
+  })
+
+  it('errors when epds_handle_login_url is not http(s)', async () => {
+    const url = 'https://bad-handle.example/client-metadata.json'
+    mockFetchOnce({
+      client_id: url,
+      redirect_uris: ['https://bad-handle.example/cb'],
+      epds_handle_login_url: 'javascript:alert(1)',
+    })
+    const result = await validateClientMetadataForPreview(url, null)
+    const check = result.checks.find((c) => c.id === 'handle-login-url')
+    expect(check?.severity).toBe('error')
+  })
+
+  it('errors when epds_handle_login_url is unparseable', async () => {
+    const url = 'https://bad-handle2.example/client-metadata.json'
+    mockFetchOnce({
+      client_id: url,
+      redirect_uris: ['https://bad-handle2.example/cb'],
+      epds_handle_login_url: 'not a url',
+    })
+    const result = await validateClientMetadataForPreview(url, null)
+    const check = result.checks.find((c) => c.id === 'handle-login-url')
+    expect(check?.severity).toBe('error')
   })
 
   it('errors when client_id field does not match the URL', async () => {

--- a/packages/shared/src/client-metadata.ts
+++ b/packages/shared/src/client-metadata.ts
@@ -72,16 +72,20 @@ export interface ClientMetadata {
   /**
    * ePDS extension — when set, the auth-service login page renders an
    * "Or sign in with ATProto/Bluesky" button. Submitting a handle
-   * navigates the browser to this URL with `?handle=<value>` appended,
-   * letting the client resolve the handle to a PDS and start a fresh
-   * OAuth flow against that PDS. Off-PDS handles cannot be authenticated
-   * by this PDS, so this is the only path that works for them.
+   * navigates the browser to this URL with a `handle=<value>` query
+   * param added (via `URLSearchParams.set`, so any existing query
+   * string is preserved), letting the client resolve the handle to a
+   * PDS and start a fresh OAuth flow against that PDS. Off-PDS handles
+   * cannot be authenticated by this PDS, so this is the only path that
+   * works for them.
    *
-   * Must be an absolute http(s):// URL on the client's own origin.
-   * `https://` is required in production; `http://` is accepted to
-   * support localhost / dev clients (this mirrors the runtime
-   * `isSafeHttpUrl` gate in auth-service's login page). If absent or
-   * not parseable as http(s), the button is not rendered.
+   * Must be an absolute http(s):// URL; should be on the client's own
+   * origin (not enforced at runtime — neither the login page's
+   * `isSafeHttpUrl` gate nor the `/preview/validate` check verifies
+   * origin). `https://` is required in production; `http://` is
+   * accepted to support localhost / dev clients (this mirrors the
+   * runtime `isSafeHttpUrl` gate in auth-service's login page). If
+   * absent or not parseable as http(s), the button is not rendered.
    */
   epds_handle_login_url?: string
 }

--- a/packages/shared/src/client-metadata.ts
+++ b/packages/shared/src/client-metadata.ts
@@ -82,10 +82,11 @@ export interface ClientMetadata {
    * Must be an absolute http(s):// URL; should be on the client's own
    * origin (not enforced at runtime — neither the login page's
    * `isSafeHttpUrl` gate nor the `/preview/validate` check verifies
-   * origin). `https://` is required in production; `http://` is
-   * accepted to support localhost / dev clients (this mirrors the
-   * runtime `isSafeHttpUrl` gate in auth-service's login page). If
-   * absent or not parseable as http(s), the button is not rendered.
+   * origin). `https://` is expected in production; `http://` is also
+   * accepted at runtime to support localhost / dev clients (this
+   * mirrors the `isSafeHttpUrl` gate in auth-service's login page,
+   * which does not enforce a scheme by environment). If absent or not
+   * parseable as http(s), the button is not rendered.
    */
   epds_handle_login_url?: string
 }

--- a/packages/shared/src/client-metadata.ts
+++ b/packages/shared/src/client-metadata.ts
@@ -77,8 +77,11 @@ export interface ClientMetadata {
    * OAuth flow against that PDS. Off-PDS handles cannot be authenticated
    * by this PDS, so this is the only path that works for them.
    *
-   * Must be an absolute https:// URL on the client's own origin.
-   * If absent, the button is not rendered.
+   * Must be an absolute http(s):// URL on the client's own origin.
+   * `https://` is required in production; `http://` is accepted to
+   * support localhost / dev clients (this mirrors the runtime
+   * `isSafeHttpUrl` gate in auth-service's login page). If absent or
+   * not parseable as http(s), the button is not rendered.
    */
   epds_handle_login_url?: string
 }

--- a/packages/shared/src/preview-validation.ts
+++ b/packages/shared/src/preview-validation.ts
@@ -393,6 +393,62 @@ function checkTosUri(metadata: ClientMetadata): PreviewCheck {
   })
 }
 
+/**
+ * `epds_handle_login_url` is the hand-off URL for the
+ * "Or sign in with ATProto/Bluesky" button on the login page. The
+ * real gate in auth-service is `isSafeHttpUrl` — accepts http and
+ * https so that localhost dev clients keep working — so this check
+ * mirrors that, rather than the stricter https-only check used for
+ * tos_uri / policy_uri (which render as consent-page links).
+ *
+ * Missing → warn (optional; users just see no ATProto/Bluesky
+ * button). Present + http(s) → ok. Present + any other scheme or
+ * unparseable → error (button silently won't render on real flows).
+ */
+function checkHandleLoginUrl(metadata: ClientMetadata): PreviewCheck {
+  const value = metadata.epds_handle_login_url
+  const label = 'epds_handle_login_url set'
+  const labelHtml = `${code('epds_handle_login_url')} set`
+
+  if (value === undefined || value === '') {
+    return {
+      id: 'handle-login-url',
+      label,
+      severity: 'warn',
+      detail:
+        'Optional. Without it, the login page doesn\'t render the "Or sign in with ATProto/Bluesky" button, so users coming from a different PDS can\'t hand off to your client.',
+      labelHtml,
+      detailHtml: `Optional. Without it, the login page doesn't render the "Or sign in with ATProto/Bluesky" button, so users coming from a different PDS can't hand off to your client.`,
+    }
+  }
+
+  let parsed: URL | null = null
+  try {
+    parsed = new URL(value)
+  } catch {
+    // fall through
+  }
+  if (parsed?.protocol !== 'https:' && parsed?.protocol !== 'http:') {
+    return {
+      id: 'handle-login-url',
+      label,
+      severity: 'error',
+      detail: `epds_handle_login_url="${value}" is not a valid http(s) URL. The login page rejects it via isSafeHttpUrl and the ATProto/Bluesky button silently won't render on real flows.`,
+      labelHtml,
+      detailHtml: `${code('epds_handle_login_url')}=${code('"' + value + '"')} is not a valid http(s) URL. The login page rejects it via ${code('isSafeHttpUrl')} and the ATProto/Bluesky button silently won't render on real flows.`,
+    }
+  }
+
+  return {
+    id: 'handle-login-url',
+    label,
+    severity: 'ok',
+    detail: `epds_handle_login_url="${value}". Login page will render the "Or sign in with ATProto/Bluesky" button and hand off to this URL with ?handle=<value>.`,
+    labelHtml,
+    detailHtml: `${code('epds_handle_login_url')}=${code('"' + value + '"')}. Login page will render the "Or sign in with ATProto/Bluesky" button and hand off to this URL with ${code('?handle=<value>')}.`,
+  }
+}
+
 function checkPolicyUri(metadata: ClientMetadata): PreviewCheck {
   return checkUriField({
     id: 'policy-uri',
@@ -476,6 +532,7 @@ export async function validateClientMetadataForPreview(
     checkBrandingCss(metadata),
     checkTosUri(metadata),
     checkPolicyUri(metadata),
+    checkHandleLoginUrl(metadata),
   )
 
   // 4. Trusted-clients membership (optional; caller may skip)

--- a/packages/shared/src/preview-validation.ts
+++ b/packages/shared/src/preview-validation.ts
@@ -443,9 +443,9 @@ function checkHandleLoginUrl(metadata: ClientMetadata): PreviewCheck {
     id: 'handle-login-url',
     label,
     severity: 'ok',
-    detail: `epds_handle_login_url="${value}". Login page will render the "Or sign in with ATProto/Bluesky" button and hand off to this URL with ?handle=<value>.`,
+    detail: `epds_handle_login_url="${value}". Login page will render the "Or sign in with ATProto/Bluesky" button and hand off to this URL with a handle=<value> query param.`,
     labelHtml,
-    detailHtml: `${code('epds_handle_login_url')}=${code('"' + value + '"')}. Login page will render the "Or sign in with ATProto/Bluesky" button and hand off to this URL with ${code('?handle=<value>')}.`,
+    detailHtml: `${code('epds_handle_login_url')}=${code('"' + value + '"')}. Login page will render the "Or sign in with ATProto/Bluesky" button and hand off to this URL with a ${code('handle=<value>')} query param.`,
   }
 }
 


### PR DESCRIPTION
## Summary

- `/preview/validate` now emits a `handle-login-url` row covering `epds_handle_login_url` in client metadata
- Missing → `warn` (field is optional; absence means the "Or sign in with ATProto/Bluesky" button just isn't rendered)
- Present + `http(s)://` → `ok` (mirrors the real `isSafeHttpUrl` gate in `auth-service/src/routes/login-page.ts`, so localhost dev clients still pass)
- Present but `javascript:`, `file:`, unparseable → `error` (the login page silently refuses to render the button; validator now points it out instead of letting OAuth round-trips fail visibly)

## Why

Up until now `/preview/validate` covered `tos_uri`, `policy_uri`, `brand_color`, `branding.css`, `redirect_uris`, etc. — but **not** `epds_handle_login_url`, which is the gate for the multi-PDS hand-off path on the login page. Adding it puts that field on the same pre-flight checklist client devs already use.

## Test plan

- [x] `pnpm test packages/shared/src/__tests__/preview-validation.test.ts` — 13 passed (3 new cases for ok/error/error)
- [x] `pnpm test` — 1024 passed (no regressions)
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:coverage` — `preview-validation.ts` at 96%, new code covered
- [ ] Visual check of the rendered `/preview/validate` page against a metadata declaring + omitting `epds_handle_login_url` (left for human reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview validation adds a "handle-login-url" check for the ATProto/Bluesky hand-off URL: valid http(s) URLs -> ok, missing/empty -> warn, non-http(s)/unparseable -> error.
* **Tests**
  * Added tests covering ok/warn/error cases (including http://localhost and https).
* **Documentation**
  * Updated metadata docs describing handle-login-url behavior and accepted URL rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/ePDS/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->