### PR TITLE
fix(auth-service): log email recipients consistently

### DIFF
--- a/.changeset/email-log-recipient-field.md
+++ b/.changeset/email-log-recipient-field.md
@@ -6,4 +6,4 @@ Email delivery logs use a consistent recipient field.
 
 **Affects:** Operators
 
-**Operators:** Update structured-log queries for `Sent client-branded OTP email` to read the recipient from `email` instead of `to`.
+**Operators:** All four email delivery paths now log the recipient as `email`: client-branded OTP, standard sign-in OTP, welcome OTP, and backup-email verification. Update structured-log queries for `Sent client-branded OTP email` to read `email` instead of `to`.

--- a/.changeset/email-log-recipient-field.md
+++ b/.changeset/email-log-recipient-field.md
@@ -1,0 +1,9 @@
+---
+'ePDS': minor
+---
+
+Email delivery logs use a consistent recipient field.
+
+**Affects:** Operators
+
+**Operators:** Update structured-log queries for `Sent client-branded OTP email` to read the recipient from `email` instead of `to`.

--- a/packages/auth-service/src/email/sender.ts
+++ b/packages/auth-service/src/email/sender.ts
@@ -133,7 +133,7 @@ export class EmailSender {
           html: branded.html,
         })
         logger.info(
-          { to, clientId: opts.clientId },
+          { email: to, clientId: opts.clientId },
           'Sent client-branded OTP email',
         )
         return

--- a/packages/auth-service/src/email/sender.ts
+++ b/packages/auth-service/src/email/sender.ts
@@ -165,6 +165,7 @@ export class EmailSender {
       text,
       html,
     })
+    logger.info({ email: to }, 'Sent sign-in OTP email')
   }
 
   private async sendWelcomeCode(opts: {
@@ -183,6 +184,7 @@ export class EmailSender {
       text,
       html,
     })
+    logger.info({ email: to }, 'Sent welcome OTP email')
   }
 
   async sendBackupEmailVerification(opts: {
@@ -201,5 +203,6 @@ export class EmailSender {
       text,
       html,
     })
+    logger.info({ email: to }, 'Sent backup email verification')
   }
 }


### PR DESCRIPTION
## Summary

Use the same structured recipient field name across every auth-service email delivery path. This makes log queries consistent without changing recipient values or outbound email envelopes.

## Changes

- Log successful delivery for all four `sendMail()` paths: client-branded OTP, standard sign-in OTP, welcome OTP, and backup-email verification.
- Expose the recipient as `email` in each application delivery log.
- Keep Nodemailer’s required `to` envelope property unchanged.
- Add an operator-facing changeset documenting the structured-log migration.

## Testing

- `pnpm format:check`
- `pnpm lint`
- TypeScript project build (`tsc --build tsconfig.json`)
- `pnpm test` (1,046 tests)
- `pnpm test:coverage`

## Notes

The recipient value is unchanged; only application logging is standardized and extended across all delivery paths.