### PR TITLE
docs(changesets): name client app developers in the skill's audience framing

### DIFF
--- a/.agents/skills/writing-changesets/SKILL.md
+++ b/.agents/skills/writing-changesets/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: writing-changesets
-description: Create changeset files for user-facing or operator-facing changes to ePDS. Use when adding features, changing configuration, altering OAuth flows, or any change a downstream consumer needs to adapt to.
+description: Create changeset files for changes to ePDS that affect end users, client app developers, or operators. Use when adding features, changing configuration, altering OAuth flows, or any change a downstream consumer needs to adapt to.
 ---
 
 # Writing Changesets
 
-Create a changeset file to document user-facing or operator-facing
-changes for release.
+Create a changeset file to document changes for release that affect
+end users, client app developers, or operators.
 
 ## When to Use
 


### PR DESCRIPTION
## Summary

The `writing-changesets` skill defines **three** audiences — End users, Client app developers, Operators — and uses all three consistently in the `**Affects:**` template, ordering rules, and examples. But two lead-in spots described changesets as only *"user-facing or operator-facing"*, silently dropping client app developers:

- the frontmatter `description` (the text the skill loader matches against to decide when to trigger), and
- the opening sentence of the skill body.

Both now name all three audiences, matching the audience list and per-audience guidance below.

## Why it matters

The `description` is the highest-stakes spot: it's what selects the skill. Omitting the API/integration audience risks the skill not firing for a change that's purely client-app-developer-facing (e.g. an OAuth flow / response-shape change with no operator or end-user impact).

## Notes

Two-line wording change, no behavioural content altered. Spotted while porting this skill to the certified-group-service repo, where the same inherited gap was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)