### PR TITLE
feat(auth-service): log better-auth OTP verification failures

### DIFF
--- a/.changeset/log-otp-verification-failures.md
+++ b/.changeset/log-otp-verification-failures.md
@@ -1,0 +1,14 @@
+---
+'ePDS': patch
+---
+
+Failed sign-in code entries now show up in the server logs, split by reason.
+
+**Affects:** Operators
+
+**Operators:** the auth service now logs its own 4xx client errors — most usefully the sign-in code failures that the browser posts straight to `/api/auth/sign-in/email-otp`, which previously reached no log at all.
+
+- Each failure is logged at `warn` (visible at the default `info` level, no `LOG_LEVEL` change needed) under the `auth:better-auth` logger name, with the message `better-auth API error` and a `message` field carrying the reason verbatim: `OTP expired`, `Invalid OTP`, or `Too many attempts`.
+- Counting `OTP expired` vs `Invalid OTP` over time separates users whose code genuinely lapsed (late email delivery) from users retyping a stale code, so a rise in `OTP expired` points at delivery delay rather than user error.
+- Only 4xx errors are logged here; 3xx redirects are filtered out and 5xx errors are already logged by the framework, so this adds no duplicate 5xx noise.
+- The email address is not included: the framework hands this logging hook the instance-wide context, not the per-request body, so the address is not reliably available at that point.

