### PR TITLE
fix(railway): root-anchor watch patterns

### DIFF
--- a/.changeset/root-anchored-railway-watch-patterns.md
+++ b/.changeset/root-anchored-railway-watch-patterns.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+Railway monorepo deployments now use repository-root paths for rebuild filtering.
+
+**Affects:** Operators
+
+**Operators:** the Railway service config files under `packages/*/railway.toml` now use leading-slash `watchPatterns` and `dockerfilePath` values, such as `/packages/shared/**` and `/Dockerfile.auth`, so rebuild filtering is evaluated against repository-root paths even though each config file lives inside a package directory. No environment variable changes are required.

--- a/.changeset/root-anchored-railway-watch-patterns.md
+++ b/.changeset/root-anchored-railway-watch-patterns.md
@@ -1,9 +1,0 @@
----
-'ePDS': patch
----
-
-Railway monorepo deployments now use repository-root paths for rebuild filtering.
-
-**Affects:** Operators
-
-**Operators:** the Railway service config files under `packages/*/railway.toml` now use leading-slash `watchPatterns` and `dockerfilePath` values, such as `/packages/shared/**` and `/Dockerfile.auth`, so rebuild filtering is evaluated against repository-root paths even though each config file lives inside a package directory. No environment variable changes are required.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -656,6 +656,9 @@ jobs:
           # excludes @otp-expiry so the rest of the suite still runs.
           E2E_INTERNAL_SECRET: ${{ secrets.E2E_INTERNAL_SECRET }}
           E2E_HEADLESS: 'true'
+          # One retry gives transient Railway/browser timing issues another
+          # chance without masking persistent failures.
+          CUCUMBER_RETRY: '1'
         run: pnpm test:e2e:headless
 
       - name: Publish e2e test report

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -159,8 +159,9 @@ Railway handles TLS automatically.
 ### Deploying
 
 Railway deploys automatically on push to the linked branch. Each service's
-`railway.toml` defines `watchPatterns` so only relevant changes trigger a
-rebuild.
+`railway.toml` defines root-anchored `watchPatterns` (leading `/`) so only
+relevant changes trigger a rebuild, even though the config files live under
+`packages/*/`.
 
 To manually redeploy:
 

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -39,6 +39,10 @@ E2E_MAILPIT_PASS=
 # Default: 3. Lower this on constrained local machines; set to 0 or 1 for serial debugging.
 # E2E_PARALLEL=3
 
