### PR TITLE
P3: fix(demo): show user-friendly authentication errors

### DIFF
--- a/.changeset/friendlier-demo-error-banners.md
+++ b/.changeset/friendlier-demo-error-banners.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+Demo client's error banners now use plain user-friendly language instead of developer wording.
+
+**Affects:** End users
+
+**End users:** several of the demo's sign-in error banners used technical wording aimed at developers ("PAR rejected the request — check server logs", "token exchange failed") that didn't tell you anything actionable. The wording is now plain English and suggests retrying, contacting support if startup failures persist, or beginning sign-in again when the session has expired.

--- a/packages/demo/src/__tests__/login-form-errors.test.ts
+++ b/packages/demo/src/__tests__/login-form-errors.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { getLoginErrorMessage } from '../lib/login-errors.js'
+
+describe('getLoginErrorMessage', () => {
+  it('gives a retry and escalation path when PAR setup fails', () => {
+    expect(getLoginErrorMessage('par_failed')).toBe(
+      "Sign-in couldn't start. Please try again. If it keeps happening, contact support.",
+    )
+  })
+
+  it('asks the user to retry after an interrupted OAuth state', () => {
+    expect(getLoginErrorMessage('state_mismatch')).toBe(
+      'Your sign-in session expired or was interrupted. Please try again.',
+    )
+  })
+
+  it('retains a safe fallback for unknown error codes', () => {
+    expect(getLoginErrorMessage('unexpected_code')).toBe(
+      'Unexpected error: unexpected_code',
+    )
+  })
+})

--- a/packages/demo/src/app/components/LoginForm.tsx
+++ b/packages/demo/src/app/components/LoginForm.tsx
@@ -2,21 +2,8 @@
 
 import { useSearchParams } from 'next/navigation'
 import { useState } from 'react'
+import { getLoginErrorMessage } from '../../lib/login-errors'
 import { ForceLoginCheckbox } from './ForceLoginCheckbox'
-
-const ERROR_MESSAGES: Record<string, string> = {
-  auth_failed: 'Authentication failed. Please try again.',
-  session_expired:
-    'Your sign-in took too long to finish. Please sign in again.',
-  par_failed:
-    'Could not start login — the PDS rejected the request. Check server logs.',
-  invalid_email: 'Please enter a valid email address.',
-  invalid_handle: 'Please enter a valid handle (e.g. you.bsky.social).',
-  invalid_login_hint: 'Invalid login hint format.',
-  token_failed: 'Login could not be completed — token exchange failed.',
-  state_mismatch:
-    'Login session expired or was tampered with. Please try again.',
-}
 
 /**
  * Interactive login form (client component). Picks up theme colours via
@@ -25,9 +12,7 @@ const ERROR_MESSAGES: Record<string, string> = {
 export function LoginForm() {
   const searchParams = useSearchParams()
   const errorCode = searchParams.get('error')
-  const errorMessage = errorCode
-    ? ERROR_MESSAGES[errorCode] || `Unexpected error: ${errorCode}`
-    : null
+  const errorMessage = getLoginErrorMessage(errorCode)
   const [submitting, setSubmitting] = useState(false)
   const [mode, setMode] = useState<'email' | 'handle'>('email')
 

--- a/packages/demo/src/lib/login-errors.ts
+++ b/packages/demo/src/lib/login-errors.ts
@@ -1,0 +1,20 @@
+const ERROR_MESSAGES: Record<string, string> = {
+  auth_failed: 'Sign-in failed. Please try again.',
+  session_expired:
+    'Your sign-in took too long to finish. Please sign in again.',
+  par_failed:
+    "Sign-in couldn't start. Please try again. If it keeps happening, contact support.",
+  invalid_email: 'Please enter a valid email address.',
+  invalid_handle: 'Please enter a valid handle (e.g. you.bsky.social).',
+  invalid_login_hint:
+    "We didn't recognise that account. Please sign in with your email instead.",
+  token_failed: "Sign-in couldn't be completed. Please sign in again.",
+  state_mismatch:
+    'Your sign-in session expired or was interrupted. Please try again.',
+}
+
+export function getLoginErrorMessage(errorCode: string | null): string | null {
+  return errorCode
+    ? ERROR_MESSAGES[errorCode] || `Unexpected error: ${errorCode}`
+    : null
+}


### PR DESCRIPTION
## Summary

Translate known demo-client authentication failures into plain-language guidance instead of exposing developer-oriented wording such as instructions to check server logs.

## Changes

- Map known callback and session failures to user-facing messages
- Preserve a neutral fallback for unknown failures
- Document the copy change with a changeset

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:coverage`


## Screenshots

**Before:** the demo exposed provider/PAR terminology and told end users to inspect server logs.

![Before: technical demo error](https://github.com/user-attachments/assets/e0b67366-0a6d-4094-92a6-7ec69e2f1743)

**After:** the message gives an immediate retry action and a support escalation path without exposing implementation details.

![After: actionable demo sign-in error](https://github.com/user-attachments/assets/96e6df50-39da-4f9d-bfd6-16ec6ee8cfe1)

## Notes

- Focused extraction and review of work originally proposed in #165.


