### PR TITLE
P3: feat(auth): suggest checking spam for OTP emails

### DIFF
--- a/.changeset/spam-hint-on-otp-form.md
+++ b/.changeset/spam-hint-on-otp-form.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+Sign-in code page hints to check spam folder when the email doesn't arrive.
+
+**Affects:** End users
+
+**End users:** the page now shows a small "If you don't see the email, check your spam folder." note below the code boxes. If you typo'd your email or the message landed in spam, you used to wait and wait and then get frustrated; the hint surfaces the most common reason early so you can either check spam or click "Use different email" sooner.

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -597,7 +597,7 @@ export function renderLoginPage(opts: {
   ${renderFaviconTag(opts.customFaviconUrl, opts.customFaviconUrlDark)}
   <title>Sign in to ${escapeHtml(appName)}</title>
   <style>
-    :root { --muted-foreground: #999; --input-bg: #ffffff; --input-border: #e5e5e5; --page-bg: #E8E8E8; --card-bg: #F8F8F8; --card-border: #E5E5E5; --btn-secondary-border: #e5e5e5; --focus-border: ${brandColor}; }
+    :root { --muted-foreground: #6b6b6b; --input-bg: #ffffff; --input-border: #e5e5e5; --page-bg: #E8E8E8; --card-bg: #F8F8F8; --card-border: #E5E5E5; --btn-secondary-border: #e5e5e5; --focus-border: ${brandColor}; }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--page-bg); min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; color: #1A130F; }
     .page-wrap { display: flex; flex-direction: column; align-items: stretch; max-width: 497px; width: 100%; }
@@ -614,6 +614,7 @@ export function renderLoginPage(opts: {
     .otp-box::placeholder { color: #d4d4d4; }
     .otp-box:focus { border-color: var(--focus-border); }
     .otp-actions { display: flex; gap: 32px; justify-content: center; margin-top: 12px; }
+    .otp-spam-hint { color: var(--muted-foreground); font-size: 13px; text-align: center; margin: 8px 0 16px; }
     .btn-primary { width: 100%; padding: 15px; background: ${brandColor}; color: white; border: none; border-radius: 9999px; font-size: 15px; font-weight: 500; cursor: pointer; transition: opacity 0.15s; }
     .btn-primary:hover { opacity: 0.9; }
     .btn-primary:disabled { opacity: 0.7; cursor: not-allowed; }
@@ -696,6 +697,9 @@ export function renderLoginPage(opts: {
         </div>
         <button type="submit" class="btn-primary">Verify</button>
       </form>
+      <p class="otp-spam-hint" id="otp-spam-hint">
+        If you don't see the email, check your spam folder.
+      </p>
       <div class="otp-actions">
         <button type="button" class="btn-secondary" id="btn-resend">Resend code</button>
         <button type="button" class="btn-secondary" id="btn-back">Use different email</button>


### PR DESCRIPTION
## Summary

Add a concise spam-folder hint below the OTP form so users have an immediate next step when the verification email is slow to appear.

## Changes

- Show a muted spam-folder hint on the OTP step
- Document the end-user change with a changeset

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:coverage`


## Screenshots

**Before:** the OTP form gave no hint about checking filtered mail.

![Before: no spam-folder hint](https://github.com/user-attachments/assets/0bea776a-0ed9-4bfc-8bf2-05b7c285f901)

**After:** a concise, readable spam-folder hint appears beneath **Verify**; it retains the theme variable and meets normal-text contrast guidance.

![After: spam-folder hint](https://github.com/user-attachments/assets/59f2dc42-c192-4fd5-9804-cbe68a05bde1)

## Notes

- Current SHA 8a163d1 passed the full deployed E2E suite in [run 30629432954](https://github.com/hypercerts-org/ePDS/actions/runs/30629432954).

- Focused extraction and review of work originally proposed in #165.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a note to the one-time passcode sign-in screen reminding users to check their spam folder if the email hasn’t arrived.

* **Style**
  * Improved contrast for muted text throughout the sign-in page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