+# Number of times Cucumber retries a failed scenario after the first attempt.
+# Default: 0. Set to 1 for up to two total attempts.
+# CUCUMBER_RETRY=0
+
 # Required only by scenarios tagged @otp-expiry. Must match the
 # deployment's EPDS_INTERNAL_SECRET so the test runner can call the
 # auth-service test hooks (e.g. POST /_internal/test/expire-otp). When

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -69,6 +69,7 @@ For OTP scenarios you also need a local Mailpit instance (see
 | `E2E_MAILPIT_PASS`       | No       | _(empty)_ | Mailpit HTTP basic auth password. Leave empty to skip OTP scenarios.                                                                                    |
 | `E2E_HEADLESS`           | No       | `false`   | Set to `true` to run without a visible browser window                                                                                                   |
 | `E2E_PARALLEL`           | No       | `3`       | Number of Cucumber worker processes for the default profile. Lower this on constrained local machines; use `0` or `1` for serial debugging.             |
+| `CUCUMBER_RETRY`         | No       | `0`       | Number of times Cucumber retries a failed scenario after the first attempt. `1` means up to two total attempts.                                         |
 
 ## Two demo clients
 

--- a/e2e/cucumber.mjs
+++ b/e2e/cucumber.mjs
@@ -43,11 +43,14 @@ const defaultTagExclusions = [
   ...hookTagExclusions,
 ]
 
-const shared = {
-  paths: ['features/**/*.feature'],
-  import: ['e2e/step-definitions/**/*.ts', 'e2e/support/**/*.ts'],
-  strict: true,
-}
+const parsedCucumberRetry = Number.parseInt(
+  process.env.CUCUMBER_RETRY ?? '0',
+  10,
+)
+const cucumberRetry =
+  Number.isFinite(parsedCucumberRetry) && parsedCucumberRetry >= 0
+    ? parsedCucumberRetry
+    : 0
 
 const parsedDefaultParallel = Number.parseInt(
   process.env.E2E_PARALLEL ?? '3',
@@ -57,6 +60,13 @@ const defaultParallel =
   Number.isFinite(parsedDefaultParallel) && parsedDefaultParallel >= 0
     ? parsedDefaultParallel
     : 3
+
+const shared = {
+  paths: ['features/**/*.feature'],
+  import: ['e2e/step-definitions/**/*.ts', 'e2e/support/**/*.ts'],
+  retry: cucumberRetry,
+  strict: true,
+}
 
 // Cucumber supports the `default: () => ({...})` form to declare multiple
 // profiles including names that aren't valid JS identifiers (e.g. hyphenated).

--- a/e2e/support/flows.ts
+++ b/e2e/support/flows.ts
@@ -43,7 +43,12 @@ export async function pickHandle(world: EpdsWorld): Promise<void> {
   const page = world.page
   if (!page) throw new Error('page is not initialised')
 
-  await page.waitForURL('**/auth/choose-handle', { timeout: 30_000 })
+  await page.waitForURL('**/auth/choose-handle', {
+    timeout: 60_000,
+    waitUntil: 'domcontentloaded',
+  })
+  await expect(page.locator('#handle-input')).toBeVisible({ timeout: 15_000 })
+
   const localPart = generateHandleLocalPart()
   await page.fill('#handle-input', localPart)
   await expect(page.locator('#handle-status.available')).toBeVisible({

--- a/packages/auth-service/railway.toml
+++ b/packages/auth-service/railway.toml
@@ -5,32 +5,35 @@ builder = "DOCKERFILE"
 # Path is relative to the repository root, not this package directory.
 # Railway does not support --target for multi-stage builds, so we use a
 # dedicated Dockerfile that produces only the auth-service image.
-dockerfilePath = "Dockerfile.auth"
+dockerfilePath = "/Dockerfile.auth"
+# Anchor watch patterns to the repository root with a leading slash. Railway
+# loads this config from packages/auth-service/railway.toml, and unanchored
+# patterns can be interpreted relative to that package directory.
 watchPatterns = [
-  "packages/auth-service/**",
-  "packages/shared/**",
+  "/packages/auth-service/**",
+  "/packages/shared/**",
   # pds-core's package.json is referenced during the workspace-aware pnpm
   # install step, so a bump there changes the produced image.
-  "packages/pds-core/package.json",
-  "Dockerfile.auth",
-  "docker-entrypoint.sh",
+  "/packages/pds-core/package.json",
+  "/Dockerfile.auth",
+  "/docker-entrypoint.sh",
   # Repo-root files COPYed by Dockerfile.auth. A change to any of these
   # can legitimately alter the produced image (new dep, new pnpm version,
   # changed tsconfig project references, etc.), so we must redeploy.
-  "package.json",
-  "pnpm-workspace.yaml",
-  "pnpm-lock.yaml",
-  "tsconfig.json",
+  "/package.json",
+  "/pnpm-workspace.yaml",
+  "/pnpm-lock.yaml",
+  "/tsconfig.json",
   # e2e test / feature changes produce a byte-identical image, but we still
   # need Railway to redeploy so the GitHub Actions e2e job (which gates on
   # deployment_status webhooks) actually runs against PRs that only touch
   # tests. Exclude markdown under these dirs so doc-only edits don't
   # pointlessly trigger a redeploy + ~8 minute e2e run.
-  "e2e/**",
-  "features/**",
-  ".github/workflows/e2e-tests.yml",
-  "!e2e/**/*.md",
-  "!features/**/*.md",
+  "/e2e/**",
+  "/features/**",
+  "/.github/workflows/e2e-tests.yml",
+  "!/e2e/**/*.md",
+  "!/features/**/*.md",
 ]
 
 [deploy]

--- a/packages/demo/railway.toml
+++ b/packages/demo/railway.toml
@@ -3,32 +3,35 @@
 [build]
 builder = "DOCKERFILE"
 # Path is relative to the repository root, not this package directory.
-dockerfilePath = "Dockerfile.demo"
+dockerfilePath = "/Dockerfile.demo"
+# Anchor watch patterns to the repository root with a leading slash. Railway
+# loads this config from packages/demo/railway.toml, and unanchored patterns can
+# be interpreted relative to that package directory.
 watchPatterns = [
-  "packages/demo/**",
+  "/packages/demo/**",
   # Workspace-sibling package.jsons are referenced during the pnpm
   # install step, so a bump to any of them changes the produced image.
-  "packages/auth-service/package.json",
-  "packages/pds-core/package.json",
-  "packages/shared/package.json",
-  "Dockerfile.demo",
+  "/packages/auth-service/package.json",
+  "/packages/pds-core/package.json",
+  "/packages/shared/package.json",
+  "/Dockerfile.demo",
   # Repo-root files COPYed by Dockerfile.demo. A change to any of these
   # can legitimately alter the produced image (new dep, new pnpm version,
   # changed tsconfig project references, etc.), so we must redeploy.
-  "package.json",
-  "pnpm-workspace.yaml",
-  "pnpm-lock.yaml",
-  "tsconfig.json",
+  "/package.json",
+  "/pnpm-workspace.yaml",
+  "/pnpm-lock.yaml",
+  "/tsconfig.json",
   # e2e test / feature changes produce a byte-identical image, but we still
   # need Railway to redeploy so the GitHub Actions e2e job (which gates on
   # deployment_status webhooks) actually runs against PRs that only touch
   # tests. Exclude markdown under these dirs so doc-only edits don't
   # pointlessly trigger a redeploy + ~8 minute e2e run.
-  "e2e/**",
-  "features/**",
-  ".github/workflows/e2e-tests.yml",
-  "!e2e/**/*.md",
-  "!features/**/*.md",
+  "/e2e/**",
+  "/features/**",
+  "/.github/workflows/e2e-tests.yml",
+  "!/e2e/**/*.md",
+  "!/features/**/*.md",
 ]
 
 [deploy]

--- a/packages/pds-core/railway.toml
+++ b/packages/pds-core/railway.toml
@@ -5,32 +5,35 @@ builder = "DOCKERFILE"
 # Path is relative to the repository root, not this package directory.
 # Railway does not support --target for multi-stage builds, so we use a
 # dedicated Dockerfile that produces only the pds-core image.
-dockerfilePath = "Dockerfile.pds"
+dockerfilePath = "/Dockerfile.pds"
+# Anchor watch patterns to the repository root with a leading slash. Railway
+# loads this config from packages/pds-core/railway.toml, and unanchored patterns
+# can be interpreted relative to that package directory.
 watchPatterns = [
-  "packages/pds-core/**",
-  "packages/shared/**",
+  "/packages/pds-core/**",
+  "/packages/shared/**",
   # auth-service's package.json is referenced during the workspace-aware
   # pnpm install step, so a bump there changes the produced image.
-  "packages/auth-service/package.json",
-  "Dockerfile.pds",
-  "docker-entrypoint.sh",
+  "/packages/auth-service/package.json",
+  "/Dockerfile.pds",
+  "/docker-entrypoint.sh",
   # Repo-root files COPYed by Dockerfile.pds. A change to any of these
   # can legitimately alter the produced image (new dep, new pnpm version,
   # changed tsconfig project references, etc.), so we must redeploy.
-  "package.json",
-  "pnpm-workspace.yaml",
-  "pnpm-lock.yaml",
-  "tsconfig.json",
+  "/package.json",
+  "/pnpm-workspace.yaml",
+  "/pnpm-lock.yaml",
+  "/tsconfig.json",
   # e2e test / feature changes produce a byte-identical image, but we still
   # need Railway to redeploy so the GitHub Actions e2e job (which gates on
   # deployment_status webhooks) actually runs against PRs that only touch
   # tests. Exclude markdown under these dirs so doc-only edits don't
   # pointlessly trigger a redeploy + ~8 minute e2e run.
-  "e2e/**",
-  "features/**",
-  ".github/workflows/e2e-tests.yml",
-  "!e2e/**/*.md",
-  "!features/**/*.md",
+  "/e2e/**",
+  "/features/**",
+  "/.github/workflows/e2e-tests.yml",
+  "!/e2e/**/*.md",
+  "!/features/**/*.md",
 ]
 
 [deploy]

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@certified-app/shared",
+  "description": "Shared database, crypto, HTML, and utility code for ePDS services.",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

This PR tests whether Railway watch patterns in package-local `railway.toml` files behave correctly when the paths are explicitly anchored to the repository root.

Changes:

- Prefix all Railway `watchPatterns` entries with `/` in:
  - `packages/auth-service/railway.toml`
  - `packages/pds-core/railway.toml`
  - `packages/demo/railway.toml`
- Prefix each `dockerfilePath` with `/` for the same root-relative interpretation.
- Document that these Railway patterns are root-anchored.
- Add a harmless `description` field to `packages/shared/package.json` as the actual probe for matching a sibling package path outside each service package.

## Why

The current unanchored patterns appear to be interpreted relative to the package directory containing each `railway.toml`, rather than relative to the monorepo root. If Railway honors leading `/` as repo-root anchoring, then sibling/root paths such as `/packages/shared/**`, `/package.json`, and `/e2e/**` should once again trigger the intended service rebuilds.

## How to validate

The useful signal from this PR is Railway's deployment behavior on the latest commit:

1. The latest commit touches `packages/shared/package.json`.
2. All three Railway services should rebuild because:
   - auth-service watches `/packages/shared/**`
   - pds-core watches `/packages/shared/**`
   - demo watches `/packages/shared/package.json`
3. If Railway skips any of those services on the latest commit, then leading-slash root anchoring is not sufficient and we need a different approach or a Railway-side fix.

A later optional probe can touch only `e2e/**/*.md` or `features/**/*.md` to confirm the negated root-anchored patterns still skip rebuilds.

## Local validation

- Parsed all three `railway.toml` files with Python `tomllib`.
- Asserted all `watchPatterns` entries are root-anchored (`/` or `!/`).
- Checked `packages/shared/package.json` with `python3 -m json.tool`.
- Checked formatting for `packages/shared/package.json`, `docs/deployment.md`, and the changeset using the repo's installed Prettier.
- Ran `git diff --check`.

Full test suite not run: the functional signal we need from this PR is Railway's rebuild/skip behavior for the shared-package probe commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * E2E tests now support configurable retry behavior for failed scenarios via the `CUCUMBER_RETRY` environment variable.

* **Bug Fixes**
  * Improved test wait timeouts and conditions for more reliable scenario execution.

* **Documentation**
  * Clarified deployment documentation regarding file-change triggers.
  * Updated E2E test configuration documentation with new retry setting.

* **Chores**
  * Updated deployment configurations for consistency with root-anchored file patterns.
  * Updated package metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/ePDS/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->