--- a/packages/auth-service/src/__tests__/log-better-auth-api-error.test.ts
+++ b/packages/auth-service/src/__tests__/log-better-auth-api-error.test.ts
@@ -18,16 +18,15 @@ function makeLogger() {
 }
 
 describe('logBetterAuthApiError', () => {
-  it('logs an expired-OTP error at warn with the reason', () => {
+  it('logs an expired-OTP error at warn with the reason and the error object', () => {
     const log = makeLogger()
-    logBetterAuthApiError(
-      new APIError('BAD_REQUEST', { message: 'OTP expired' }),
-      log,
-    )
+    const error = new APIError('BAD_REQUEST', { message: 'OTP expired' })
+    logBetterAuthApiError(error, log)
 
     expect(log.warn).toHaveBeenCalledOnce()
     expect(log.warn).toHaveBeenCalledWith(
       expect.objectContaining({
+        err: error,
         status: 'BAD_REQUEST',
         statusCode: 400,
         message: 'OTP expired',

--- a/packages/auth-service/src/__tests__/log-better-auth-api-error.test.ts
+++ b/packages/auth-service/src/__tests__/log-better-auth-api-error.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for logBetterAuthApiError — the bridge that surfaces better-auth's
+ * 4xx client errors (notably "OTP expired" vs "Invalid OTP") in our pino logs.
+ *
+ * These are exactly the errors better-auth throws from its email-otp verify
+ * endpoint (better-auth 1.4.18 dist/plugins/email-otp/routes.mjs), which the
+ * browser posts to directly and which were previously logged nowhere.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { APIError } from 'better-auth/api'
+import { logBetterAuthApiError } from '../better-auth.js'
+
+/** Minimal stand-in for the pino logger — only `warn` is exercised. */
+function makeLogger() {
+  return { warn: vi.fn() } as unknown as Parameters<
+    typeof logBetterAuthApiError
+  >[1]
+}
+
+describe('logBetterAuthApiError', () => {
+  it('logs an expired-OTP error at warn with the reason', () => {
+    const log = makeLogger()
+    logBetterAuthApiError(
+      new APIError('BAD_REQUEST', { message: 'OTP expired' }),
+      log,
+    )
+
+    expect(log.warn).toHaveBeenCalledOnce()
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'BAD_REQUEST',
+        statusCode: 400,
+        message: 'OTP expired',
+      }),
+      'better-auth API error',
+    )
+  })
+
+  it('logs an invalid-OTP error at warn, distinct from expiry', () => {
+    const log = makeLogger()
+    logBetterAuthApiError(
+      new APIError('BAD_REQUEST', { message: 'Invalid OTP' }),
+      log,
+    )
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 400, message: 'Invalid OTP' }),
+      'better-auth API error',
+    )
+  })
+
+  it('logs a 403 too-many-attempts error at warn', () => {
+    const log = makeLogger()
+    logBetterAuthApiError(
+      new APIError('FORBIDDEN', { message: 'Too many attempts' }),
+      log,
+    )
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'FORBIDDEN',
+        statusCode: 403,
+        message: 'Too many attempts',
+      }),
+      'better-auth API error',
+    )
+  })
+
+  it('falls back to error.message when the body has no message', () => {
+    const log = makeLogger()
+    const err = new APIError('BAD_REQUEST')
+    err.message = 'bare message'
+    logBetterAuthApiError(err, log)
+
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'bare message' }),
+      'better-auth API error',
+    )
+  })
+
+  it('ignores 5xx errors (already logged by better-auth itself)', () => {
+    const log = makeLogger()
+    logBetterAuthApiError(
+      new APIError('INTERNAL_SERVER_ERROR', { message: 'boom' }),
+      log,
+    )
+
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+
+  it('ignores 3xx redirects', () => {
+    const log = makeLogger()
+    logBetterAuthApiError(new APIError('FOUND'), log)
+
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-APIError values', () => {
+    const log = makeLogger()
+    logBetterAuthApiError(new Error('some other failure'), log)
+    logBetterAuthApiError('a string', log)
+    logBetterAuthApiError(undefined, log)
+
+    expect(log.warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/auth-service/src/better-auth.ts
+++ b/packages/auth-service/src/better-auth.ts
@@ -5,9 +5,10 @@
  * - Email OTP plugin (for future migration from custom OTP implementation)
  * - Social providers (Google, GitHub — only when env vars are set)
  * - Session lifetime from env vars
+ * - An onAPIError hook that surfaces 4xx client errors in our logs
+ *   (see logBetterAuthApiError below)
  *
  * The instance is mounted at /api/auth/* alongside the existing custom routes.
- * No existing behavior is changed — this is a foundation-only step.
  */
 import type { EpdsDb } from '@certified-app/shared'
 import { createLogger } from '@certified-app/shared'
@@ -61,6 +62,7 @@ export function logBetterAuthApiError(
 
   log.warn(
     {
+      err: error,
       status: error.status,
       statusCode,
       message: error.body?.message ?? error.message,

--- a/packages/auth-service/src/better-auth.ts
+++ b/packages/auth-service/src/better-auth.ts
@@ -12,6 +12,7 @@
 import type { EpdsDb } from '@certified-app/shared'
 import { createLogger } from '@certified-app/shared'
 import { betterAuth } from 'better-auth'
+import { APIError } from 'better-auth/api'
 import { generateRandomString } from 'better-auth/crypto'
 import { getMigrations } from 'better-auth/db'
 import { emailOTP } from 'better-auth/plugins'
@@ -22,7 +23,51 @@ import { ensurePdsUrl } from './lib/pds-url.js'
 
 export type BetterAuthInstance = ReturnType<typeof createBetterAuth>
 
+/** The logger type used across this module — avoids a direct pino dependency. */
+type BetterAuthLogger = ReturnType<typeof createLogger>
+
 const logger = createLogger('auth:better-auth')
+
+/**
+ * Surface better-auth 4xx client errors in our own logs.
+ *
+ * The main OAuth login flow posts straight from the browser to
+ * /api/auth/sign-in/email-otp, handled by better-auth's node handler. On
+ * verification failure better-auth throws an `APIError` whose message is the
+ * exact reason — "OTP expired", "Invalid OTP" or "Too many attempts" — but
+ * these never reach our logs because we set neither `logger` nor `onAPIError`.
+ * This is the only place that distinguishes a genuinely-late email (expired)
+ * from a user retyping a stale code (invalid), so we log it at `warn` (visible
+ * at prod's default `info` level) to make the split countable over time.
+ *
+ * Only 4xx `APIError`s are logged here. 3xx redirects (e.g. status "FOUND")
+ * are filtered by better-auth before this runs, and 5xx errors are already
+ * logged by better-auth's own error handler, so we skip them to avoid noise
+ * and double-logging. Non-`APIError` values are ignored for the same reason.
+ *
+ * The email address is deliberately not logged: better-auth invokes
+ * `onAPIError.onError` with the instance-wide auth context, not the per-request
+ * endpoint context, so the request body (and hence the email) is not available
+ * here without unsafe assumptions.
+ */
+export function logBetterAuthApiError(
+  error: unknown,
+  log: BetterAuthLogger,
+): void {
+  if (!(error instanceof APIError)) return
+
+  const statusCode = error.statusCode
+  if (statusCode < 400 || statusCode >= 500) return
+
+  log.warn(
+    {
+      status: error.status,
+      statusCode,
+      message: error.body?.message ?? error.message,
+    },
+    'better-auth API error',
+  )
+}
 
 const AUTH_FLOW_COOKIE = 'epds_auth_flow'
 
@@ -157,6 +202,14 @@ export function createBetterAuth(
     database: betterAuthDb as any,
     baseURL: `https://${authHostname}`,
     basePath: '/api/auth',
+
+    // Route better-auth's 4xx client errors (notably "OTP expired" vs
+    // "Invalid OTP") into our pino logs; see logBetterAuthApiError above.
+    onAPIError: {
+      onError(error) {
+        logBetterAuthApiError(error, logger)
+      },
+    },
 
     session: {
       expiresIn: sessionExpiresIn,


### PR DESCRIPTION
## Problem

Fixes #184.

better-auth distinguishes expired OTPs from wrong OTPs when verifying (`OTP expired` vs `Invalid OTP`), but in production we never saw either:

- The main OAuth login flow posts directly from the browser to `/api/auth/sign-in/email-otp` (`packages/auth-service/src/routes/login-page.ts`), handled by `toNodeHandler(betterAuthInstance)` with no HTTP access logging.
- better-auth's built-in `onError` only logs 4xx `APIError`s when `logger.level` is set in the `betterAuth()` options. `createBetterAuth()` configured neither `logger` nor `onAPIError`, so "OTP expired" failures were completely silent server-side.

Only the secondary `/account/verify-otp` route logged verification failures.

## Change

Wire `onAPIError.onError` in `createBetterAuth()` to a small exported helper `logBetterAuthApiError()`:

- Logs 4xx `APIError`s at `warn` (visible at prod's default `info` level) under the `auth:better-auth` logger, with the `status`, `statusCode`, and reason `message` (`OTP expired` / `Invalid OTP` / `Too many attempts`).
- Skips 3xx redirects (better-auth filters `FOUND` before this runs anyway) and 5xx errors (already logged by better-auth's own handler) to avoid noise and double-logging.
- Ignores non-`APIError` values.

The email address is deliberately not logged: better-auth invokes `onAPIError.onError` with the instance-wide auth context, not the per-request endpoint context, so the request body is not reliably available there. The issue's "where safely available" caveat anticipated this.

The handler is extracted into a pure, exported function so it can be unit-tested directly without instantiating a full better-auth instance — matching the existing test style in this package.

## Why

Counting `OTP expired` vs `Invalid OTP` occurrences over time directly answers how many users hit the 10-minute expiry window, and correlating those with email-send timestamps attributes them to delivery delay vs user behaviour. This is the signal that separates genuinely-late emails from users retyping old codes, and we were dropping it.

## Testing

- New unit test `log-better-auth-api-error.test.ts` (7 cases): expired/invalid/too-many-attempts all logged at `warn` with the right reason; `body.message` fallback to `error.message`; 5xx, 3xx redirects, and non-`APIError` values all skipped.
- `pnpm typecheck` — clean.
- `pnpm lint` — clean.
- Full auth-service suite — 426 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
