### PR TITLE
auth: support mobile paste in segmented code input

### DIFF
--- a/.changeset/mobile-code-paste.md
+++ b/.changeset/mobile-code-paste.md
@@ -6,6 +6,6 @@ Pasting a sign-in code on mobile now fills the complete code instead of only the
 
 **Affects:** End users, Client app developers
 
-**End users:** No action is required; long-press paste and mobile one-time-code autofill now work with the existing segmented code-field appearance. Tapping or clicking a filled code slot selects that character for replacement.
+**End users:** No action is required; long-press paste and mobile one-time-code autofill now work with the existing segmented code-field appearance. Tapping or clicking a filled code slot selects that character for replacement. The field now provides clearer keyboard focus, announces status messages to screen readers, describes automatic submission, and respects reduced-motion preferences.
 
 **Client app developers:** Branding CSS that styles an active code slot should use `.otp-box.active` instead of `.otp-box:focus`; the real input now keeps focus while the slots remain presentational.

--- a/.changeset/mobile-code-paste.md
+++ b/.changeset/mobile-code-paste.md
@@ -1,11 +1,15 @@
 ---
-'ePDS': patch
+'ePDS': minor
 ---
 
-Pasting a sign-in code on mobile now fills the complete code instead of only the first character.
+Entering a sign-in code now works better on phones and with assistive technology.
 
 **Affects:** End users, Client app developers
 
-**End users:** No action is required; long-press paste and mobile one-time-code autofill now work with the existing segmented code-field appearance. Tapping or clicking a filled code slot selects that character for replacement. The field now provides clearer keyboard focus, announces status messages to screen readers, describes automatic submission, and respects reduced-motion preferences.
+**End users:** Long-press paste and one-time-code autofill now fill the whole code. Filled positions can be selected and replaced, status messages are announced to screen readers, and the code field respects reduced-motion settings.
 
-**Client app developers:** Branding CSS that styles an active code slot should use `.otp-box.active` instead of `.otp-box:focus`; the real input now keeps focus while the slots remain presentational.
+**Client app developers:** This is a breaking change for branding CSS that targets the sign-in code field.
+
+- `.otp-box` is now a `<div>` instead of an `<input>`. Selectors such as `input.otp-box`, `input[data-slot]`, and `.otp-box::placeholder` no longer match.
+- `.otp-box:focus` no longer matches because one `.otp-input-overlay` now owns focus. Use `.otp-box.active` for the selected position and `.otp-character.placeholder` for empty positions.
+- Broad `input` and `input:focus` rules now also match `.otp-input-overlay`. Exclude that class or override it so its background, border, outline, text, and caret stay transparent; otherwise it may cover the visible code boxes.

--- a/.changeset/mobile-code-paste.md
+++ b/.changeset/mobile-code-paste.md
@@ -6,6 +6,6 @@ Pasting a sign-in code on mobile now fills the complete code instead of only the
 
 **Affects:** End users, Client app developers
 
-**End users:** No action is required; long-press paste and mobile one-time-code autofill now work with the existing segmented code-field appearance.
+**End users:** No action is required; long-press paste and mobile one-time-code autofill now work with the existing segmented code-field appearance. Tapping or clicking a filled code slot selects that character for replacement.
 
 **Client app developers:** Branding CSS that styles an active code slot should use `.otp-box.active` instead of `.otp-box:focus`; the real input now keeps focus while the slots remain presentational.

--- a/.changeset/mobile-code-paste.md
+++ b/.changeset/mobile-code-paste.md
@@ -8,8 +8,4 @@ Entering a sign-in code now works better on phones and with assistive technology
 
 **End users:** Long-press paste and one-time-code autofill now fill the whole code. Filled positions can be selected and replaced, status messages are announced to screen readers, and the code field respects reduced-motion settings.
 
-**Client app developers:** This is a breaking change for branding CSS that targets the sign-in code field.
-
-- `.otp-box` is now a `<div>` instead of an `<input>`. Selectors such as `input.otp-box`, `input[data-slot]`, and `.otp-box::placeholder` no longer match.
-- `.otp-box:focus` no longer matches because one `.otp-input-overlay` now owns focus. Use `.otp-box.active` for the selected position and `.otp-character.placeholder` for empty positions.
-- Broad `input` and `input:focus` rules now also match `.otp-input-overlay`. Exclude that class or override it so its background, border, outline, text, and caret stay transparent; otherwise it may cover the visible code boxes.
+**Client app developers:** Existing trusted-client visual styling on direct `input` selectors and their focus or placeholder states continues to style the sign-in code slots automatically. Common `input.otp-box`, `input[data-slot]`, `.otp-box:focus`, and `.otp-box::placeholder` forms are also supported. New branding should use `.otp-box.active` for the selected position and `.otp-character.placeholder` for empty positions; `.otp-input-overlay` is internal and protected from broad `input` rules. Browser automation that previously filled each `.otp-box` should fill the single `#code` input instead; malformed CSS, mechanical input declarations, and more complex DOM-coupled selectors remain unchanged.

--- a/.changeset/mobile-code-paste.md
+++ b/.changeset/mobile-code-paste.md
@@ -1,0 +1,11 @@
+---
+'ePDS': patch
+---
+
+Pasting a sign-in code on mobile now fills the complete code instead of only the first character.
+
+**Affects:** End users, Client app developers
+
+**End users:** No action is required; long-press paste and mobile one-time-code autofill now work with the existing segmented code-field appearance.
+
+**Client app developers:** Branding CSS that styles an active code slot should use `.otp-box.active` instead of `.otp-box:focus`; the real input now keeps focus while the slots remain presentational.

--- a/docs/design/testing-gaps.md
+++ b/docs/design/testing-gaps.md
@@ -89,6 +89,11 @@ this area's main gap: `login-page.ts`, `consent.ts`, `recovery.ts`, `account-log
   signCallback round-trip).
 - Pure helper functions within routes (e.g., handle validation in
   `choose-handle.ts`) could be extracted and tested.
+- OTP branding compatibility is extracted into `otp-branding-compat.ts` and
+  unit-tested across broad input, focus, placeholder, `.otp-box`, and
+  `[data-slot]` selectors, including malformed-CSS fallback and rejection of
+  mechanical declarations. Client-branding e2e coverage checks computed styles
+  and hit testing; mobile autofill still requires physical-device coverage.
 
 **Recommended strategy:**
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -408,6 +408,8 @@ so retinting the whole card is one declaration:
 }
 ```
 
+The sign-in code control exposes `.otp-box` for each visual position, `.otp-box.active` for the selected position, and `.otp-character.placeholder` for empty positions. To preserve common visual rules written for the old inputs, ePDS projects direct `input` selectors and their `:focus`, `:focus-visible`, and `::placeholder` states onto those elements. The same projections support `input.otp-box` and `input[data-slot]`, while `.otp-box:focus`, `.otp-box:focus-visible`, and `.otp-box::placeholder` remain compatible. Mechanical declarations such as `display` and `touch-action`, more complex DOM-coupled selectors, and malformed stylesheets are not projected. Treat `.otp-input-overlay` as an internal interaction element; ePDS protects it from broad `input` rules so client branding cannot cover or disable the visual slots. Browser automation should fill the single `#code` input rather than individual `.otp-box` elements.
+
 The upstream consent + chooser pages served by pds-core ship with
 default Certified-style styling out of the box; trusted-client
 `branding.css` is layered on top of it via cascade order, so any rules

