### PR TITLE
auth: clarify Resend webhook log messages

### DIFF
--- a/.changeset/resend-log-message-context.md
+++ b/.changeset/resend-log-message-context.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+Resend webhook logs now identify the email event type and provider in their message text.
+
+**Affects:** Operators
+
+**Operators:** Log messages use text such as `Received email event delivered from resend`, making events legible in log viewers that de-emphasize structured fields.

--- a/packages/auth-service/src/__tests__/resend-webhook.test.ts
+++ b/packages/auth-service/src/__tests__/resend-webhook.test.ts
@@ -119,7 +119,7 @@ describe('Resend webhook receiver', () => {
         email: 'person@example.com',
         subject: '[REDACTED] — Your sign-in code',
       },
-      'Received email event',
+      'Received email event delivered from resend',
     )
   })
 
@@ -137,7 +137,7 @@ describe('Resend webhook receiver', () => {
         messageId: 'resend-email-123',
         email: 'person@example.com',
       }),
-      'Received email event',
+      `Received email event ${normalizedType} from resend`,
     )
   })
 
@@ -222,7 +222,7 @@ describe('Resend webhook receiver', () => {
         eventType: normalizedType,
         messageId: 'resend-email-123',
       }),
-      'Received email event',
+      `Received email event ${normalizedType} from resend`,
     )
   })
 

--- a/packages/auth-service/src/routes/resend-webhook.ts
+++ b/packages/auth-service/src/routes/resend-webhook.ts
@@ -233,7 +233,7 @@ function logResendEvent(
     email: event.data.to[0],
     subject: redactOtpFromSubject(event.data.subject, otpLength, otpCharset),
   }
-  const message = 'Received email event'
+  const message = `Received email event ${fields.eventType} from ${fields.provider}`
   if ((WARNING_RESEND_EVENT_TYPES as readonly string[]).includes(event.type)) {
     logger.warn(fields, message)
   } else {


### PR DESCRIPTION
## Summary

Make Resend webhook events immediately legible in log viewers that emphasize message text over structured properties.

## Changes

- Include the normalized event type and provider in accepted webhook messages.
- Preserve the existing structured `eventType` and `provider` fields.
- Update tests for both informational and warning-level event messages.
- Add an operator-facing patch changeset.

## Testing

- `pnpm format:check`
- `pnpm lint`
- TypeScript project build (`tsc --build tsconfig.json`)
- `pnpm test` — 1,067 tests passed
- `pnpm test:coverage`

## Notes

Messages now use text such as `Received email event delivered from resend`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Resend webhook logs now include the email event type and provider directly in the message, making them easier to understand in log viewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->