### PR TITLE
P0: fix(shared): safely fall back from malformed client IDs

### DIFF
--- a/.changeset/fallback-app-name-on-malformed-client-id.md
+++ b/.changeset/fallback-app-name-on-malformed-client-id.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+Sign-in pages no longer leak a malformed client_id as the displayed app name.
+
+**Affects:** End users
+
+**End users:** if you arrived at a sign-in page with a broken `client_id` parameter on the URL (e.g. from a misconfigured app or a tampered link), the page would display that raw broken value as the app's name, e.g. "Sign in to not-a-url" or "Sign in to my-local-app". The page now falls back to "an application" in that case, so a malformed value in the URL doesn't leak into the visible page text or browser tab title.

--- a/packages/shared/src/__tests__/client-metadata.test.ts
+++ b/packages/shared/src/__tests__/client-metadata.test.ts
@@ -23,9 +23,14 @@ beforeEach(() => {
 })
 
 describe('resolveClientMetadata', () => {
-  it('returns client_name for non-URL client_id', async () => {
+  it('returns empty metadata for a non-URL client_id', async () => {
+    // Non-URL client_ids used to surface the raw value as
+    // metadata.client_name, which then ended up in page titles
+    // ("Sign in to not-a-url") on the auth-service login page.
+    // Returning empty metadata lets the caller's fallback chain
+    // (client_name || extractDomain → 'an application') win.
     const metadata = await resolveClientMetadata('my-local-app')
-    expect(metadata.client_name).toBe('my-local-app')
+    expect(metadata).toEqual({})
   })
 
   it('returns seeded metadata from cache', async () => {
@@ -135,10 +140,13 @@ describe('resolveClientName', () => {
     expect(name).toBe('no-name.app')
   })
 
-  it('returns client_id as-is for non-URL', async () => {
-    const name = await resolveClientName('unnamed-client')
-    expect(name).toBe('unnamed-client')
-  })
+  it.each(['unnamed-client', 'ftp://example.com/client-metadata.json'])(
+    'falls back to "an application" for unsupported client_id %s',
+    async (clientId) => {
+      const name = await resolveClientName(clientId)
+      expect(name).toBe('an application')
+    },
+  )
 })
 
 describe('getClientCss', () => {

--- a/packages/shared/src/client-metadata.ts
+++ b/packages/shared/src/client-metadata.ts
@@ -168,10 +168,18 @@ export async function resolveClientMetadata(
   try {
     parsedUrl = new URL(clientId)
   } catch {
-    return { client_name: clientId }
+    // Malformed clientId — return empty metadata so the caller's
+    // fallback chain (client_name || extractDomain(clientId) ||
+    // 'an application') doesn't end up surfacing the literal raw
+    // string ("Sign in to not-a-url") in page titles and copy.
+    // The caller's extractDomain will also fail; the final
+    // fallback to "an application" wins.
+    return {}
   }
   if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
-    return { client_name: clientId }
+    // Same shape as the unparseable case: don't surface the raw
+    // schemeless or non-http value to end users.
+    return {}
   }
 
   if (!options.noCache) {
@@ -240,7 +248,9 @@ function fallback(clientId: string, skipCache: boolean): ClientMetadata {
 function extractDomain(urlStr: string): string | null {
   try {
     const url = new URL(urlStr)
-    return url.hostname
+    return url.protocol === 'https:' || url.protocol === 'http:'
+      ? url.hostname
+      : null
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary

Avoid presenting a malformed or non-HTTP client identifier as the application's visible name. Callers now fall back to neutral application copy when metadata cannot provide a trustworthy name.

## Changes

- Return no display name for malformed and unsupported client IDs
- Retain safe hostname fallback for valid HTTP(S) identifiers
- Add focused metadata tests and a changeset

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:coverage`


## Screenshots

With `client_id=my-local-app`, the deployed page uses the generic browser title **Sign in to an application** instead of reflecting the malformed identifier.

![Safe client-name fallback page](https://github.com/user-attachments/assets/4fcf39a6-e49c-44f4-8694-e1208c348e1c)

## Notes

- Focused extraction and review of work originally proposed in #165.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in pages no longer display malformed client IDs as application names.
  * Browser tab titles now use the generic “an application” label when app information cannot be resolved.
  * Invalid or unsupported client identifiers are handled with safer fallback metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