--- a/e2e/step-definitions/auth.steps.ts
+++ b/e2e/step-definitions/auth.steps.ts
@@ -46,14 +46,13 @@ async function buildIncorrectOtpCode(world: EpdsWorld): Promise<string> {
   // When world.otpCode is not set (e.g. the OTP email step was skipped),
   // we cannot read OTP_LENGTH / OTP_CHARSET from env directly because the
   // test runner has no access to the deployed service's environment on
-  // Railway. Instead, infer the config from the segmented OTP boxes that
-  // the auth service renders. Length comes from the box count; charset is
-  // inferred from the per-box inputmode attribute (the old hidden-input
-  // path's `pattern` attribute is no longer rendered).
+  // Railway. Instead, infer the config from the real OTP input rendered by
+  // the auth service.
   const page = getPage(world)
-  const boxes = page.locator('.otp-box')
-  const otpLength = (await boxes.count()) || testEnv.otpLength
-  const inputModeAttr = await boxes.first().getAttribute('inputmode')
+  const input = page.locator('#code')
+  const maxlengthAttr = await input.getAttribute('maxlength')
+  const otpLength = Number(maxlengthAttr) || testEnv.otpLength
+  const inputModeAttr = await input.getAttribute('inputmode')
   const otpCharset: 'numeric' | 'alphanumeric' =
     inputModeAttr === 'numeric' ? 'numeric' : testEnv.otpCharset
 
@@ -351,18 +350,16 @@ Then(
   async function (this: EpdsWorld) {
     const page = getPage(this)
     const boxes = page.locator('.otp-box')
+    const input = page.locator('#code')
     const count = await boxes.count()
     if (count === 0) {
       throw new Error('No .otp-box elements found — OTP form is not rendered')
     }
-    // Every box must be both visible AND enabled. Asserting on .first()
-    // alone hid regressions where a partial form (e.g. a stale
-    // "verifying..." latch on later boxes) blocked further attempts even
-    // though the first box looked fine.
-    for (let i = 0; i < count; i++) {
-      await expect(boxes.nth(i)).toBeVisible()
-      await expect(boxes.nth(i)).toBeEnabled()
+    for (let index = 0; index < count; index++) {
+      await expect(boxes.nth(index)).toBeVisible()
     }
+    await expect(input).toBeVisible()
+    await expect(input).toBeEnabled()
   },
 )
 
@@ -628,14 +625,15 @@ Then(
 When(
   'the user enters two digits from the old OTP',
   async function (this: EpdsWorld) {
-    const otpBoxes = getPage(this).locator('.otp-box')
-    await otpBoxes.nth(0).fill('1')
-    await otpBoxes.nth(1).fill('2')
-    // Prove the digits actually landed, so the later empty-box assertion
+    // The .otp-box divs are presentational; the code lives in the single
+    // #code input behind them.
+    const input = getPage(this).locator('#code')
+    await input.focus()
+    await input.pressSequentially('12')
+    // Prove the digits actually landed, so the later empty-input assertion
     // demonstrates that resend cleared them rather than that they were
     // never entered.
-    await expect(otpBoxes.nth(0)).toHaveValue('1')
-    await expect(otpBoxes.nth(1)).toHaveValue('2')
+    await expect(input).toHaveValue('12')
   },
 )
 
@@ -685,12 +683,20 @@ Then(
     if (!this.otpCode) {
       throw new Error('No fresh OTP was captured from the mail trap')
     }
-    const otpBoxes = getPage(this).locator('.otp-box')
+    const page = getPage(this)
+    const otpBoxes = page.locator('.otp-box')
+    const input = page.locator('#code')
     await expect(otpBoxes).toHaveCount(this.otpCode.length)
+    // The code lives in the single input behind the slots, so emptiness is
+    // its value. Each slot still renders a placeholder character when empty,
+    // hence the `empty` class rather than empty text.
+    await expect(input).toHaveValue('')
     for (let index = 0; index < this.otpCode.length; index += 1) {
-      await expect(otpBoxes.nth(index)).toHaveValue('')
+      await expect(otpBoxes.nth(index)).toHaveClass(/\bempty\b/)
     }
-    await expect(otpBoxes.first()).toBeFocused()
+    // Focus lands on the input; the first slot reflects it via `active`.
+    await expect(input).toBeFocused()
+    await expect(otpBoxes.first()).toHaveClass(/\bactive\b/)
   },
 )
 

--- a/e2e/step-definitions/client-branding.steps.ts
+++ b/e2e/step-definitions/client-branding.steps.ts
@@ -110,6 +110,142 @@ Then(
 )
 
 Then(
+  'legacy OTP selectors style the visual code slots',
+  async function (this: EpdsWorld) {
+    await waitForLoginPage(this)
+    const page = getPage(this)
+    const input = page.locator('#code')
+    await expect(input).toBeVisible()
+    await input.focus()
+    await page.waitForFunction(() => {
+      const slot = document.querySelector<HTMLElement>('.otp-box.active')
+      if (!slot) return false
+
+      const probe = document.createElement('span')
+      probe.style.color = 'var(--focus-border)'
+      document.body.appendChild(probe)
+      const expectedFocus = getComputedStyle(probe).color
+      probe.remove()
+      return getComputedStyle(slot).borderColor === expectedFocus
+    })
+
+    const result = await page.evaluate(() => {
+      const slot = document.querySelector<HTMLElement>('.otp-box.active')
+      const character = slot?.querySelector<HTMLElement>(
+        '.otp-character.placeholder',
+      )
+      const idleSlot = document.querySelector<HTMLElement>(
+        '.otp-box:not(.active)',
+      )
+      const emailInput = document.querySelector<HTMLInputElement>('#email')
+      const heading = document.querySelector<HTMLElement>('#heading')
+      if (!slot || !character || !idleSlot || !emailInput || !heading) {
+        return null
+      }
+
+      const probe = document.createElement('span')
+      probe.style.color = 'var(--focus-border)'
+      document.body.appendChild(probe)
+      const expectedFocus = getComputedStyle(probe).color
+      probe.remove()
+
+      const css = Array.from(document.querySelectorAll('style'))
+        .map((style) => style.textContent)
+        .join('\n')
+
+      return {
+        hasInputAlias: css.includes(':where(#otp-boxes)>div:where(.otp-box)'),
+        hasFocusAlias: css.includes(
+          ':where(#otp-boxes)>div:where(.otp-box).active',
+        ),
+        hasPlaceholderAlias: css.includes(
+          ':where(#otp-boxes)>div:where(.otp-box)>span:where(.otp-character.placeholder)',
+        ),
+        slotColor: getComputedStyle(slot).color,
+        headingColor: getComputedStyle(heading).color,
+        slotBackground: getComputedStyle(idleSlot).backgroundColor,
+        expectedInputBackground: getComputedStyle(emailInput).backgroundColor,
+        slotBorderColor: getComputedStyle(idleSlot).borderColor,
+        expectedInputBorderColor: getComputedStyle(emailInput).borderColor,
+        placeholderColor: getComputedStyle(character).color,
+        expectedPlaceholderColor: getComputedStyle(emailInput, '::placeholder')
+          .color,
+        activeBorderColor: getComputedStyle(slot).borderColor,
+        expectedFocus,
+      }
+    })
+
+    expect(result).not.toBeNull()
+    expect(result).toMatchObject({
+      hasInputAlias: true,
+      hasFocusAlias: true,
+      hasPlaceholderAlias: true,
+    })
+    expect(result?.slotColor).toBe(result?.headingColor)
+    expect(result?.slotBackground).toBe(result?.expectedInputBackground)
+    expect(result?.slotBorderColor).toBe(result?.expectedInputBorderColor)
+    expect(result?.placeholderColor).toBe(result?.expectedPlaceholderColor)
+    expect(result?.activeBorderColor).toBe(result?.expectedFocus)
+  },
+)
+
+Then(
+  'the real OTP input remains protected and hit-testable',
+  async function (this: EpdsWorld) {
+    await waitForLoginPage(this)
+    const page = getPage(this)
+    const input = page.locator('#code')
+    await expect(input).toBeVisible()
+    await expect(input).toBeEnabled()
+    await input.fill('12')
+
+    const result = await input.evaluate((element) => {
+      const otpInput = element as HTMLInputElement
+      const style = getComputedStyle(otpInput)
+      const slots = Array.from(
+        document.querySelectorAll<HTMLElement>('.otp-box'),
+      )
+
+      return {
+        display: style.display,
+        visibility: style.visibility,
+        opacity: style.opacity,
+        pointerEvents: style.pointerEvents,
+        touchAction: style.touchAction,
+        userSelect: style.userSelect,
+        backgroundColor: style.backgroundColor,
+        borderWidth: style.borderWidth,
+        hitTestedAcrossSlots: slots.every((slot) => {
+          const rect = slot.getBoundingClientRect()
+          return (
+            document.elementFromPoint(
+              rect.left + rect.width / 2,
+              rect.top + rect.height / 2,
+            ) === otpInput
+          )
+        }),
+        renderedCharacters: slots
+          .slice(0, 2)
+          .map((slot) => slot.textContent.trim()),
+      }
+    })
+
+    expect(result).toMatchObject({
+      display: 'block',
+      visibility: 'visible',
+      opacity: '1',
+      pointerEvents: 'auto',
+      touchAction: 'auto',
+      userSelect: 'text',
+      backgroundColor: 'rgba(0, 0, 0, 0)',
+      borderWidth: '0px',
+      hitTestedAcrossSlots: true,
+      renderedCharacters: ['1', '2'],
+    })
+  },
+)
+
+Then(
   'the login page body uses the default background color',
   async function (this: EpdsWorld) {
     await waitForLoginPage(this)

--- a/e2e/step-definitions/client-branding.steps.ts
+++ b/e2e/step-definitions/client-branding.steps.ts
@@ -30,6 +30,17 @@ const INJECTED_CSS_SIGNATURE = 'body { background: #1a1208'
 // retint it.
 const DEFAULT_LOGIN_BG_RGB = 'rgb(232, 232, 232)' // #E8E8E8
 
+// Stable computed signatures for the trusted demo's default amber theme.
+// These are intentionally independent of other elements on the rendered page
+// so a regression affecting both source inputs and projected slots still fails.
+const TRUSTED_OTP_STYLE = {
+  slotColor: 'rgb(254, 243, 199)', // #fef3c7
+  slotBackground: 'rgb(26, 18, 8)', // #1a1208
+  slotBorderColor: 'rgb(74, 53, 32)', // #4a3520
+  placeholderColor: 'rgb(185, 139, 85)', // #b98b55
+  activeBorderColor: 'rgb(245, 158, 11)', // #f59e0b
+} as const
+
 async function waitForLoginPage(world: EpdsWorld): Promise<void> {
   const page = getPage(world)
   // Wait for auth-service-specific element — #step-otp only exists on
@@ -117,17 +128,12 @@ Then(
     const input = page.locator('#code')
     await expect(input).toBeVisible()
     await input.focus()
-    await page.waitForFunction(() => {
+    await page.waitForFunction((expectedBorder) => {
       const slot = document.querySelector<HTMLElement>('.otp-box.active')
-      if (!slot) return false
-
-      const probe = document.createElement('span')
-      probe.style.color = 'var(--focus-border)'
-      document.body.appendChild(probe)
-      const expectedFocus = getComputedStyle(probe).color
-      probe.remove()
-      return getComputedStyle(slot).borderColor === expectedFocus
-    })
+      return slot
+        ? getComputedStyle(slot).borderColor === expectedBorder
+        : false
+    }, TRUSTED_OTP_STYLE.activeBorderColor)
 
     const result = await page.evaluate(() => {
       const slot = document.querySelector<HTMLElement>('.otp-box.active')
@@ -137,17 +143,7 @@ Then(
       const idleSlot = document.querySelector<HTMLElement>(
         '.otp-box:not(.active)',
       )
-      const emailInput = document.querySelector<HTMLInputElement>('#email')
-      const heading = document.querySelector<HTMLElement>('#heading')
-      if (!slot || !character || !idleSlot || !emailInput || !heading) {
-        return null
-      }
-
-      const probe = document.createElement('span')
-      probe.style.color = 'var(--focus-border)'
-      document.body.appendChild(probe)
-      const expectedFocus = getComputedStyle(probe).color
-      probe.remove()
+      if (!slot || !character || !idleSlot) return null
 
       const css = Array.from(document.querySelectorAll('style'))
         .map((style) => style.textContent)
@@ -162,16 +158,10 @@ Then(
           ':where(#otp-boxes)>div:where(.otp-box)>span:where(.otp-character.placeholder)',
         ),
         slotColor: getComputedStyle(slot).color,
-        headingColor: getComputedStyle(heading).color,
         slotBackground: getComputedStyle(idleSlot).backgroundColor,
-        expectedInputBackground: getComputedStyle(emailInput).backgroundColor,
         slotBorderColor: getComputedStyle(idleSlot).borderColor,
-        expectedInputBorderColor: getComputedStyle(emailInput).borderColor,
         placeholderColor: getComputedStyle(character).color,
-        expectedPlaceholderColor: getComputedStyle(emailInput, '::placeholder')
-          .color,
         activeBorderColor: getComputedStyle(slot).borderColor,
-        expectedFocus,
       }
     })
 
@@ -180,12 +170,8 @@ Then(
       hasInputAlias: true,
       hasFocusAlias: true,
       hasPlaceholderAlias: true,
+      ...TRUSTED_OTP_STYLE,
     })
-    expect(result?.slotColor).toBe(result?.headingColor)
-    expect(result?.slotBackground).toBe(result?.expectedInputBackground)
-    expect(result?.slotBorderColor).toBe(result?.expectedInputBorderColor)
-    expect(result?.placeholderColor).toBe(result?.expectedPlaceholderColor)
-    expect(result?.activeBorderColor).toBe(result?.expectedFocus)
   },
 )
 

--- a/e2e/step-definitions/otp-character-filtering.steps.ts
+++ b/e2e/step-definitions/otp-character-filtering.steps.ts
@@ -33,11 +33,17 @@ Then(
 // Segmented sign-in grid
 //
 // The grid is a different code path from the two single-input forms: its
-// filtering lives in JS input/paste handlers rather than an oninput
-// attribute, and the paste handler additionally spreads the cleaned
-// characters across boxes. Neither behaviour is observable in the rendered
-// HTML, so only a browser-level test can catch a regression there.
+// filtering lives in a JS input/paste handler rather than an oninput
+// attribute, and the paste handler additionally normalizes the whole value
+// before it is rendered across the slots. Neither behaviour is observable in
+// the rendered HTML, so only a browser-level test can catch a regression.
+//
+// The grid is one real `#code` input behind non-interactive `.otp-box` divs
+// (needed for mobile long-press paste and one-time-code autofill), so these
+// steps drive `#code` and assert on what each slot displays.
 // ---------------------------------------------------------------------------
+
+const SIGN_IN_OTP_INPUT = '#code'
 
 When(
   'the sign-in OTP preview uses the {string} character policy',
@@ -47,15 +53,20 @@ When(
       `${testEnv.authUrl}/preview/login-otp?otp_charset=${encodeURIComponent(charset)}`,
     )
     // The handlers under test are attached by the page's inline script, so
-    // wait for the boxes rather than racing the script with the first fill.
-    await page.locator('.otp-box').first().waitFor({ state: 'visible' })
+    // wait for the input rather than racing the script with the first fill.
+    await page.locator(SIGN_IN_OTP_INPUT).waitFor({ state: 'visible' })
   },
 )
 
 When(
   'the user types {string} into the first sign-in OTP box',
   async function (this: EpdsWorld, value: string) {
-    await getPage(this).locator('.otp-box').first().fill(value)
+    // pressSequentially, not fill: typing one character at a time is what a
+    // user does, and it drives the input handler once per character the way
+    // the old per-box grid did.
+    const input = getPage(this).locator(SIGN_IN_OTP_INPUT)
+    await input.focus()
+    await input.pressSequentially(value)
   },
 )
 
@@ -64,14 +75,13 @@ When(
   async function (this: EpdsWorld, value: string) {
     // Playwright cannot portably seed the system clipboard, and the handler
     // reads only event.clipboardData, so synthesise the event directly. This
-    // still drives the real listener, including its filtering and spreading.
+    // still drives the real listener, including its normalization.
     await getPage(this)
-      .locator('.otp-box')
-      .first()
-      .evaluate((box, pasted) => {
+      .locator(SIGN_IN_OTP_INPUT)
+      .evaluate((input, pasted) => {
         const data = new DataTransfer()
         data.setData('text/plain', pasted)
-        box.dispatchEvent(
+        input.dispatchEvent(
           new ClipboardEvent('paste', {
             clipboardData: data,
             bubbles: true,
@@ -85,21 +95,29 @@ When(
 Then(
   'the sign-in OTP boxes spell {string}',
   async function (this: EpdsWorld, expected: string) {
-    const boxes = getPage(this).locator('.otp-box')
+    const page = getPage(this)
+    const boxes = page.locator('.otp-box')
     const count = await boxes.count()
     if (count < expected.length) {
       throw new Error(
         `Expected at least ${expected.length} OTP boxes, found ${count}`,
       )
     }
-    // Assert on every box rather than just the filled prefix: a spreading
-    // bug that scattered characters into later boxes would otherwise pass.
-    const padded = expected.padEnd(count, ' ')
+    // The input holds the value the form actually submits, so pin it directly
+    // rather than inferring it from the slots alone.
+    await expect(page.locator(SIGN_IN_OTP_INPUT)).toHaveValue(expected)
+    // Then assert every slot renders it, including that the trailing slots
+    // stayed empty — a normalization bug that leaked extra characters into
+    // later slots would otherwise pass. An empty slot still shows a
+    // placeholder character, so `empty` is the class, not the text.
     for (let index = 0; index < count; index += 1) {
-      const character = padded[index]
-      await expect(boxes.nth(index)).toHaveValue(
-        character === ' ' ? '' : character,
-      )
+      const box = boxes.nth(index)
+      if (index >= expected.length) {
+        await expect(box).toHaveClass(/\bempty\b/)
+      } else {
+        await expect(box).not.toHaveClass(/\bempty\b/)
+        await expect(box.locator('.otp-character')).toHaveText(expected[index])
+      }
     }
   },
 )

--- a/e2e/support/flows.ts
+++ b/e2e/support/flows.ts
@@ -76,8 +76,8 @@ export async function pickHandle(world: EpdsWorld): Promise<void> {
  *   2. Fill #email with the provided email, submit
  *   3. Wait for #step-otp.active (30 s)
  *   4. Fetch OTP from Mailpit via waitForEmail + extractOtp
- *   5. Fill the segmented OTP boxes via fillOtp (page auto-submits on
- *      the last digit; no explicit verify click needed)
+ *   5. Fill the OTP control via fillOtp (page auto-submits when the
+ *      complete code is entered; no explicit verify click needed)
  *   6. Wait for /auth/choose-handle, fill #handle-input with a generated
  *      local part, wait for the availability check to confirm "available",
  *      then click #submit-btn

--- a/e2e/support/otp.ts
+++ b/e2e/support/otp.ts
@@ -1,25 +1,15 @@
 /**
- * Helper for filling the auth-service login page's segmented 6-box OTP input.
+ * Fill the auth-service login page's OTP control.
  *
- * The login page renders six visible `.otp-box` inputs that feed a hidden
- * `#code` field via JS. The page's input handler auto-submits the verify
- * form once the last digit is entered, so callers should NOT click the
- * verify button after this helper returns.
+ * The page uses one real `#code` input beneath segmented visual slots. Filling
+ * the complete value in one operation matches paste and mobile autofill, and
+ * the input handler auto-submits when the configured length is reached.
  */
 import type { Page } from '@playwright/test'
 
 export async function fillOtp(page: Page, otp: string): Promise<void> {
-  const boxes = page.locator('.otp-box')
-  await boxes.first().waitFor({ state: 'visible' })
-  // Clear any stale digits first. Otherwise filling box[0] of a populated
-  // form leaves boxes 1–5 with old values, and the input handler sees a
-  // 6-char hidden value on the very first fill — triggering a premature
-  // auto-submit with mixed old+new digits.
-  const count = await boxes.count()
-  for (let i = 0; i < count; i++) {
-    await boxes.nth(i).fill('')
-  }
-  for (let i = 0; i < otp.length; i++) {
-    await boxes.nth(i).fill(otp[i])
-  }
+  const input = page.locator('#code')
+  await input.waitFor({ state: 'visible' })
+  await input.fill('')
+  await input.fill(otp)
 }

--- a/e2e/tsconfig.e2e.json
+++ b/e2e/tsconfig.e2e.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "module": "Node16",
     "moduleResolution": "Node16",
     "strict": true,

--- a/features/client-branding.feature
+++ b/features/client-branding.feature
@@ -13,6 +13,11 @@ Feature: Client branding — CSS injection and custom email templates
     When the trusted demo client initiates an OAuth login
     Then the login page HTML contains the trusted client's custom CSS
 
+  Scenario: Legacy OTP branding remains functional with the single input
+    When the trusted demo client initiates an OAuth login
+    Then legacy OTP selectors style the visual code slots
+    And the real OTP input remains protected and hit-testable
+
   @untrusted-client
   Scenario: Trusted and untrusted demo clients render visibly differently
     When the trusted demo client initiates an OAuth login

--- a/packages/auth-service/package.json
+++ b/packages/auth-service/package.json
@@ -17,6 +17,8 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "nodemailer": "^6.9.8",
+    "postcss": "^8.5.25",
+    "postcss-selector-parser": "^7.1.4",
     "svix": "^1.96.1"
   },
   "devDependencies": {

--- a/packages/auth-service/src/__tests__/login-page.test.ts
+++ b/packages/auth-service/src/__tests__/login-page.test.ts
@@ -562,6 +562,45 @@ describe('renderLoginPage sign-in error copy', () => {
   })
 })
 
+describe('renderLoginPage OTP accessibility', () => {
+  it('announces asynchronous status and error messages', () => {
+    const html = renderDefault()
+    expect(html).toContain(
+      'role="status" aria-live="polite" aria-atomic="true"',
+    )
+  })
+
+  it('describes code format and automatic submission to assistive technology', () => {
+    const numericHtml = renderDefault()
+    expect(numericHtml).toContain('aria-label="6-digit verification code"')
+    expect(numericHtml).toContain(
+      'aria-describedby="otp-subtitle otp-auto-submit"',
+    )
+    expect(numericHtml).toContain(
+      'The code submits automatically when all 6 digits are entered.',
+    )
+    expect(numericHtml).toContain('spellcheck="false"')
+
+    const alphanumericHtml = renderDefault({ otpCharset: 'alphanumeric' })
+    expect(alphanumericHtml).toContain(
+      'aria-label="6-character verification code"',
+    )
+    expect(alphanumericHtml).toContain(
+      'The code submits automatically when all 6 characters are entered.',
+    )
+  })
+
+  it('provides visible focus, themed caret colour, and reduced motion', () => {
+    const html = renderDefault()
+    expect(html).toContain(
+      '.otp-box.active { border-color: var(--focus-border); outline: 2px solid var(--focus-border); outline-offset: 2px; }',
+    )
+    expect(html).toContain('background: currentColor')
+    expect(html).toContain('@media (prefers-reduced-motion: reduce)')
+    expect(html).toContain('.otp-fake-caret { animation: none; }')
+  })
+})
+
 describe('renderLoginPage OTP verify-form double-submit latch (regression)', () => {
   it('declares the verifying flag at IIFE scope so input/paste/submit handlers share it', () => {
     const html = renderDefault()

--- a/packages/auth-service/src/__tests__/login-page.test.ts
+++ b/packages/auth-service/src/__tests__/login-page.test.ts
@@ -562,6 +562,102 @@ describe('renderLoginPage sign-in error copy', () => {
   })
 })
 
+describe('renderLoginPage OTP branding compatibility', () => {
+  it('renders client metadata without custom CSS', () => {
+    const logoUri = 'https://client.example/logo.png'
+    const html = renderDefault({
+      branding: {
+        client_name: 'Example App',
+        brand_color: '#111111',
+        logo_uri: logoUri,
+      },
+      initialStep: 'otp',
+      otpAlreadySent: true,
+      loginHint: 'user@example.com',
+      termsOfServiceUrl: 'https://client.example/terms',
+      privacyPolicyUrl: 'https://client.example/privacy',
+      legalEntityName: 'Example Org',
+    })
+
+    expect(html).toContain('<title>Sign in to Example App</title>')
+    expect(html).toContain(`src="${logoUri}" alt="Example App"`)
+    expect(html).toContain('--focus-border: #111111')
+    expect(html).toContain('<h1 id="heading">Enter your code</h1>')
+    expect(html).toContain('Code already sent to us***@example.com')
+    expect(html).toContain(
+      'style="display:none;">By signing in, you agree to Example Org\'s',
+    )
+  })
+
+  it('rejects unsafe client brand colors before CSS interpolation', () => {
+    const html = renderDefault({
+      branding: {
+        brand_color: 'red; background: url(https://example.com/tracker)',
+      },
+    })
+
+    expect(html).toContain('--focus-border: #1A130F')
+    expect(html).not.toContain('tracker')
+  })
+
+  it('renders malformed client CSS unchanged without blocking login', () => {
+    const malformedCss = '.otp-box:focus { color: gold;'
+    const html = renderDefault({ customCss: malformedCss })
+
+    expect(html).toContain(`<style>${malformedCss}</style>`)
+    expect(html).toContain('data-epds-otp-invariants')
+    expect(html).toContain('id="form-verify-otp"')
+  })
+
+  it('aliases legacy focus styling to the active visual slot', () => {
+    const html = renderDefault({
+      customCss: '.otp-box:focus { border-color: rgb(1, 2, 3) !important; }',
+    })
+
+    expect(html).toMatch(
+      /\.otp-box:focus\s*,\s*\.otp-box\.active\s*\{\s*border-color: rgb\(1, 2, 3\) !important;/,
+    )
+  })
+
+  it('protects the real input after client branding is applied', () => {
+    const customCss =
+      'input { display: none !important; background: white !important; }'
+    const html = renderDefault({ customCss })
+    const clientCssIndex = html.indexOf(customCss)
+    const invariantCssIndex = html.indexOf('data-epds-otp-invariants')
+
+    expect(clientCssIndex).toBeGreaterThan(0)
+    expect(invariantCssIndex).toBeGreaterThan(clientCssIndex)
+    expect(html.slice(invariantCssIndex)).toContain(
+      '#form-verify-otp #otp-boxes > #code.otp-input-overlay',
+    )
+    expect(html.slice(invariantCssIndex)).toContain(
+      'pointer-events: auto !important',
+    )
+    expect(html.slice(invariantCssIndex)).toContain(
+      'background: transparent !important',
+    )
+  })
+
+  it('protects long-press paste and wins over important client layers', () => {
+    const customCss =
+      '@layer branding { input { display: none !important; touch-action: none !important; } }'
+    const html = renderDefault({ customCss })
+    const layerDeclarationIndex = html.indexOf('@layer epds-otp-invariants;')
+    const clientCssIndex = html.indexOf('@layer branding')
+    const invariantCssIndex = html.indexOf('data-epds-otp-invariants')
+    const invariantCss = html.slice(invariantCssIndex)
+
+    expect(layerDeclarationIndex).toBeGreaterThan(0)
+    expect(layerDeclarationIndex).toBeLessThan(clientCssIndex)
+    expect(invariantCssIndex).toBeGreaterThan(clientCssIndex)
+    expect(invariantCss).toContain('@layer epds-otp-invariants')
+    expect(invariantCss).toContain('-webkit-touch-callout: default !important')
+    expect(invariantCss).toContain('-webkit-user-select: text !important')
+    expect(invariantCss).toContain('touch-action: auto !important')
+  })
+})
+
 describe('renderLoginPage OTP accessibility', () => {
   it('announces asynchronous status and error messages', () => {
     const html = renderDefault()

--- a/packages/auth-service/src/__tests__/login-page.test.ts
+++ b/packages/auth-service/src/__tests__/login-page.test.ts
@@ -601,6 +601,42 @@ describe('renderLoginPage OTP accessibility', () => {
   })
 })
 
+describe('renderLoginPage OTP pointer selection', () => {
+  it('selects mouse slots on pointerdown before native caret placement', () => {
+    const html = renderDefault()
+    const pointerStart = html.indexOf("otpInput.addEventListener('pointerdown'")
+    const pointerEnd = html.indexOf(
+      "otpInput.addEventListener('click'",
+      pointerStart,
+    )
+    expect(pointerStart).toBeGreaterThan(0)
+    expect(pointerEnd).toBeGreaterThan(pointerStart)
+
+    const pointerHandler = html.slice(pointerStart, pointerEnd)
+    expect(pointerHandler).toContain("e.pointerType !== 'mouse'")
+    const preventDefault = pointerHandler.indexOf('e.preventDefault();')
+    const focus = pointerHandler.indexOf('otpInput.focus();')
+    const selectSlot = pointerHandler.indexOf('selectOtpSlotAtPoint(')
+    expect(preventDefault).toBeGreaterThan(0)
+    expect(focus).toBeGreaterThan(preventDefault)
+    expect(selectSlot).toBeGreaterThan(focus)
+  })
+
+  it('retains click selection as the touch and iOS fallback', () => {
+    const html = renderDefault()
+    const clickStart = html.indexOf("otpInput.addEventListener('click'")
+    const clickEnd = html.indexOf(
+      "otpInput.addEventListener('keyup'",
+      clickStart,
+    )
+    expect(clickStart).toBeGreaterThan(0)
+    expect(clickEnd).toBeGreaterThan(clickStart)
+    expect(html.slice(clickStart, clickEnd)).toContain(
+      'selectOtpSlotAtPoint(e.clientX, e.clientY)',
+    )
+  })
+})
+
 describe('renderLoginPage OTP verify-form double-submit latch (regression)', () => {
   it('declares the verifying flag at IIFE scope so input/paste/submit handlers share it', () => {
     const html = renderDefault()

--- a/packages/auth-service/src/__tests__/login-page.test.ts
+++ b/packages/auth-service/src/__tests__/login-page.test.ts
@@ -23,6 +23,7 @@ import {
   safeResolveClientMetadata,
 } from '../routes/login-page.js'
 import type { ClientMetadata } from '../lib/client-metadata.js'
+import { normalizeOtpValue } from '../otp-input.js'
 
 // ---------------------------------------------------------------------------
 // Shared DB helpers
@@ -739,10 +740,10 @@ describe('renderLoginPage flow-aborted notice + reactive abort gates', () => {
     const fnEnd = html.indexOf('function abortIfFlowDead', fnStart)
     expect(fnEnd).toBeGreaterThan(fnStart)
     const fnBody = html.slice(fnStart, fnEnd)
-    // OTP boxes, Resend, Back, and Verify must all get disabled —
+    // OTP input, Resend, Back, and Verify must all get disabled —
     // anything left enabled would let the user click into a path
     // that silently fails.
-    expect(fnBody).toMatch(/otpBoxes\[i\]\.disabled = true/)
+    expect(fnBody).toMatch(/otpInput\.disabled = true/)
     expect(fnBody).toMatch(/resendBtn\.disabled = true/)
     expect(fnBody).toMatch(/backBtn\.disabled = true/)
     expect(fnBody).toMatch(/verifyBtn\.disabled = true/)
@@ -865,64 +866,63 @@ describe('renderLoginPage flow-aborted notice + reactive abort gates', () => {
   })
 })
 
-// The segmented OTP grid used to strip whitespace only, so a code copied
+// The segmented OTP input used to strip whitespace only, so a code copied
 // with surrounding punctuation, or a letter typed into a digits-only code,
 // reached the server verbatim and failed verification. It also never
 // upper-cased, while alphanumeric codes are generated as A-Z0-9 and the
 // other two OTP forms upper-case on the way in — so a desktop user typing
 // lowercase (where `autocapitalize` does nothing) submitted a code the
-// server would always reject. These pin the shared charset filter.
-describe('renderLoginPage OTP grid charset filter', () => {
-  it('emits the numeric filter from the shared helper', () => {
-    const html = renderDefault({ otpCharset: 'numeric' })
-    expect(html).toContain(`var otpCharFilter = ${/\D/g.toString()};`)
-  })
-
-  it('emits the alphanumeric filter from the shared helper', () => {
-    const html = renderDefault({ otpCharset: 'alphanumeric' })
-    expect(html).toContain(`var otpCharFilter = ${/[^A-Za-z0-9]/g.toString()};`)
-  })
-
-  it('upper-cases only under the alphanumeric policy', () => {
-    expect(renderDefault({ otpCharset: 'alphanumeric' })).toContain(
-      "otpCharset === 'alphanumeric' ? cleaned.toUpperCase() : cleaned",
+// server would always reject. These pin the shared charset normalizer.
+describe('renderLoginPage OTP charset filter', () => {
+  // The single input replaced the per-box `filterOtpChars` helper these
+  // originally pinned. normalizeOtpValue subsumes it — it strips whitespace,
+  // drops out-of-charset characters, upper-cases alphanumeric codes, and caps
+  // the length — and is unit-tested directly in otp-input.test.ts. These now
+  // pin that the page really ships that shared function rather than a
+  // divergent client-side copy, and that every entry path routes through it.
+  it('serializes the shared normalizer into the page', () => {
+    const html = renderDefault()
+    expect(html).toContain(
+      `var normalizeOtpValue = (${normalizeOtpValue.toString()});`,
     )
   })
 
-  it('routes the input handler through the filter, not a whitespace-only strip', () => {
+  it('routes typed input through the normalizer, not a whitespace-only strip', () => {
     const html = renderDefault()
-    expect(html).toContain('var v = filterOtpChars(box.value);')
+    expect(html).toContain(
+      'var normalized = normalizeOtpValue(otpInput.value, otpLength, otpCharset);',
+    )
     // The old whitespace-only strip is a strict subset of every charset
-    // filter; leaving one behind would mean a handler was missed.
+    // filter; leaving one behind would mean an entry path was missed.
     expect(html).not.toMatch(/replace\(\/\\s\/g, ''\)/)
   })
 
-  it('routes the paste handler through the filter before slicing to the free boxes', () => {
+  it('routes pasted input through the normalizer', () => {
     const html = renderDefault()
-    expect(html).toContain(
-      'var cleaned = filterOtpChars(data).slice(0, otpBoxes.length - idx);',
+    const pasteStart = html.indexOf("otpInput.addEventListener('paste'")
+    expect(pasteStart).toBeGreaterThan(0)
+    const pasteEnd = html.indexOf(
+      "otpInput.addEventListener('focus'",
+      pasteStart,
     )
+    expect(pasteEnd).toBeGreaterThan(pasteStart)
+    expect(html.slice(pasteStart, pasteEnd)).toContain('normalizeOtpValue(')
   })
 
-  it('defines the filter before the box handlers that call it', () => {
-    const html = renderDefault()
-    const defIdx = html.indexOf('function filterOtpChars(s)')
-    const inputIdx = html.indexOf('var v = filterOtpChars(box.value);')
-    const pasteIdx = html.indexOf('var cleaned = filterOtpChars(data)')
-    expect(defIdx).toBeGreaterThan(0)
-    expect(inputIdx).toBeGreaterThan(defIdx)
-    expect(pasteIdx).toBeGreaterThan(defIdx)
-  })
-
-  it('declares otpCharset once, above the filter that reads it', () => {
+  it('declares otpCharset once, above the normalizer that reads it', () => {
     const html = renderDefault()
     expect(html.match(/var otpCharset =/g)).toHaveLength(1)
     expect(html.match(/var otpLength =/g)).toHaveLength(1)
-    // filterOtpChars is only ever called from event handlers, but keeping
-    // the declaration above it removes any reliance on var hoisting.
     expect(html.indexOf('var otpCharset =')).toBeLessThan(
-      html.indexOf('function filterOtpChars(s)'),
+      html.indexOf('var normalizeOtpValue ='),
     )
+  })
+
+  it('normalizes to the configured charset', () => {
+    // Behavioural cover for what the serialized normalizer will do in the
+    // browser under each policy the page can be rendered with.
+    expect(normalizeOtpValue('1a2-3 4', 6, 'numeric')).toBe('1234')
+    expect(normalizeOtpValue('a1-b2 c3', 6, 'alphanumeric')).toBe('A1B2C3')
   })
 })
 

--- a/packages/auth-service/src/__tests__/otp-branding-compat.test.ts
+++ b/packages/auth-service/src/__tests__/otp-branding-compat.test.ts
@@ -139,6 +139,22 @@ describe('adaptOtpBrandingCss', () => {
     expect(result.css).toContain(OTP_PLACEHOLDER_ALIAS)
   })
 
+  it('preserves keyframe offsets while projecting ordinary selectors', () => {
+    const result = adaptOtpBrandingCss(`
+      @keyframes otp-caret-blink {
+        0%, 70%, 100% { opacity: 1; }
+        20%, 50% { opacity: 0; }
+      }
+      input { color: #1a130f !important; }
+    `)
+
+    expect(result.status).toBe('adapted')
+    expect(result.rewrites).toEqual(['input'])
+    expect(result.css).toContain('@keyframes otp-caret-blink')
+    expect(result.css).toContain('20%, 50% { opacity: 0; }')
+    expect(result.css).toContain(SLOT_ALIAS)
+  })
+
   it('does not project mechanical declarations onto visual slots', () => {
     const css = `
       input,

--- a/packages/auth-service/src/__tests__/otp-branding-compat.test.ts
+++ b/packages/auth-service/src/__tests__/otp-branding-compat.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest'
+import { adaptOtpBrandingCss } from '../lib/otp-branding-compat.js'
+
+const SLOT_ALIAS = ':where(#otp-boxes)>div:where(.otp-box)'
+const ACTIVE_SLOT_ALIAS = `${SLOT_ALIAS}.active`
+const INPUT_PLACEHOLDER_ALIAS = `${SLOT_ALIAS}>span:where(.otp-character.placeholder)`
+const CLASS_SLOT_ALIAS = ':where(#otp-boxes)>div.otp-box'
+const DATA_SLOT_ALIAS = ':where(#otp-boxes)>div[data-slot]:where(.otp-box)'
+const OTP_PLACEHOLDER_ALIAS = '.otp-box>span:where(.otp-character.placeholder)'
+
+describe('adaptOtpBrandingCss', () => {
+  it('returns absent when the client has no branding CSS', () => {
+    expect(adaptOtpBrandingCss(null)).toEqual({
+      status: 'absent',
+      css: null,
+      rewrites: [],
+    })
+  })
+
+  it('keeps unrelated CSS byte-for-byte unchanged', () => {
+    const css = 'body { color: tomato; }'
+
+    expect(adaptOtpBrandingCss(css)).toEqual({
+      status: 'unchanged',
+      css,
+      rewrites: [],
+    })
+  })
+
+  it('projects safe bare input visual declarations onto every slot', () => {
+    const result = adaptOtpBrandingCss(`
+      body, span, input {
+        /* Comments inside a rule must not affect declaration filtering. */
+        font-family: Georgia, serif !important;
+      }
+      input {
+        background-color: #faf8f6 !important;
+        border: 1px solid #d4c9bc !important;
+        color: #1a130f !important;
+      }
+    `)
+
+    expect(result.status).toBe('adapted')
+    expect(result.rewrites).toEqual(['input'])
+    expect((result.css ?? '').split(SLOT_ALIAS)).toHaveLength(3)
+  })
+
+  it('deduplicates bare focus and focus-visible projections', () => {
+    const result = adaptOtpBrandingCss(`
+      input:focus,
+      input:focus-visible,
+      textarea:focus {
+        border-color: #3e7053 !important;
+        outline-color: #3e7053 !important;
+        box-shadow: 0 0 0 3px #3e70533d !important;
+      }
+    `)
+
+    expect(result.status).toBe('adapted')
+    expect(result.rewrites).toEqual(['input-focus'])
+    expect((result.css ?? '').split(ACTIVE_SLOT_ALIAS)).toHaveLength(2)
+  })
+
+  it('projects a bare input placeholder color onto empty characters', () => {
+    const result = adaptOtpBrandingCss(
+      'input::placeholder, textarea::placeholder { color: #8c8279 !important; }',
+    )
+
+    expect(result.status).toBe('adapted')
+    expect(result.rewrites).toEqual(['input-placeholder'])
+    expect(result.css).toContain(INPUT_PLACEHOLDER_ALIAS)
+  })
+
+  it('projects class-qualified legacy input variants with matching specificity', () => {
+    const result = adaptOtpBrandingCss(`
+      input.otp-box {
+        background: #faf8f6 !important;
+        border-radius: 0 !important;
+        font-family: ui-monospace, monospace !important;
+      }
+      input.otp-box:focus,
+      input.otp-box:focus-visible {
+        border-color: #3e7053 !important;
+        box-shadow: 0 0 0 3px #3e70533d !important;
+      }
+      input.otp-box::placeholder {
+        color: #8c8279 !important;
+        font-style: italic !important;
+      }
+    `)
+
+    expect(result.status).toBe('adapted')
+    expect(result.rewrites).toEqual([
+      'input-otp-box',
+      'input-otp-box-focus',
+      'input-otp-box-placeholder',
+    ])
+    expect(result.css).toContain(CLASS_SLOT_ALIAS)
+    expect(result.css).toContain(`${CLASS_SLOT_ALIAS}.active`)
+    expect(result.css).toContain(
+      `${CLASS_SLOT_ALIAS}>span:where(.otp-character.placeholder)`,
+    )
+  })
+
+  it('projects data-slot-qualified legacy input variants with matching specificity', () => {
+    const result = adaptOtpBrandingCss(`
+      input[data-slot] { color: #1a130f !important; }
+      input[data-slot]:focus,
+      input[data-slot]:focus-visible { outline: 2px solid #d4b08a !important; }
+      input[data-slot]::placeholder { color: #8c8279 !important; }
+    `)
+
+    expect(result.status).toBe('adapted')
+    expect(result.rewrites).toEqual([
+      'input-data-slot',
+      'input-data-slot-focus',
+      'input-data-slot-placeholder',
+    ])
+    expect(result.css).toContain(DATA_SLOT_ALIAS)
+    expect(result.css).toContain(`${DATA_SLOT_ALIAS}.active`)
+    expect(result.css).toContain(
+      `${DATA_SLOT_ALIAS}>span:where(.otp-character.placeholder)`,
+    )
+  })
+
+  it('projects class-level focus and placeholder selectors', () => {
+    const result = adaptOtpBrandingCss(`
+      .otp-box:focus,
+      .otp-box:focus-visible {
+        border-color: #8b5cf6 !important;
+        outline: 2px solid #8b5cf6 !important;
+      }
+      .otp-box::placeholder { color: #d9d8d2 !important; }
+    `)
+
+    expect(result.status).toBe('adapted')
+    expect(result.rewrites).toEqual(['otp-box-focus', 'otp-box-placeholder'])
+    expect(result.css).toContain('.otp-box.active')
+    expect(result.css).toContain(OTP_PLACEHOLDER_ALIAS)
+  })
+
+  it('does not project mechanical declarations onto visual slots', () => {
+    const css = `
+      input,
+      input.otp-box,
+      input[data-slot] {
+        display: none !important;
+        touch-action: none !important;
+      }
+    `
+
+    expect(adaptOtpBrandingCss(css)).toEqual({
+      status: 'unchanged',
+      css,
+      rewrites: [],
+    })
+  })
+
+  it('does not project unrelated or structurally complex selectors', () => {
+    const css = `
+      .field input,
+      input[type="checkbox"],
+      .theme input.otp-box,
+      :is(.otp-box):focus {
+        background: white !important;
+      }
+    `
+
+    expect(adaptOtpBrandingCss(css)).toEqual({
+      status: 'unchanged',
+      css,
+      rewrites: [],
+    })
+  })
+
+  it('does not duplicate a visual alias already supplied in the same rule', () => {
+    const css = `input, ${SLOT_ALIAS} { color: #1a130f; }`
+
+    expect(adaptOtpBrandingCss(css)).toEqual({
+      status: 'unchanged',
+      css,
+      rewrites: [],
+    })
+  })
+
+  it('is idempotent', () => {
+    const first = adaptOtpBrandingCss(`
+      input { background: #faf8f6 !important; }
+      input.otp-box:focus { border-color: #3e7053 !important; }
+      input[data-slot]::placeholder { color: #8c8279 !important; }
+    `)
+    expect(first.status).toBe('adapted')
+
+    const second = adaptOtpBrandingCss(first.css)
+    expect(second).toEqual({
+      status: 'unchanged',
+      css: first.css,
+      rewrites: [],
+    })
+  })
+
+  it('falls back to the original CSS when parsing fails', () => {
+    const css = '.otp-box:focus { color: gold;'
+    const result = adaptOtpBrandingCss(css)
+
+    expect(result.status).toBe('fallback')
+    expect(result.css).toBe(css)
+    expect(result.rewrites).toEqual([])
+    if (result.status === 'fallback') {
+      expect(result.failure.kind).toBe('stylesheet-parse-failed')
+    }
+  })
+
+  it('re-escapes a closing style tag after serialization', () => {
+    const result = adaptOtpBrandingCss(
+      '.otp-box::placeholder { color: "</style><script>bad</script>"; }',
+    )
+
+    expect(result.status).toBe('adapted')
+    expect(result.css).not.toContain('</style>')
+    expect(result.css).toMatch(/\\(?:u003c|3c )\/style>/)
+  })
+})

--- a/packages/auth-service/src/__tests__/otp-input.test.ts
+++ b/packages/auth-service/src/__tests__/otp-input.test.ts
@@ -1,19 +1,86 @@
 /**
- * Tests for buildOtpInputProps — derives HTML input attributes from OTP config.
+ * Tests for the pure OTP input helpers.
  *
- * Covers:
- * 1. Correct pattern and placeholder for numeric charset
- * 2. Correct pattern and placeholder for alphanumeric charset
- * 3. Pattern and placeholder length match the requested otpLength
- * 4. Numeric pattern rejects letters
- * 5. Alphanumeric pattern accepts both letters and digits
+ * Covers input normalization for one-shot mobile paste/autofill values and
+ * derives the HTML input attributes from the configured OTP format.
  */
 import { describe, it, expect } from 'vitest'
 import {
   buildOtpInputFilter,
   buildOtpInputProps,
+  normalizeOtpValue,
+  resolveOtpSelection,
   resolvePreviewOtpCharset,
 } from '../otp-input.js'
+
+describe('OTP input selection', () => {
+  it('leaves empty values and existing selections unchanged', () => {
+    expect(resolveOtpSelection(0, 6, 0, 0, 0, 0)).toBeNull()
+    expect(resolveOtpSelection(4, 6, 2, 3, 2, 3)).toBeNull()
+  })
+
+  it('keeps a collapsed caret at the end of a partial code for appending', () => {
+    expect(resolveOtpSelection(4, 6, 4, 4, 4, 4)).toBeNull()
+  })
+
+  it('selects the previous slot after moving left from append mode', () => {
+    expect(resolveOtpSelection(4, 6, 3, 3, 4, 4)).toEqual({
+      start: 3,
+      end: 4,
+      direction: 'backward',
+    })
+  })
+
+  it('continues selecting previous slots on repeated left-arrow presses', () => {
+    expect(resolveOtpSelection(4, 6, 3, 3, 3, 4)).toEqual({
+      start: 2,
+      end: 3,
+      direction: 'backward',
+    })
+  })
+
+  it('selects the first slot when the caret moves to the beginning', () => {
+    expect(resolveOtpSelection(4, 6, 0, 0, 1, 2)).toEqual({
+      start: 0,
+      end: 1,
+      direction: 'forward',
+    })
+  })
+
+  it('selects the next slot when moving forward', () => {
+    expect(resolveOtpSelection(4, 6, 2, 2, 1, 2)).toEqual({
+      start: 2,
+      end: 3,
+      direction: 'forward',
+    })
+  })
+
+  it('selects the final slot when a complete code receives focus', () => {
+    expect(resolveOtpSelection(6, 6, 6, 6, 6, 6)).toEqual({
+      start: 5,
+      end: 6,
+      direction: 'backward',
+    })
+  })
+})
+
+describe('OTP input value normalization', () => {
+  it('accepts a complete numeric code delivered at once', () => {
+    expect(normalizeOtpValue('123456', 6, 'numeric')).toBe('123456')
+  })
+
+  it('caps input at the configured code length', () => {
+    expect(normalizeOtpValue('123456789', 6, 'numeric')).toBe('123456')
+  })
+
+  it('removes whitespace from a copied code', () => {
+    expect(normalizeOtpValue('123 456', 6, 'numeric')).toBe('123456')
+  })
+
+  it('normalizes alphanumeric codes to supported uppercase characters', () => {
+    expect(normalizeOtpValue('a1-b2 c3', 6, 'alphanumeric')).toBe('A1B2C3')
+  })
+})
 
 describe('Recovery flow: OTP input props', () => {
   it('numeric charset produces digit-only pattern and zero placeholder', () => {

--- a/packages/auth-service/src/__tests__/otp-input.test.ts
+++ b/packages/auth-service/src/__tests__/otp-input.test.ts
@@ -1,14 +1,15 @@
 /**
  * Tests for the pure OTP input helpers.
  *
- * Covers input normalization for one-shot mobile paste/autofill values and
- * derives the HTML input attributes from the configured OTP format.
+ * Covers segmented selection, one-shot mobile paste/autofill normalization,
+ * and HTML input attributes derived from the configured OTP format.
  */
 import { describe, it, expect } from 'vitest'
 import {
   buildOtpInputFilter,
   buildOtpInputProps,
   normalizeOtpValue,
+  resolveOtpClickSelection,
   resolveOtpSelection,
   resolvePreviewOtpCharset,
 } from '../otp-input.js'
@@ -60,6 +61,24 @@ describe('OTP input selection', () => {
       start: 5,
       end: 6,
       direction: 'backward',
+    })
+  })
+})
+
+describe('OTP click selection', () => {
+  it('selects the clicked character when the slot is populated', () => {
+    expect(resolveOtpClickSelection(4, 2)).toEqual({
+      start: 2,
+      end: 3,
+      direction: 'forward',
+    })
+  })
+
+  it('places the caret at the end when an empty later slot is clicked', () => {
+    expect(resolveOtpClickSelection(4, 6)).toEqual({
+      start: 4,
+      end: 4,
+      direction: 'forward',
     })
   })
 })

--- a/packages/auth-service/src/__tests__/otp-input.test.ts
+++ b/packages/auth-service/src/__tests__/otp-input.test.ts
@@ -101,6 +101,33 @@ describe('OTP input value normalization', () => {
   })
 })
 
+describe('client-serialized OTP helpers', () => {
+  it('remain self-contained outside their module scope', () => {
+    const isolate = <Args extends unknown[], Result>(
+      fn: (...args: Args) => Result,
+    ): ((...args: Args) => Result) => {
+      // The renderer also uses toString(); global evaluation proves these
+      // helpers do not close over module bindings.
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      return new Function(`return (${fn.toString()})`)() as (
+        ...args: Args
+      ) => Result
+    }
+
+    expect(isolate(normalizeOtpValue)('12 34 56', 6, 'numeric')).toBe('123456')
+    expect(isolate(resolveOtpClickSelection)(3, 1)).toEqual({
+      start: 1,
+      end: 2,
+      direction: 'forward',
+    })
+    expect(isolate(resolveOtpSelection)(4, 6, 3, 3, 4, 4)).toEqual({
+      start: 3,
+      end: 4,
+      direction: 'backward',
+    })
+  })
+})
+
 describe('Recovery flow: OTP input props', () => {
   it('numeric charset produces digit-only pattern and zero placeholder', () => {
     const props = buildOtpInputProps(8, 'numeric')

--- a/packages/auth-service/src/lib/otp-branding-compat.ts
+++ b/packages/auth-service/src/lib/otp-branding-compat.ts
@@ -1,0 +1,364 @@
+import postcss from 'postcss'
+import selectorParser from 'postcss-selector-parser'
+import { escapeCss } from '@certified-app/shared'
+
+export type OtpBrandingRewriteId =
+  | 'input'
+  | 'input-focus'
+  | 'input-placeholder'
+  | 'input-otp-box'
+  | 'input-otp-box-focus'
+  | 'input-otp-box-placeholder'
+  | 'input-data-slot'
+  | 'input-data-slot-focus'
+  | 'input-data-slot-placeholder'
+  | 'otp-box-focus'
+  | 'otp-box-placeholder'
+
+export type OtpBrandingFailureKind =
+  | 'stylesheet-parse-failed'
+  | 'selector-parse-failed'
+  | 'serialization-failed'
+
+/**
+ * Mechanical styles that branding must not override on the real OTP input.
+ * Visual branding belongs on `.otp-box` and its projected state classes.
+ */
+const OTP_INPUT_INVARIANT_RULES = `
+  #form-verify-otp #otp-boxes > #code.otp-input-overlay {
+    box-sizing: border-box !important;
+    position: absolute !important;
+    inset: 0 !important;
+    z-index: 2147483647 !important;
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    touch-action: auto !important;
+    -webkit-touch-callout: default !important;
+    user-select: text !important;
+    -webkit-user-select: text !important;
+    width: 100% !important;
+    height: 100% !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
+    max-width: none !important;
+    max-height: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    color: transparent !important;
+    -webkit-text-fill-color: transparent !important;
+    -webkit-text-stroke: 0 transparent !important;
+    text-shadow: none !important;
+    caret-color: transparent !important;
+    background: transparent !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    outline: 0 !important;
+    box-shadow: none !important;
+    transform: none !important;
+    filter: none !important;
+    clip: auto !important;
+    clip-path: none !important;
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    transition: none !important;
+    animation: none !important;
+    font-family: monospace !important;
+    font-size: 56px !important;
+    line-height: 1 !important;
+    letter-spacing: -0.5em !important;
+    cursor: text !important;
+  }
+  #form-verify-otp #otp-boxes > #code.otp-input-overlay::selection {
+    color: transparent !important;
+    background: transparent !important;
+  }
+  #form-verify-otp #otp-boxes > #code.otp-input-overlay:disabled {
+    cursor: not-allowed !important;
+  }
+  #otp-boxes > .otp-box > .otp-character {
+    font-family: inherit !important;
+  }
+`
+
+/**
+ * Duplicate the rules outside a layer for older browsers, then place them in
+ * the first-declared layer so their important declarations beat client layers.
+ */
+export const OTP_INPUT_INVARIANT_CSS = `
+${OTP_INPUT_INVARIANT_RULES}
+@layer epds-otp-invariants {
+${OTP_INPUT_INVARIANT_RULES}
+}
+`
+
+export type OtpBrandingCompatResult =
+  | {
+      status: 'absent'
+      css: null
+      rewrites: readonly []
+    }
+  | {
+      status: 'unchanged'
+      css: string
+      rewrites: readonly []
+    }
+  | {
+      status: 'adapted'
+      css: string
+      rewrites: readonly OtpBrandingRewriteId[]
+    }
+  | {
+      status: 'fallback'
+      css: string
+      rewrites: readonly []
+      failure: {
+        kind: OtpBrandingFailureKind
+        cause: unknown
+      }
+    }
+
+type SelectorProjection = {
+  rewrite: OtpBrandingRewriteId
+  alias: string
+  allowedProperties: readonly string[]
+}
+
+const SLOT_ALIAS = ':where(#otp-boxes)>div:where(.otp-box)'
+const CLASS_SLOT_ALIAS = ':where(#otp-boxes)>div.otp-box'
+const DATA_SLOT_ALIAS = ':where(#otp-boxes)>div[data-slot]:where(.otp-box)'
+const ACTIVE_SLOT_ALIAS = `${SLOT_ALIAS}.active`
+const INPUT_PLACEHOLDER_ALIAS = `${SLOT_ALIAS}>span:where(.otp-character.placeholder)`
+const OTP_PLACEHOLDER_ALIAS = '.otp-box>span:where(.otp-character.placeholder)'
+
+/**
+ * This is intentionally a finite direct-selector compatibility contract. It
+ * covers broad input rules plus the most common class- and attribute-qualified
+ * selectors for the old OTP inputs. Structural and functional selectors stay
+ * unchanged rather than reintroducing general selector rewriting.
+ */
+const INPUT_VISUAL_PROPERTIES = [
+  'background',
+  'background-color',
+  'border',
+  'border-color',
+  'border-radius',
+  'border-style',
+  'border-width',
+  'box-shadow',
+  'color',
+  'font',
+  'font-family',
+  'font-size',
+  'font-style',
+  'font-weight',
+  'letter-spacing',
+  'line-height',
+  'outline',
+  'outline-color',
+  'outline-offset',
+  'outline-style',
+  'outline-width',
+  'text-align',
+  'text-shadow',
+  'text-transform',
+] as const
+const INPUT_FOCUS_PROPERTIES = [
+  'background',
+  'background-color',
+  'border',
+  'border-color',
+  'border-radius',
+  'border-style',
+  'border-width',
+  'box-shadow',
+  'color',
+  'outline',
+  'outline-color',
+  'outline-offset',
+  'outline-style',
+  'outline-width',
+] as const
+const PLACEHOLDER_PROPERTIES = [
+  'color',
+  'font-style',
+  'font-weight',
+  'opacity',
+  'text-shadow',
+] as const
+
+const SELECTOR_PROJECTIONS: Readonly<
+  Partial<Record<string, SelectorProjection>>
+> = {
+  input: {
+    rewrite: 'input',
+    alias: SLOT_ALIAS,
+    allowedProperties: INPUT_VISUAL_PROPERTIES,
+  },
+  'input:focus': {
+    rewrite: 'input-focus',
+    alias: ACTIVE_SLOT_ALIAS,
+    allowedProperties: INPUT_FOCUS_PROPERTIES,
+  },
+  'input:focus-visible': {
+    rewrite: 'input-focus',
+    alias: ACTIVE_SLOT_ALIAS,
+    allowedProperties: INPUT_FOCUS_PROPERTIES,
+  },
+  'input::placeholder': {
+    rewrite: 'input-placeholder',
+    alias: INPUT_PLACEHOLDER_ALIAS,
+    allowedProperties: PLACEHOLDER_PROPERTIES,
+  },
+  'input.otp-box': {
+    rewrite: 'input-otp-box',
+    alias: CLASS_SLOT_ALIAS,
+    allowedProperties: INPUT_VISUAL_PROPERTIES,
+  },
+  'input.otp-box:focus': {
+    rewrite: 'input-otp-box-focus',
+    alias: `${CLASS_SLOT_ALIAS}.active`,
+    allowedProperties: INPUT_FOCUS_PROPERTIES,
+  },
+  'input.otp-box:focus-visible': {
+    rewrite: 'input-otp-box-focus',
+    alias: `${CLASS_SLOT_ALIAS}.active`,
+    allowedProperties: INPUT_FOCUS_PROPERTIES,
+  },
+  'input.otp-box::placeholder': {
+    rewrite: 'input-otp-box-placeholder',
+    alias: `${CLASS_SLOT_ALIAS}>span:where(.otp-character.placeholder)`,
+    allowedProperties: PLACEHOLDER_PROPERTIES,
+  },
+  'input[data-slot]': {
+    rewrite: 'input-data-slot',
+    alias: DATA_SLOT_ALIAS,
+    allowedProperties: INPUT_VISUAL_PROPERTIES,
+  },
+  'input[data-slot]:focus': {
+    rewrite: 'input-data-slot-focus',
+    alias: `${DATA_SLOT_ALIAS}.active`,
+    allowedProperties: INPUT_FOCUS_PROPERTIES,
+  },
+  'input[data-slot]:focus-visible': {
+    rewrite: 'input-data-slot-focus',
+    alias: `${DATA_SLOT_ALIAS}.active`,
+    allowedProperties: INPUT_FOCUS_PROPERTIES,
+  },
+  'input[data-slot]::placeholder': {
+    rewrite: 'input-data-slot-placeholder',
+    alias: `${DATA_SLOT_ALIAS}>span:where(.otp-character.placeholder)`,
+    allowedProperties: PLACEHOLDER_PROPERTIES,
+  },
+  '.otp-box:focus': {
+    rewrite: 'otp-box-focus',
+    alias: '.otp-box.active',
+    allowedProperties: INPUT_FOCUS_PROPERTIES,
+  },
+  '.otp-box:focus-visible': {
+    rewrite: 'otp-box-focus',
+    alias: '.otp-box.active',
+    allowedProperties: INPUT_FOCUS_PROPERTIES,
+  },
+  '.otp-box::placeholder': {
+    rewrite: 'otp-box-placeholder',
+    alias: OTP_PLACEHOLDER_ALIAS,
+    allowedProperties: PLACEHOLDER_PROPERTIES,
+  },
+}
+
+function canonicalSelector(selector: selectorParser.Selector): string {
+  return selectorParser().processSync(selector.toString(), { lossless: false })
+}
+
+function parseAlias(alias: string): selectorParser.Selector {
+  return selectorParser().astSync(alias).nodes[0]
+}
+
+function addKnownAliases(
+  selectorRoot: selectorParser.Root,
+  declarationProperties: readonly string[],
+): OtpBrandingRewriteId[] {
+  const appliedRewrites = new Set<OtpBrandingRewriteId>()
+  const existingSelectors = new Set(selectorRoot.nodes.map(canonicalSelector))
+  const originalSelectors = [...selectorRoot.nodes]
+
+  for (const selector of originalSelectors) {
+    const projection = SELECTOR_PROJECTIONS[canonicalSelector(selector)]
+    // Copy only complete rules from the verified client fixtures. If a rule
+    // includes a mechanical property such as display or touch-action, leave
+    // it on the real input rather than applying it to the visual slot divs.
+    if (
+      !projection ||
+      declarationProperties.length === 0 ||
+      !declarationProperties.every((property) =>
+        projection.allowedProperties.includes(property),
+      )
+    ) {
+      continue
+    }
+
+    const alias = parseAlias(projection.alias)
+    const canonicalAlias = canonicalSelector(alias)
+    if (existingSelectors.has(canonicalAlias)) continue
+
+    selectorRoot.append(alias)
+    existingSelectors.add(canonicalAlias)
+    appliedRewrites.add(projection.rewrite)
+  }
+
+  return [...appliedRewrites]
+}
+
+/**
+ * Project the confirmed trusted-client selectors onto the single-input OTP DOM.
+ *
+ * The function never throws: malformed CSS falls back to the original,
+ * already escaped stylesheet so branding cannot make login unavailable.
+ */
+export function adaptOtpBrandingCss(
+  safeClientCss: string | null,
+): OtpBrandingCompatResult {
+  if (!safeClientCss) {
+    return { status: 'absent', css: null, rewrites: [] }
+  }
+
+  let phase: OtpBrandingFailureKind = 'stylesheet-parse-failed'
+
+  try {
+    const root = postcss.parse(safeClientCss)
+    const rewrites = new Set<OtpBrandingRewriteId>()
+    phase = 'selector-parse-failed'
+
+    root.walkRules((rule) => {
+      const selectorRoot = selectorParser().astSync(rule.selector)
+      const declarationProperties = rule.nodes.flatMap((node) =>
+        node.type === 'decl' ? [node.prop.toLowerCase()] : [],
+      )
+      const ruleRewrites = addKnownAliases(selectorRoot, declarationProperties)
+      if (ruleRewrites.length === 0) return
+
+      rule.selector = selectorRoot.toString()
+      for (const rewrite of ruleRewrites) rewrites.add(rewrite)
+    })
+
+    if (rewrites.size === 0) {
+      return { status: 'unchanged', css: safeClientCss, rewrites: [] }
+    }
+
+    phase = 'serialization-failed'
+    return {
+      status: 'adapted',
+      css: escapeCss(root.toString()),
+      rewrites: [...rewrites],
+    }
+  } catch (cause) {
+    return {
+      status: 'fallback',
+      css: safeClientCss,
+      rewrites: [],
+      failure: { kind: phase, cause },
+    }
+  }
+}

--- a/packages/auth-service/src/otp-input.ts
+++ b/packages/auth-service/src/otp-input.ts
@@ -80,7 +80,7 @@ export function normalizeOtpValue(
   const allowedValue =
     otpCharset === 'alphanumeric'
       ? compactValue.toUpperCase().replace(/[^A-Z0-9]/g, '')
-      : compactValue.replace(/[^0-9]/g, '')
+      : compactValue.replace(/\D/g, '')
 
   return allowedValue.slice(0, otpLength)
 }

--- a/packages/auth-service/src/otp-input.ts
+++ b/packages/auth-service/src/otp-input.ts
@@ -1,8 +1,8 @@
 /**
- * Pure helper for deriving HTML input attributes from OTP configuration.
+ * Pure helpers for OTP input attributes, normalization, and segmented selection.
  *
- * Extracted so that both the recovery and account-login routes use identical
- * logic, and so the logic can be unit-tested without rendering or parsing HTML.
+ * Shared attribute generation keeps recovery and account-login consistent,
+ * while the selection helpers preserve slot-style editing over one real input.
  */
 
 export type OtpCharset = 'numeric' | 'alphanumeric'
@@ -61,6 +61,22 @@ export function resolveOtpSelection(
     start: nextStart,
     end: nextStart + 1,
     direction: movingBackward ? 'backward' : 'forward',
+  }
+}
+
+/**
+ * Select a populated visual slot, or place the caret at the end when the
+ * clicked slot is beyond the current value.
+ */
+export function resolveOtpClickSelection(
+  valueLength: number,
+  slot: number,
+): OtpSelection {
+  const start = Math.min(slot, valueLength)
+  return {
+    start,
+    end: start < valueLength ? start + 1 : start,
+    direction: 'forward',
   }
 }
 

--- a/packages/auth-service/src/otp-input.ts
+++ b/packages/auth-service/src/otp-input.ts
@@ -14,6 +14,77 @@ export interface OtpInputProps {
   autocapitalize: 'characters' | 'off'
 }
 
+/** The one-character selection a segmented OTP control should show. */
+export interface OtpSelection {
+  start: number
+  end: number
+  direction: 'forward' | 'backward' | 'none'
+}
+
+/**
+ * Resolve a collapsed browser caret into segmented-field replacement mode.
+ *
+ * A caret at the end of a partial code remains collapsed so typing appends.
+ * Elsewhere the character beside the caret is selected so arrow-key edits
+ * replace one slot instead of inserting and shifting the remaining code.
+ */
+export function resolveOtpSelection(
+  valueLength: number,
+  otpLength: number,
+  start: number | null,
+  end: number | null,
+  previousStart: number | null,
+  previousEnd: number | null,
+): OtpSelection | null {
+  if (valueLength === 0 || start === null || end === null || start !== end) {
+    return null
+  }
+
+  const isInsertionAtEnd = start === valueLength && valueLength < otpLength
+  if (isInsertionAtEnd) return null
+
+  if (start === 0) {
+    return { start: 0, end: 1, direction: 'forward' }
+  }
+  if (start === valueLength) {
+    return { start: start - 1, end: start, direction: 'backward' }
+  }
+
+  const movingBackward = previousEnd !== null && start < previousEnd
+  const wasInserting =
+    previousStart === previousEnd &&
+    previousStart !== null &&
+    previousStart < otpLength
+  const nextStart = movingBackward && !wasInserting ? start - 1 : start
+
+  return {
+    start: nextStart,
+    end: nextStart + 1,
+    direction: movingBackward ? 'backward' : 'forward',
+  }
+}
+
+/**
+ * Normalize a value entered or pasted into the sign-in code field.
+ *
+ * Use this before rendering or submitting a code so mobile autofill, pasted
+ * whitespace, and unsupported characters cannot produce a value outside the
+ * configured length and character set.
+ */
+export function normalizeOtpValue(
+  value: string,
+  otpLength: number,
+  otpCharset: 'numeric' | 'alphanumeric',
+): string {
+  const compactValue = value.replace(/\s/g, '')
+  const allowedValue =
+    otpCharset === 'alphanumeric'
+      ? compactValue.toUpperCase().replace(/[^A-Z0-9]/g, '')
+      : compactValue.replace(/[^0-9]/g, '')
+
+  return allowedValue.slice(0, otpLength)
+}
+
 export function buildOtpInputProps(
   otpLength: number,
   otpCharset: OtpCharset,

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -45,6 +45,7 @@ import { socialProviders } from '../better-auth.js'
 import {
   buildOtpInputProps,
   normalizeOtpValue,
+  resolveOtpClickSelection,
   resolveOtpSelection,
 } from '../otp-input.js'
 import {
@@ -522,6 +523,7 @@ export function renderLoginPage(opts: {
   // It is self-contained, so serializing its source avoids maintaining a
   // second client-only implementation inside this server-rendered page.
   const normalizeOtpValueSource = normalizeOtpValue.toString()
+  const resolveOtpClickSelectionSource = resolveOtpClickSelection.toString()
   const resolveOtpSelectionSource = resolveOtpSelection.toString()
 
   // ATProto/Bluesky handle login button.
@@ -801,6 +803,7 @@ export function renderLoginPage(opts: {
       var otpLength = ${opts.otpLength};
       var otpCharset = ${JSON.stringify(opts.otpCharset)};
       var normalizeOtpValue = (${normalizeOtpValueSource});
+      var resolveOtpClickSelection = (${resolveOtpClickSelectionSource});
       var resolveOtpSelection = (${resolveOtpSelectionSource});
 
       // PAR heartbeat — slides the upstream request_uri inactivity
@@ -1114,7 +1117,29 @@ export function renderLoginPage(opts: {
 
       otpInput.addEventListener('focus', positionOtpSelection);
       otpInput.addEventListener('blur', renderOtpSlots);
-      otpInput.addEventListener('click', syncOtpSelection);
+      otpInput.addEventListener('click', function(e) {
+        // The real input must remain above the visual slots for iOS long-press
+        // paste. Read the box underneath the click without changing hit testing.
+        var clickedBox = document.elementsFromPoint(e.clientX, e.clientY).find(function(element) {
+          return element.hasAttribute('data-slot');
+        });
+        if (!clickedBox) {
+          syncOtpSelection();
+          return;
+        }
+
+        var selection = resolveOtpClickSelection(
+          otpInput.value.length,
+          Number(clickedBox.getAttribute('data-slot')),
+        );
+        otpInput.setSelectionRange(
+          selection.start,
+          selection.end,
+          selection.direction,
+        );
+        previousOtpSelection = [selection.start, selection.end];
+        renderOtpSlots();
+      });
       otpInput.addEventListener('keyup', syncOtpSelection);
       document.addEventListener('selectionchange', function() {
         if (document.activeElement === otpInput) syncOtpSelection();

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -575,8 +575,12 @@ export function renderLoginPage(opts: {
   // server-rendered into whichever step is initially visible and moved
   // between the two slots on step transitions; both transitions call
   // clearError() first, so it is always empty when it moves.
+  //
+  // aria-atomic keeps a message and its inline action announcing as one
+  // utterance: setFlash() swaps the region's children wholesale, and
+  // without it a screen reader may read only the changed subtree.
   const flashRegionHtml =
-    '<div id="error-msg" class="flash-msg hidden" role="status" aria-live="polite"></div>'
+    '<div id="error-msg" class="flash-msg hidden" role="status" aria-live="polite" aria-atomic="true"></div>'
 
   // Social login buttons — redirect to better-auth provider endpoints
   const socialButtonsHtml = hasSocialProviders
@@ -623,6 +627,7 @@ export function renderLoginPage(opts: {
   <style>
     :root { --muted-foreground: #666; --input-bg: #ffffff; --input-border: #e5e5e5; --page-bg: #E8E8E8; --card-bg: #F8F8F8; --card-border: #E5E5E5; --btn-secondary-border: #e5e5e5; --focus-border: ${brandColor}; }
     * { box-sizing: border-box; margin: 0; padding: 0; }
+    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--page-bg); min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; color: #1A130F; }
     .page-wrap { display: flex; flex-direction: column; align-items: stretch; max-width: 497px; width: 100%; }
     .container { background: var(--card-bg); padding: 64px 48px 40px; width: 100%; text-align: center; border-radius: 20px; border: 1px solid var(--card-border); box-shadow: 0 1px 2px rgba(0,0,0,0.03); }
@@ -638,14 +643,15 @@ export function renderLoginPage(opts: {
        text and caret are transparent preserves iOS long-press paste. */
     .otp-boxes { position: relative; display: flex; gap: 10px; justify-content: center; margin-bottom: 24px; cursor: text; }
     .otp-box { position: relative; display: flex; align-items: center; justify-content: center; width: 48px; height: 56px; padding: 0; text-align: center; font-size: 24px; font-family: 'SF Mono', Menlo, Consolas, monospace; border: 1px solid var(--input-border); border-radius: 8px; background: var(--input-bg); color: #1A130F; outline: none; transition: border-color 0.15s; }
-    .otp-box.active { border-color: var(--focus-border); }
+    .otp-box.active { border-color: var(--focus-border); outline: 2px solid var(--focus-border); outline-offset: 2px; }
     .otp-character.placeholder { color: #d4d4d4; }
-    .otp-fake-caret { display: none; position: absolute; width: 1px; height: 28px; background: #1A130F; animation: otp-caret-blink 1.2s ease-out infinite; }
+    .otp-fake-caret { display: none; position: absolute; width: 1px; height: 28px; background: currentColor; animation: otp-caret-blink 1.2s ease-out infinite; }
     .otp-box.active.empty .otp-fake-caret { display: block; }
     .otp-input-overlay { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 1; color: transparent; -webkit-text-fill-color: transparent; caret-color: transparent; background: transparent; border: 0; outline: 0; box-shadow: none; font-family: monospace; font-size: 56px; line-height: 1; letter-spacing: -0.5em; }
     .otp-input-overlay::selection { color: transparent; background: transparent; }
     .otp-input-overlay:disabled { cursor: not-allowed; }
     @keyframes otp-caret-blink { 0%, 70%, 100% { opacity: 1; } 20%, 50% { opacity: 0; } }
+    @media (prefers-reduced-motion: reduce) { .otp-fake-caret { animation: none; } }
     .otp-actions { display: flex; gap: 32px; justify-content: center; margin-top: 12px; }
     .btn-primary { width: 100%; padding: 15px; background: ${brandColor}; color: white; border: none; border-radius: 9999px; font-size: 15px; font-weight: 500; cursor: pointer; transition: opacity 0.15s; }
     .btn-primary:hover { opacity: 0.9; }
@@ -738,6 +744,7 @@ export function renderLoginPage(opts: {
           ? `Code already sent to ${escapeHtml(opts.loginHint.replace(/(.{2})[^@]*(@.*)/, '$1***$2'))}`
           : ''
       }</p>
+      <span id="otp-auto-submit" class="sr-only">The code submits automatically when all ${opts.otpLength} ${opts.otpCharset === 'alphanumeric' ? 'characters' : 'digits'} are entered.</span>
       <form id="form-verify-otp">
         <input type="hidden" id="otp-email" name="email" value="${escapeHtml(opts.loginHint)}">
         <div class="otp-boxes" id="otp-boxes">
@@ -749,9 +756,10 @@ export function renderLoginPage(opts: {
             .join('\n          ')}
           <input type="text" class="otp-input-overlay" id="code" name="code"
                  maxlength="${opts.otpLength}" inputmode="${inputProps.inputmode}"
-                 autocapitalize="${inputProps.autocapitalize}"
+                 autocapitalize="${inputProps.autocapitalize}" spellcheck="false"
                  autocomplete="one-time-code" pattern="${inputProps.pattern}"
-                 aria-label="Verification code" aria-describedby="otp-subtitle">
+                 aria-label="${opts.otpLength}-${opts.otpCharset === 'alphanumeric' ? 'character' : 'digit'} verification code"
+                 aria-describedby="otp-subtitle otp-auto-submit">
         </div>
         <!-- Flash slot: see #flash-slot-email. Sitting between the
              boxes and Verify puts a rejected-code message at the point

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -537,6 +537,14 @@ export function renderLoginPage(opts: {
       },
       'Unable to apply OTP branding projections; using the original client CSS. Check branding.css in /preview/login-otp',
     )
+    logger.debug(
+      {
+        err: otpBranding.failure.cause,
+        clientId: opts.clientId,
+        failureKind: otpBranding.failure.kind,
+      },
+      'OTP branding projection failure details',
+    )
   }
   // The browser uses the exact pure normalizer covered by otp-input.test.ts.
   // It is self-contained, so serializing its source avoids maintaining a

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -1123,18 +1123,12 @@ export function renderLoginPage(opts: {
         otpInput.dispatchEvent(new Event('input', { bubbles: true }));
       });
 
-      otpInput.addEventListener('focus', positionOtpSelection);
-      otpInput.addEventListener('blur', renderOtpSlots);
-      otpInput.addEventListener('click', function(e) {
-        // The real input must remain above the visual slots for iOS long-press
-        // paste. Read the box underneath the click without changing hit testing.
-        var clickedBox = document.elementsFromPoint(e.clientX, e.clientY).find(function(element) {
+      /** Select the visual OTP slot beneath a pointer coordinate. */
+      function selectOtpSlotAtPoint(clientX, clientY) {
+        var clickedBox = document.elementsFromPoint(clientX, clientY).find(function(element) {
           return element.hasAttribute('data-slot');
         });
-        if (!clickedBox) {
-          syncOtpSelection();
-          return;
-        }
+        if (!clickedBox) return false;
 
         var selection = resolveOtpClickSelection(
           otpInput.value.length,
@@ -1147,6 +1141,21 @@ export function renderLoginPage(opts: {
         );
         previousOtpSelection = [selection.start, selection.end];
         renderOtpSlots();
+        return true;
+      }
+
+      otpInput.addEventListener('focus', positionOtpSelection);
+      otpInput.addEventListener('blur', renderOtpSlots);
+      otpInput.addEventListener('pointerdown', function(e) {
+        if (e.pointerType !== 'mouse' || e.button !== 0) return;
+        // Stop the native caret jumping to the end before click selects the
+        // intended slot. Touch remains native so iOS long-press paste works.
+        e.preventDefault();
+        otpInput.focus();
+        selectOtpSlotAtPoint(e.clientX, e.clientY);
+      });
+      otpInput.addEventListener('click', function(e) {
+        if (!selectOtpSlotAtPoint(e.clientX, e.clientY)) syncOtpSelection();
       });
       otpInput.addEventListener('keyup', syncOtpSelection);
       document.addEventListener('selectionchange', function() {

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -42,7 +42,11 @@ import {
   type HandleMode,
 } from '@certified-app/shared'
 import { socialProviders } from '../better-auth.js'
-import { buildOtpInputFilter, buildOtpInputProps } from '../otp-input.js'
+import {
+  buildOtpInputProps,
+  normalizeOtpValue,
+  resolveOtpSelection,
+} from '../otp-input.js'
 import {
   resolveLoginHint,
   fetchParLoginHint,
@@ -514,7 +518,11 @@ export function renderLoginPage(opts: {
     : `<img src="/static/certified-brandmark.svg" alt="Certified" class="client-logo">`
 
   const inputProps = buildOtpInputProps(opts.otpLength, opts.otpCharset)
-  const inputFilter = buildOtpInputFilter(opts.otpCharset)
+  // The browser uses the exact pure normalizer covered by otp-input.test.ts.
+  // It is self-contained, so serializing its source avoids maintaining a
+  // second client-only implementation inside this server-rendered page.
+  const normalizeOtpValueSource = normalizeOtpValue.toString()
+  const resolveOtpSelectionSource = resolveOtpSelection.toString()
 
   // ATProto/Bluesky handle login button.
   //
@@ -624,10 +632,18 @@ export function renderLoginPage(opts: {
     .field input { width: 100%; padding: 14px 20px; border: 1px solid var(--input-border); border-radius: 8px; font-size: 16px; outline: none; background: var(--input-bg); transition: border-color 0.15s; }
     .field input:focus { border-color: var(--focus-border); }
     ${EMAIL_TYPO_GUARD_CSS}
-    .otp-boxes { display: flex; gap: 10px; justify-content: center; margin-bottom: 24px; }
-    .otp-box { width: 48px; height: 56px; padding: 0; text-align: center; font-size: 24px; font-family: 'SF Mono', Menlo, Consolas, monospace; border: 1px solid var(--input-border); border-radius: 8px; background: var(--input-bg); color: #1A130F; outline: none; transition: border-color 0.15s; }
-    .otp-box::placeholder { color: #d4d4d4; }
-    .otp-box:focus { border-color: var(--focus-border); }
+    /* One real input spans the visual slots. Keeping opacity at 1 while the
+       text and caret are transparent preserves iOS long-press paste. */
+    .otp-boxes { position: relative; display: flex; gap: 10px; justify-content: center; margin-bottom: 24px; cursor: text; }
+    .otp-box { position: relative; display: flex; align-items: center; justify-content: center; width: 48px; height: 56px; padding: 0; text-align: center; font-size: 24px; font-family: 'SF Mono', Menlo, Consolas, monospace; border: 1px solid var(--input-border); border-radius: 8px; background: var(--input-bg); color: #1A130F; outline: none; transition: border-color 0.15s; }
+    .otp-box.active { border-color: var(--focus-border); }
+    .otp-character.placeholder { color: #d4d4d4; }
+    .otp-fake-caret { display: none; position: absolute; width: 1px; height: 28px; background: #1A130F; animation: otp-caret-blink 1.2s ease-out infinite; }
+    .otp-box.active.empty .otp-fake-caret { display: block; }
+    .otp-input-overlay { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 1; color: transparent; -webkit-text-fill-color: transparent; caret-color: transparent; background: transparent; border: 0; outline: 0; box-shadow: none; font-family: monospace; font-size: 56px; line-height: 1; letter-spacing: -0.5em; }
+    .otp-input-overlay::selection { color: transparent; background: transparent; }
+    .otp-input-overlay:disabled { cursor: not-allowed; }
+    @keyframes otp-caret-blink { 0%, 70%, 100% { opacity: 1; } 20%, 50% { opacity: 0; } }
     .otp-actions { display: flex; gap: 32px; justify-content: center; margin-top: 12px; }
     .btn-primary { width: 100%; padding: 15px; background: ${brandColor}; color: white; border: none; border-radius: 9999px; font-size: 15px; font-weight: 500; cursor: pointer; transition: opacity 0.15s; }
     .btn-primary:hover { opacity: 0.9; }
@@ -722,18 +738,18 @@ export function renderLoginPage(opts: {
       }</p>
       <form id="form-verify-otp">
         <input type="hidden" id="otp-email" name="email" value="${escapeHtml(opts.loginHint)}">
-        <input type="hidden" id="code" name="code">
         <div class="otp-boxes" id="otp-boxes">
           ${Array.from({ length: opts.otpLength })
             .map(
               (_, i) =>
-                `<input type="text" class="otp-box" data-slot="${i}" maxlength="1"
-                   inputmode="${inputProps.inputmode}" autocapitalize="${inputProps.autocapitalize}"
-                   ${i === 0 ? 'autocomplete="one-time-code"' : 'autocomplete="off"'}
-                   placeholder="${opts.otpCharset === 'alphanumeric' ? 'A' : '0'}"
-                   aria-label="${opts.otpCharset === 'alphanumeric' ? 'Character' : 'Digit'} ${i + 1}">`,
+                `<div class="otp-box empty" data-slot="${i}" aria-hidden="true"><span class="otp-character placeholder">${opts.otpCharset === 'alphanumeric' ? 'A' : '0'}</span><span class="otp-fake-caret"></span></div>`,
             )
             .join('\n          ')}
+          <input type="text" class="otp-input-overlay" id="code" name="code"
+                 maxlength="${opts.otpLength}" inputmode="${inputProps.inputmode}"
+                 autocapitalize="${inputProps.autocapitalize}"
+                 autocomplete="one-time-code" pattern="${inputProps.pattern}"
+                 aria-label="Verification code" aria-describedby="otp-subtitle">
         </div>
         <!-- Flash slot: see #flash-slot-email. Sitting between the
              boxes and Verify puts a rejected-code message at the point
@@ -781,9 +797,11 @@ export function renderLoginPage(opts: {
       var headingEl = document.getElementById('heading');
       var termsEl = document.getElementById('terms');
       var otpBoxes = Array.prototype.slice.call(document.querySelectorAll('.otp-box'));
-      var hiddenCode = document.getElementById('code');
+      var otpInput = document.getElementById('code');
       var otpLength = ${opts.otpLength};
       var otpCharset = ${JSON.stringify(opts.otpCharset)};
+      var normalizeOtpValue = (${normalizeOtpValueSource});
+      var resolveOtpSelection = (${resolveOtpSelectionSource});
 
       // PAR heartbeat — slides the upstream request_uri inactivity
       // timer (atproto's AUTHORIZATION_INACTIVITY_TIMEOUT, 5 min) so
@@ -881,7 +899,7 @@ export function renderLoginPage(opts: {
         flowAborted = true;
         // Disable every form control on the OTP step so nothing the
         // user does on the form has any effect from here on.
-        for (var i = 0; i < otpBoxes.length; i++) otpBoxes[i].disabled = true;
+        otpInput.disabled = true;
         var resendBtn = document.getElementById('btn-resend');
         if (resendBtn) resendBtn.disabled = true;
         var backBtn = document.getElementById('btn-back');
@@ -991,68 +1009,117 @@ export function renderLoginPage(opts: {
         return false;
       }
 
-      // Drop characters the configured code alphabet can't contain, so a
-      // code copied out of prose (punctuation, line breaks, a stray letter
-      // in a digits-only code) still lands in the boxes as a valid code
-      // instead of silently failing verification. Alphanumeric codes are
-      // generated uppercase, and the browser only auto-capitalises on soft
-      // keyboards, so normalise here too — otherwise a desktop user typing
-      // lowercase submits a code the server will reject.
-      var otpCharFilter = ${inputFilter.toString()};
-      function filterOtpChars(s) {
-        var cleaned = s.replace(otpCharFilter, '');
-        return otpCharset === 'alphanumeric' ? cleaned.toUpperCase() : cleaned;
-      }
+      var previousOtpSelection = [otpInput.selectionStart, otpInput.selectionEnd];
 
-      function updateHiddenCode() {
-        var v = '';
-        for (var i = 0; i < otpBoxes.length; i++) v += otpBoxes[i].value;
-        hiddenCode.value = v;
+      /** Render the single input's value and selection into visual slots. */
+      function renderOtpSlots() {
+        var value = otpInput.value;
+        var selectionStart = otpInput.selectionStart === null ? value.length : otpInput.selectionStart;
+        var activeSlot = Math.min(selectionStart, otpBoxes.length - 1);
+        var focused = document.activeElement === otpInput;
+
+        otpBoxes.forEach(function(box, index) {
+          var character = box.querySelector('.otp-character');
+          var valueAtSlot = value[index] || '';
+          character.textContent = valueAtSlot || (otpCharset === 'alphanumeric' ? 'A' : '0');
+          character.classList.toggle('placeholder', !valueAtSlot);
+          box.classList.toggle('empty', !valueAtSlot);
+          box.classList.toggle('active', focused && index === activeSlot);
+        });
       }
 
       function clearOtpBoxes() {
-        for (var i = 0; i < otpBoxes.length; i++) otpBoxes[i].value = '';
-        hiddenCode.value = '';
+        otpInput.value = '';
+        previousOtpSelection = [0, 0];
+        renderOtpSlots();
       }
 
-      otpBoxes.forEach(function(box, idx) {
-        box.addEventListener('input', function() {
-          // keep only the last typed char (handles paste into a single box)
-          var v = filterOtpChars(box.value);
-          if (v.length > 1) v = v.slice(-1);
-          box.value = v;
-          updateHiddenCode();
-          if (box.value && idx < otpBoxes.length - 1) otpBoxes[idx + 1].focus();
-          if (hiddenCode.value.length === otpBoxes.length) {
-            document.getElementById('form-verify-otp').requestSubmit();
-          }
-        });
-        box.addEventListener('keydown', function(e) {
-          if (e.key === 'Backspace' && !box.value && idx > 0) {
-            otpBoxes[idx - 1].focus();
-            otpBoxes[idx - 1].value = '';
-            updateHiddenCode();
-            e.preventDefault();
-          } else if (e.key === 'ArrowLeft' && idx > 0) {
-            otpBoxes[idx - 1].focus();
-          } else if (e.key === 'ArrowRight' && idx < otpBoxes.length - 1) {
-            otpBoxes[idx + 1].focus();
-          }
-        });
-        box.addEventListener('paste', function(e) {
-          e.preventDefault();
-          var data = (e.clipboardData || window.clipboardData).getData('text') || '';
-          var cleaned = filterOtpChars(data).slice(0, otpBoxes.length - idx);
-          for (var i = 0; i < cleaned.length; i++) otpBoxes[idx + i].value = cleaned[i];
-          updateHiddenCode();
-          var nextIdx = Math.min(idx + cleaned.length, otpBoxes.length - 1);
-          otpBoxes[nextIdx].focus();
-          if (hiddenCode.value.length === otpBoxes.length) {
-            document.getElementById('form-verify-otp').requestSubmit();
-          }
-        });
-        box.addEventListener('focus', function() { box.select(); });
+      /**
+       * Keep collapsed browser carets aligned with segmented-field editing.
+       * At the end of a partial value the caret remains in insertion mode;
+       * elsewhere one character is selected so typing replaces that slot
+       * instead of shifting every following character.
+       */
+      function syncOtpSelection() {
+        if (document.activeElement !== otpInput) {
+          renderOtpSlots();
+          return;
+        }
+
+        var selection = resolveOtpSelection(
+          otpInput.value.length,
+          otpLength,
+          otpInput.selectionStart,
+          otpInput.selectionEnd,
+          previousOtpSelection[0],
+          previousOtpSelection[1],
+        );
+        if (selection) {
+          otpInput.setSelectionRange(
+            selection.start,
+            selection.end,
+            selection.direction,
+          );
+        }
+
+        previousOtpSelection = [otpInput.selectionStart, otpInput.selectionEnd];
+        renderOtpSlots();
+      }
+
+      function positionOtpSelection() {
+        var end = otpInput.value.length;
+        var start = Math.min(end, otpBoxes.length - 1);
+        otpInput.setSelectionRange(start, end);
+        previousOtpSelection = [start, end];
+        renderOtpSlots();
+      }
+
+      function focusOtpInput() {
+        otpInput.focus();
+        positionOtpSelection();
+      }
+
+      otpInput.addEventListener('input', function() {
+        var normalized = normalizeOtpValue(otpInput.value, otpLength, otpCharset);
+        if (otpInput.value !== normalized) otpInput.value = normalized;
+        syncOtpSelection();
+        if (otpInput.value.length === otpLength) {
+          document.getElementById('form-verify-otp').requestSubmit();
+        }
       });
+
+      // Keep the real input visible to hit testing (opacity:1) for iOS
+      // long-press paste. Handle clipboard insertion before maxlength is
+      // applied so formatted values such as "123 456" can be normalized
+      // without the browser truncating the last character first.
+      otpInput.addEventListener('paste', function(e) {
+        if (!e.clipboardData) return;
+        e.preventDefault();
+        var pasted = e.clipboardData.getData('text/plain') || '';
+        var start = otpInput.selectionStart === null ? otpInput.value.length : otpInput.selectionStart;
+        var end = otpInput.selectionEnd === null ? start : otpInput.selectionEnd;
+        var valueBeforePaste = otpInput.value.slice(0, start);
+        otpInput.value = normalizeOtpValue(
+          valueBeforePaste + pasted + otpInput.value.slice(end),
+          otpLength,
+          otpCharset,
+        );
+        var cursor = Math.min(
+          normalizeOtpValue(valueBeforePaste + pasted, otpLength, otpCharset).length,
+          otpInput.value.length,
+        );
+        otpInput.setSelectionRange(cursor, cursor);
+        otpInput.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+
+      otpInput.addEventListener('focus', positionOtpSelection);
+      otpInput.addEventListener('blur', renderOtpSlots);
+      otpInput.addEventListener('click', syncOtpSelection);
+      otpInput.addEventListener('keyup', syncOtpSelection);
+      document.addEventListener('selectionchange', function() {
+        if (document.activeElement === otpInput) syncOtpSelection();
+      });
+      renderOtpSlots();
 
       /**
        * Swap the flash region's contents in a single mutation.
@@ -1234,7 +1301,7 @@ export function renderLoginPage(opts: {
         headingEl.textContent = 'Enter your code';
         if (termsEl) termsEl.style.display = 'none';
         clearOtpBoxes();
-        if (otpBoxes.length) otpBoxes[0].focus();
+        focusOtpInput();
         clearError();
         moveFlashTo('flash-slot-otp');
         startHeartbeat();
@@ -1437,7 +1504,7 @@ export function renderLoginPage(opts: {
             // a still-full grid would auto-submit on the first keystroke
             // (length stays at 6) and spam the rate limiter.
             clearOtpBoxes();
-            if (otpBoxes.length) otpBoxes[0].focus();
+            focusOtpInput();
           }
         } finally {
           // Leave the latch set on success: verifyOtp triggers a redirect,
@@ -1472,7 +1539,7 @@ export function renderLoginPage(opts: {
           // Clear any characters typed for the old code so the new code
           // starts from a clean, focused input grid.
           clearOtpBoxes();
-          if (otpBoxes.length) otpBoxes[0].focus();
+          focusOtpInput();
           // Both facts only matter once a resend has happened, so they
           // live here rather than in permanently-visible page copy:
           // sending a new OTP invalidates every earlier one, and a user
@@ -1501,7 +1568,7 @@ export function renderLoginPage(opts: {
       if (initialStep === 'otp' && loginHint) {
         currentEmail = loginHint;
         var masked = loginHint.replace(/(.{2})[^@]*(@.*)/, '$1***$2');
-        if (otpBoxes.length) otpBoxes[0].focus();
+        focusOtpInput();
         if (!otpAlreadySent) {
           // First load — fire the OTP send in the background.
           sendOtp(loginHint).then(function(result) {

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -49,6 +49,10 @@ import {
   resolveOtpSelection,
 } from '../otp-input.js'
 import {
+  adaptOtpBrandingCss,
+  OTP_INPUT_INVARIANT_CSS,
+} from '../lib/otp-branding-compat.js'
+import {
   resolveLoginHint,
   fetchParLoginHint,
 } from '../lib/resolve-login-hint.js'
@@ -519,6 +523,21 @@ export function renderLoginPage(opts: {
     : `<img src="/static/certified-brandmark.svg" alt="Certified" class="client-logo">`
 
   const inputProps = buildOtpInputProps(opts.otpLength, opts.otpCharset)
+  const otpBranding = adaptOtpBrandingCss(opts.customCss)
+  if (otpBranding.status === 'adapted') {
+    logger.debug(
+      { clientId: opts.clientId, rewrites: otpBranding.rewrites },
+      'Applied OTP branding projections',
+    )
+  } else if (otpBranding.status === 'fallback') {
+    logger.warn(
+      {
+        clientId: opts.clientId,
+        failureKind: otpBranding.failure.kind,
+      },
+      'Unable to apply OTP branding projections; using the original client CSS. Check branding.css in /preview/login-otp',
+    )
+  }
   // The browser uses the exact pure normalizer covered by otp-input.test.ts.
   // It is self-contained, so serializing its source avoids maintaining a
   // second client-only implementation inside this server-rendered page.
@@ -625,6 +644,7 @@ export function renderLoginPage(opts: {
   ${renderFaviconTag(opts.customFaviconUrl, opts.customFaviconUrlDark)}
   <title>Sign in to ${escapeHtml(appName)}</title>
   <style>
+    @layer epds-otp-invariants;
     :root { --muted-foreground: #666; --input-bg: #ffffff; --input-border: #e5e5e5; --page-bg: #E8E8E8; --card-bg: #F8F8F8; --card-border: #E5E5E5; --btn-secondary-border: #e5e5e5; --focus-border: ${brandColor}; }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
@@ -647,9 +667,6 @@ export function renderLoginPage(opts: {
     .otp-character.placeholder { color: #d4d4d4; }
     .otp-fake-caret { display: none; position: absolute; width: 1px; height: 28px; background: currentColor; animation: otp-caret-blink 1.2s ease-out infinite; }
     .otp-box.active.empty .otp-fake-caret { display: block; }
-    .otp-input-overlay { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 1; color: transparent; -webkit-text-fill-color: transparent; caret-color: transparent; background: transparent; border: 0; outline: 0; box-shadow: none; font-family: monospace; font-size: 56px; line-height: 1; letter-spacing: -0.5em; }
-    .otp-input-overlay::selection { color: transparent; background: transparent; }
-    .otp-input-overlay:disabled { cursor: not-allowed; }
     @keyframes otp-caret-blink { 0%, 70%, 100% { opacity: 1; } 20%, 50% { opacity: 0; } }
     @media (prefers-reduced-motion: reduce) { .otp-fake-caret { animation: none; } }
     .otp-actions { display: flex; gap: 32px; justify-content: center; margin-top: 12px; }
@@ -706,7 +723,8 @@ export function renderLoginPage(opts: {
     .recovery-link { display: var(--recovery-link-display, block); margin-top: 16px; color: var(--muted-foreground); font-size: 13px; text-decoration: none; text-align: center; }
     .recovery-link:hover { color: #1A130F; }
     .recovery-link:focus-visible { outline: 2px solid var(--focus-border, #2563eb); outline-offset: 2px; border-radius: 4px; }
-  </style>${renderOptionalStyleTag(opts.customCss)}
+  </style>${renderOptionalStyleTag(otpBranding.css)}
+  <style data-epds-otp-invariants>${OTP_INPUT_INVARIANT_CSS}</style>
 </head>
 <body>
   <div class="page-wrap">

--- a/packages/demo/src/__tests__/theme.test.ts
+++ b/packages/demo/src/__tests__/theme.test.ts
@@ -40,10 +40,10 @@ describe('getTheme', () => {
       '.account-info { background: #2d1a4f; color: #c4b5fd; }',
     )
     expect(theme?.injectedCss).toContain(
-      '} input { background: #1a1033; border-color: #3d2a5c; color: #e8e0f0; }',
+      '} input { background: #1a1033 !important; border-color: #3d2a5c !important; color: #e8e0f0 !important; }',
     )
     expect(theme?.injectedCss).toContain(
-      'input::placeholder { color: #7c6894; }',
+      'input::placeholder { color: #7c6894 !important; }',
     )
     expect(theme?.injectedCss).toContain(
       'input:focus { border-color: #8b5cf6 !important; }',

--- a/packages/demo/src/__tests__/theme.test.ts
+++ b/packages/demo/src/__tests__/theme.test.ts
@@ -40,7 +40,13 @@ describe('getTheme', () => {
       '.account-info { background: #2d1a4f; color: #c4b5fd; }',
     )
     expect(theme?.injectedCss).toContain(
-      '.otp-box.active { border-color: #8b5cf6 !important; }',
+      '} input { background: #1a1033; border-color: #3d2a5c; color: #e8e0f0; }',
+    )
+    expect(theme?.injectedCss).toContain(
+      'input::placeholder { color: #7c6894; }',
+    )
+    expect(theme?.injectedCss).toContain(
+      'input:focus { border-color: #8b5cf6 !important; }',
     )
   })
 

--- a/packages/demo/src/__tests__/theme.test.ts
+++ b/packages/demo/src/__tests__/theme.test.ts
@@ -39,6 +39,9 @@ describe('getTheme', () => {
     expect(theme?.injectedCss).toContain(
       '.account-info { background: #2d1a4f; color: #c4b5fd; }',
     )
+    expect(theme?.injectedCss).toContain(
+      '.otp-box.active { border-color: #8b5cf6 !important; }',
+    )
   })
 
   it('returns the amber page theme', () => {

--- a/packages/demo/src/lib/theme.ts
+++ b/packages/demo/src/lib/theme.ts
@@ -124,8 +124,11 @@ function buildInjectedCss(
     `.field input { background: ${page.inputBg}; border-color: ${page.inputBorder}; color: ${page.text}; }`,
     `.field input:focus { border-color: ${page.focusBorder}; }`,
     `.field input::placeholder { color: ${page.textHint}; }`,
-    `.otp-box { color: ${page.text}; }`,
-    `.otp-box.active { border-color: ${page.focusBorder} !important; }`,
+    // Deliberately use the broad selectors found in trusted production
+    // clients so the bundled demo continuously exercises OTP projection.
+    `input { background: ${page.inputBg}; border-color: ${page.inputBorder}; color: ${page.text}; }`,
+    `input::placeholder { color: ${page.textHint}; }`,
+    `input:focus { border-color: ${page.focusBorder} !important; }`,
     `.btn-primary { background: ${page.primary}; color: ${page.primaryText}; }`,
     `.btn-primary:hover { background: ${page.primaryHover}; }`,
     // Standalone actions under Verify (.btn-secondary buttons and the

--- a/packages/demo/src/lib/theme.ts
+++ b/packages/demo/src/lib/theme.ts
@@ -126,8 +126,8 @@ function buildInjectedCss(
     `.field input::placeholder { color: ${page.textHint}; }`,
     // Deliberately use the broad selectors found in trusted production
     // clients so the bundled demo continuously exercises OTP projection.
-    `input { background: ${page.inputBg}; border-color: ${page.inputBorder}; color: ${page.text}; }`,
-    `input::placeholder { color: ${page.textHint}; }`,
+    `input { background: ${page.inputBg} !important; border-color: ${page.inputBorder} !important; color: ${page.text} !important; }`,
+    `input::placeholder { color: ${page.textHint} !important; }`,
     `input:focus { border-color: ${page.focusBorder} !important; }`,
     `.btn-primary { background: ${page.primary}; color: ${page.primaryText}; }`,
     `.btn-primary:hover { background: ${page.primaryHover}; }`,

--- a/packages/demo/src/lib/theme.ts
+++ b/packages/demo/src/lib/theme.ts
@@ -125,7 +125,7 @@ function buildInjectedCss(
     `.field input:focus { border-color: ${page.focusBorder}; }`,
     `.field input::placeholder { color: ${page.textHint}; }`,
     `.otp-box { color: ${page.text}; }`,
-    `.otp-box:focus { border-color: ${page.focusBorder} !important; }`,
+    `.otp-box.active { border-color: ${page.focusBorder} !important; }`,
     `.btn-primary { background: ${page.primary}; color: ${page.primaryText}; }`,
     `.btn-primary:hover { background: ${page.primaryHover}; }`,
     // Standalone actions under Verify (.btn-secondary buttons and the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,12 @@ importers:
       nodemailer:
         specifier: ^6.9.8
         version: 6.10.1
+      postcss:
+        specifier: ^8.5.25
+        version: 8.5.25
+      postcss-selector-parser:
+        specifier: ^7.1.4
+        version: 7.1.4
       svix:
         specifier: ^1.96.1
         version: 1.96.1
@@ -2247,6 +2253,11 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -3308,6 +3319,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanostores@1.1.0:
     resolution: {integrity: sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==}
     engines: {node: ^20.0.0 || >=22.0.0}
@@ -3598,8 +3614,16 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss-selector-parser@7.1.4:
+    resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
+    engines: {node: '>=4'}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -7186,6 +7210,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssesc@3.0.0: {}
+
   csstype@3.2.3: {}
 
   data-view-buffer@1.0.2:
@@ -8329,6 +8355,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.17: {}
+
   nanostores@1.1.0: {}
 
   napi-build-utils@2.0.0: {}
@@ -8621,9 +8649,20 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-selector-parser@7.1.4:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,10 +23,10 @@ export default defineConfig({
       // Ratchet thresholds — update these whenever coverage increases.
       // See AGENTS.md for the ratcheting policy.
       thresholds: {
-        statements: 58,
-        branches: 57,
-        functions: 71,
-        lines: 57,
+        statements: 59,
+        branches: 59,
+        functions: 72,
+        lines: 58,
       },
     },
   },


### PR DESCRIPTION
## Summary

* replace per-character OTP inputs with one full-length input behind the existing visual slots
  * this is how its done in shadcn and is the recommended way for accessbility. Heavily referenced from [input-otp](<https://github.com/guilhermerodz/input-otp>)
* preserve mobile paste, one-time-code autofill, and keyboard replacement behavior
* keep client branding selectors and browser-driven OTP helpers compatible
* add pure normalization and selection tests plus a patch changeset

Closes hypercerts-org/ePDS#212

## Testing

* `pnpm typecheck`
* `pnpm lint`
* `pnpm test` — 1,057 tests passed
* `pnpm test:coverage`
* Chromium mobile-context smoke test for formatted paste and keyboard replacement

## Summary by CodeRabbit

* **Bug Fixes**
  * Pasting or autofilling a mobile sign-in code now fills the complete one-time code instead of only the first character.
  * Improved OTP input behavior, including caret movement, selection, validation, normalization, and automatic submission.
  * OTP controls now receive clearer focus, accessibility, and disabled-state handling.
* **Style**
  * Updated OTP active-state styling guidance for themed interfaces.

## Summary by CodeRabbit

* **New Features**
  * Improved one-time-code entry on mobile, including full-code paste and autofill.
  * Added easier selection and replacement of individual code positions.
  * Improved screen-reader announcements and support for reduced-motion preferences.
  * OTP entry now uses a single input while preserving the segmented visual design.
* **Bug Fixes**
  * Corrected code normalization, caret movement, focus handling, and automatic submission.
  * Updated active-state styling for OTP fields.

## Summary by CodeRabbit

* **New Features**
  * Improved mobile sign-in code entry with long-press paste and one-time-code autofill.
  * Added flexible code selection, replacement, normalization, and automatic submission.
  * Added screen-reader announcements, accessibility metadata, and reduced-motion support.
* **Style**
  * Improved compatibility with existing sign-in branding and input styles.
  * Added clearer focus, placeholder, active-slot, and caret styling.
* **Documentation**
  * Updated guidance for OTP styling and browser-based code entry.