### PR TITLE
P2: fix(auth): explain stale authorization and recovery links

### DIFF
--- a/.changeset/friendlier-stale-link-errors.md
+++ b/.changeset/friendlier-stale-link-errors.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+Stale sign-in and account-recovery links now explain how to restart.
+
+**Affects:** End users
+
+**End users:** Return to the app you were signing into and start again when either page reports that the old link no longer belongs to an active sign-in flow.

--- a/e2e/step-definitions/account-recovery.steps.ts
+++ b/e2e/step-definitions/account-recovery.steps.ts
@@ -329,3 +329,39 @@ Then(
     await assertNoEmailFor(this.backupEmail)
   },
 )
+
+// ---------------------------------------------------------------------------
+// Stale-recovery-link UX
+// ---------------------------------------------------------------------------
+
+When(
+  'the user navigates directly to the recovery page without an active sign-in',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await page.goto(`${testEnv.authUrl}/auth/recover`)
+  },
+)
+
+Then(
+  'the page explains that recovery has to start from the sign-in page',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await expect(page.locator('body')).toContainText(
+      /recovery has to be started from the sign-in page/i,
+      { timeout: 10_000 },
+    )
+  },
+)
+
+Then(
+  'the page does not mention the technical field name {string}',
+  async function (this: EpdsWorld, fieldName: string) {
+    const page = getPage(this)
+    const body = await page.locator('body').innerText()
+    if (body.toLowerCase().includes(fieldName.toLowerCase())) {
+      throw new Error(
+        `Expected the page to not surface the technical field name "${fieldName}", but its body text contained it. Page body: ${body}`,
+      )
+    }
+  },
+)

--- a/e2e/step-definitions/auth.steps.ts
+++ b/e2e/step-definitions/auth.steps.ts
@@ -969,3 +969,26 @@ Then('the email input is empty and focused', async function (this: EpdsWorld) {
   await expect(input).toHaveValue('', { timeout: 5_000 })
   await expect(input).toBeFocused({ timeout: 5_000 })
 })
+
+// ---------------------------------------------------------------------------
+// Stale-authorization-link UX
+// ---------------------------------------------------------------------------
+
+When(
+  'the user navigates directly to the authorize page without an active sign-in',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await page.goto(`${testEnv.authUrl}/oauth/authorize`)
+  },
+)
+
+Then(
+  'the page explains that sign-in has to start from the app',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await expect(page.locator('body')).toContainText(
+      /sign-in has to be started from the app/i,
+      { timeout: 10_000 },
+    )
+  },
+)

--- a/features/account-recovery.feature
+++ b/features/account-recovery.feature
@@ -39,6 +39,18 @@ Feature: Account recovery via backup emails
     Then the recovery OTP form is displayed
     And no email arrives for that non-existent address
 
+  # /auth/recover requires an active sign-in flow (it carries a
+  # request_uri that points at the upstream PAR). Hitting the URL
+  # directly — typically by following a stale link or pasting from
+  # somewhere — used to surface "Missing request_uri parameter",
+  # which leaks the internal OAuth field name and tells the user
+  # nothing actionable.
+  @stale-link
+  Scenario: Direct visit to recovery URL surfaces a friendly explanation, not a technical field name
+    When the user navigates directly to the recovery page without an active sign-in
+    Then the page explains that recovery has to start from the sign-in page
+    And the page does not mention the technical field name "request_uri"
+
   # --- Backup email management ---
 
   Scenario: User removes a backup email

--- a/features/passwordless-authentication.feature
+++ b/features/passwordless-authentication.feature
@@ -403,6 +403,14 @@ Feature: Passwordless authentication via email OTP
     When the user clicks "Use different email"
     Then the email input is empty and focused
 
+  # Direct visits to /oauth/authorize have no active request. Explain
+  # how to restart instead of exposing the internal request_uri field.
+  @stale-link
+  Scenario: Direct visit to /oauth/authorize surfaces a friendly explanation
+    When the user navigates directly to the authorize page without an active sign-in
+    Then the page explains that sign-in has to start from the app
+    And the page does not mention the technical field name "request_uri"
+
   @email @demo-cookie-expiry @bug-report
   Scenario: Demo client's OAuth cookie has expired by the time of callback — useful error, not generic auth_failed
     When the demo client starts a new OAuth flow with random handle mode

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -168,10 +168,19 @@ export function createLoginPageRouter(ctx: AuthServiceContext): Router {
     const clientId = req.query.client_id as string | undefined
     const loginHint = req.query.login_hint as string | undefined
     if (!requestUri) {
+      // The user landed here without an active sign-in flow —
+      // typically a stale link or direct visit. The technical
+      // "Missing request_uri parameter" tells them nothing
+      // actionable; surface the honest, useful message instead.
       res
         .status(400)
         .type('html')
-        .send(renderError('Missing request_uri parameter'))
+        .send(
+          renderError(
+            'Sign-in has to be started from the app you are signing into. Please return to that app and try again.',
+            { title: 'No active sign-in' },
+          ),
+        )
       return
     }
 

--- a/packages/auth-service/src/routes/recovery.ts
+++ b/packages/auth-service/src/routes/recovery.ts
@@ -76,10 +76,19 @@ export function createRecoveryRouter(
     const requestUri = req.query.request_uri as string | undefined
 
     if (!requestUri) {
+      // The user landed here without an active sign-in flow —
+      // typically a stale link or direct visit. The technical
+      // "Missing request_uri parameter" tells them nothing
+      // actionable; surface the honest, useful message instead.
       res
         .status(400)
         .type('html')
-        .send(renderError('Missing request_uri parameter'))
+        .send(
+          renderError(
+            'Account recovery has to be started from the sign-in page. Please sign in again from the app you came from.',
+            { title: 'No active sign-in' },
+          ),
+        )
       return
     }
 


### PR DESCRIPTION
## Summary

Replace raw missing-parameter errors on stale or direct sign-in and recovery visits with actionable guidance. Users are told that the link is no longer usable and how to restart.

## Changes

- Add user-facing stale-link responses for authorization and recovery
- Assert visible error wording without matching hidden fields or scripts
- Document both user-facing changes with changesets

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:coverage`


## Screenshots

**Before:** stale sign-in and recovery links exposed the internal `request_uri` parameter name.

![Before: stale sign-in internal error](https://github.com/user-attachments/assets/d00d6ebd-0ad6-4ae0-97b7-dc6705da151b)

![Before: stale recovery internal error](https://github.com/user-attachments/assets/8140ea6a-e0b3-4beb-97a7-26c02517f66b)

**After:** both routes give actionable guidance.

![After: stale sign-in guidance](https://github.com/user-attachments/assets/d893268f-e00f-4113-9c62-65208df5740a)

![After: stale recovery guidance](https://github.com/user-attachments/assets/583f97df-b414-487c-bd19-360c1f25592b)

## Notes

- Focused extraction and review of work originally proposed in #165.
- The deployed E2E suite [passed](https://github.com/hypercerts-org/ePDS/actions/runs/30547817055).


