### PR TITLE
auth: format Resend webhook event messages

### DIFF
--- a/.changeset/resend-log-message-context.md
+++ b/.changeset/resend-log-message-context.md
@@ -6,4 +6,4 @@ Resend webhook logs now identify the email event type and provider in their mess
 
 **Affects:** Operators
 
-**Operators:** Log messages use text such as `Received email event delivered from resend`, making events legible in log viewers that de-emphasize structured fields.
+**Operators:** Log messages use text such as `Received email event 'delivered' from Resend`, making events legible in log viewers that de-emphasize structured fields.

--- a/packages/auth-service/src/__tests__/resend-webhook.test.ts
+++ b/packages/auth-service/src/__tests__/resend-webhook.test.ts
@@ -119,7 +119,7 @@ describe('Resend webhook receiver', () => {
         email: 'person@example.com',
         subject: '[REDACTED] — Your sign-in code',
       },
-      'Received email event delivered from resend',
+      "Received email event 'delivered' from Resend",
     )
   })
 
@@ -137,7 +137,7 @@ describe('Resend webhook receiver', () => {
         messageId: 'resend-email-123',
         email: 'person@example.com',
       }),
-      `Received email event ${normalizedType} from resend`,
+      `Received email event '${normalizedType}' from Resend`,
     )
   })
 
@@ -222,7 +222,7 @@ describe('Resend webhook receiver', () => {
         eventType: normalizedType,
         messageId: 'resend-email-123',
       }),
-      `Received email event ${normalizedType} from resend`,
+      `Received email event '${normalizedType}' from Resend`,
     )
   })
 

--- a/packages/auth-service/src/routes/resend-webhook.ts
+++ b/packages/auth-service/src/routes/resend-webhook.ts
@@ -14,6 +14,7 @@ import { Webhook } from 'svix'
 import { createLogger } from '@certified-app/shared'
 
 const logger = createLogger('auth:email-webhook')
+const PROVIDER = { id: 'resend', displayName: 'Resend' } as const
 
 export const RESEND_WEBHOOK_PATH = '/webhooks/resend'
 
@@ -154,7 +155,7 @@ function verifyResendWebhook(
     payload = verifier.verify(req.body, headers)
   } catch (err) {
     logger.warn(
-      { err, provider: 'resend', eventId: headers['svix-id'] },
+      { err, provider: PROVIDER.id, eventId: headers['svix-id'] },
       'Rejected email webhook with invalid signature',
     )
     return { ok: false, error: 'Invalid webhook signature' }
@@ -162,7 +163,7 @@ function verifyResendWebhook(
 
   if (!isResendEvent(payload)) {
     logger.warn(
-      { provider: 'resend', eventId: headers['svix-id'] },
+      { provider: PROVIDER.id, eventId: headers['svix-id'] },
       'Rejected invalid email webhook payload',
     )
     return { ok: false, error: 'Invalid webhook payload' }
@@ -225,7 +226,7 @@ function logResendEvent(
   otpCharset: OtpCharset,
 ): void {
   const fields = {
-    provider: 'resend',
+    provider: PROVIDER.id,
     eventId: svixId,
     eventType: NORMALIZED_EVENT_TYPES[event.type],
     occurredAt: event.created_at,
@@ -233,7 +234,7 @@ function logResendEvent(
     email: event.data.to[0],
     subject: redactOtpFromSubject(event.data.subject, otpLength, otpCharset),
   }
-  const message = `Received email event ${fields.eventType} from ${fields.provider}`
+  const message = `Received email event '${fields.eventType}' from ${PROVIDER.displayName}`
   if ((WARNING_RESEND_EVENT_TYPES as readonly string[]).includes(event.type)) {
     logger.warn(fields, message)
   } else {
@@ -268,7 +269,7 @@ export function createResendWebhookRouter(
       if (!isLoggedResendEvent(result.event)) {
         logger.debug(
           {
-            provider: 'resend',
+            provider: PROVIDER.id,
             eventId,
             eventType: result.event.type.slice('email.'.length),
           },
@@ -281,7 +282,7 @@ export function createResendWebhookRouter(
       const eventFromAddress = parseSingleEmailAddress(result.event.data.from)
       if (eventFromAddress !== expectedFromAddress) {
         logger.debug(
-          { provider: 'resend', eventId },
+          { provider: PROVIDER.id, eventId },
           'Ignored email webhook for another sender',
         )
         res.status(200).json({ received: true, ignored: true })


### PR DESCRIPTION
## Summary

Finish the Resend webhook log-message improvement by quoting event types and rendering the provider’s human-readable name without changing its structured identifier.

## Changes

- Define provider metadata once as machine ID `resend` and display name `Resend`.
- Render messages such as `Received email event 'delivered' from Resend`.
- Continue emitting `provider: "resend"` for structured log queries.
- Update informational and warning-level message tests and release notes.

## Testing

- `pnpm format:check`
- `pnpm lint`
- TypeScript project build (`tsc --build tsconfig.json`)
- `pnpm test` — all tests passed
- `pnpm test:coverage`

## Notes

Follow-up to merged PR #209.
