### PR TITLE
fix(demo): avoid error log for DPoP nonce challenge

### DIFF
--- a/packages/demo/src/__tests__/oauth-login-flow2.test.ts
+++ b/packages/demo/src/__tests__/oauth-login-flow2.test.ts
@@ -139,6 +139,7 @@ describe('OAuth login route (Flow 2)', () => {
 
   it('handles DPoP nonce retry (400 → dpop-nonce header → retry succeeds)', async () => {
     let callCount = 0
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     global.fetch = vi.fn().mockImplementation(() => {
       callCount++
       if (callCount === 1) {
@@ -170,6 +171,7 @@ describe('OAuth login route (Flow 2)', () => {
     // Should redirect successfully after retry
     expect(resp.status).toBe(307)
     expect(resp._url).toContain('request_uri=')
+    expect(errorSpy).not.toHaveBeenCalled()
   })
 
   it('session cookie round-trips the stored OAuth data', async () => {

--- a/packages/demo/src/__tests__/oauth-login-flow2.test.ts
+++ b/packages/demo/src/__tests__/oauth-login-flow2.test.ts
@@ -140,6 +140,7 @@ describe('OAuth login route (Flow 2)', () => {
   it('handles DPoP nonce retry (400 → dpop-nonce header → retry succeeds)', async () => {
     let callCount = 0
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const textSpy = vi.fn(() => Promise.resolve('use_dpop_nonce'))
     global.fetch = vi.fn().mockImplementation(() => {
       callCount++
       if (callCount === 1) {
@@ -150,7 +151,7 @@ describe('OAuth login route (Flow 2)', () => {
           ok: false,
           status: 400,
           headers,
-          text: () => Promise.resolve('use_dpop_nonce'),
+          text: textSpy,
         })
       }
       // Second call: success
@@ -172,6 +173,30 @@ describe('OAuth login route (Flow 2)', () => {
     expect(resp.status).toBe(307)
     expect(resp._url).toContain('request_uri=')
     expect(errorSpy).not.toHaveBeenCalled()
+    expect(textSpy).not.toHaveBeenCalled()
+  })
+
+  it('logs a terminal PAR failure when no DPoP nonce is provided', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      headers: new Headers(),
+      text: () => Promise.resolve('invalid_request'),
+    })
+
+    const resp = (await GET(makeRequest())) as unknown as {
+      status: number
+      _url: string
+    }
+
+    expect(resp.status).toBe(307)
+    expect(resp._url).toBe('http://localhost:3002/?error=par_failed')
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[oauth/login] PAR failed:',
+      400,
+      'invalid_request',
+    )
   })
 
   it('session cookie round-trips the stored OAuth data', async () => {

--- a/packages/demo/src/app/api/oauth/login/route.ts
+++ b/packages/demo/src/app/api/oauth/login/route.ts
@@ -210,7 +210,6 @@ export async function GET(request: Request) {
     const oauthCookie = createOAuthSessionCookie(sessionData)
 
     if (!parRes.ok) {
-      const parErrBody = await parRes.text()
       const dpopNonce = parRes.headers.get('dpop-nonce')
       if (dpopNonce) {
         console.log('[oauth/login] PAR requires DPoP nonce; retrying')
@@ -266,6 +265,7 @@ export async function GET(request: Request) {
         return resp2
       }
 
+      const parErrBody = await parRes.text()
       console.error('[oauth/login] PAR failed:', parRes.status, parErrBody)
       return NextResponse.redirect(new URL('/?error=par_failed', baseUrl))
     }

--- a/packages/demo/src/app/api/oauth/login/route.ts
+++ b/packages/demo/src/app/api/oauth/login/route.ts
@@ -211,12 +211,9 @@ export async function GET(request: Request) {
 
     if (!parRes.ok) {
       const parErrBody = await parRes.text()
-      console.error('[oauth/login] PAR failed:', parRes.status, parErrBody)
-
-      // Check for DPoP nonce requirement
       const dpopNonce = parRes.headers.get('dpop-nonce')
       if (dpopNonce) {
-        console.log('[oauth/login] Retrying with DPoP nonce')
+        console.log('[oauth/login] PAR requires DPoP nonce; retrying')
         const dpopProof2 = createDpopProof({
           privateKey,
           jwk: publicJwk,
@@ -269,6 +266,7 @@ export async function GET(request: Request) {
         return resp2
       }
 
+      console.error('[oauth/login] PAR failed:', parRes.status, parErrBody)
       return NextResponse.redirect(new URL('/?error=par_failed', baseUrl))
     }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       // Ratchet thresholds — update these whenever coverage increases.
       // See AGENTS.md for the ratcheting policy.
       thresholds: {
-        statements: 56,
+        statements: 57,
         branches: 56,
         functions: 70,
         lines: 55,


### PR DESCRIPTION
# Avoid error log for expected DPoP nonce challenge

## Summary

The demo's hand-rolled OAuth flow currently reports the authorization server's expected DPoP nonce challenge as a PAR failure, even though it immediately retries successfully. This makes normal email login activity look like an operational error.

## Changes

- Log a `DPoP-Nonce` challenge as an informational retry message.
- Reserve the PAR failure error for responses that cannot be retried with a nonce.
- Assert that a successful nonce retry does not emit an error log.

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (71 files, 1,037 tests)
- `pnpm test:coverage` (71 files, 1,037 tests)

## Notes

No changeset is included because this only corrects internal demo logging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth login reliability for scenarios requiring a DPoP nonce.
  * Retry behavior now logs a dedicated “requires DPoP nonce; retrying” message, avoiding misleading PAR failure output when the retry succeeds.
  * Maintains clear failure logging when PAR fails and no DPoP nonce is available.
* **Tests**
  * Strengthened OAuth login flow coverage around nonce retry and error logging expectations.
  * Tightened Vitest coverage requirements (statement coverage ratchet).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->