### PR TITLE
P0: fix(auth): show account-settings action results

### DIFF
--- a/.changeset/account-settings-flash-messages.md
+++ b/.changeset/account-settings-flash-messages.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+Account Settings now confirms every action with a visible banner.
+
+**Affects:** End users
+
+**End users:** when you added a backup email, removed one, changed your handle, revoked a session, or hit a validation error on any of those, the page silently bounced back to the same form with no indication that anything had changed (or what went wrong). The page now shows a green "Backup email added" / "Handle updated" / etc. banner on success, and a red "That handle is not available" / "We couldn't send the verification email" / etc. banner on error — so you know whether your action took effect.

--- a/packages/auth-service/src/__tests__/account-settings-flash.test.ts
+++ b/packages/auth-service/src/__tests__/account-settings-flash.test.ts
@@ -34,6 +34,8 @@ describe('account-settings flash messages', () => {
       'already_primary',
       'account_not_found',
       'send_failed',
+      'backup_remove_failed',
+      'revoke_failed',
       'verify_failed',
       'invalid_handle',
       'handle_failed',

--- a/packages/auth-service/src/__tests__/account-settings-flash.test.ts
+++ b/packages/auth-service/src/__tests__/account-settings-flash.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   FLASH_SUCCESS_MESSAGES,
   FLASH_ERROR_MESSAGES,
+  resolveAccountFlashFromQuery,
 } from '../routes/account-settings.js'
 
 describe('account-settings flash messages', () => {
@@ -62,5 +63,47 @@ describe('account-settings flash messages', () => {
     for (const msg of Object.values(FLASH_ERROR_MESSAGES)) {
       expect(msg).not.toMatch(/<[a-z]/i)
     }
+  })
+})
+
+describe('resolveAccountFlashFromQuery', () => {
+  it('returns the success message when the success code is known', () => {
+    const result = resolveAccountFlashFromQuery({ success: 'backup_added' })
+    expect(result.successMessage).toBe(FLASH_SUCCESS_MESSAGES.backup_added)
+    expect(result.errorMessage).toBeNull()
+  })
+
+  it('returns the error message when the error code is known', () => {
+    const result = resolveAccountFlashFromQuery({
+      success: '',
+      error: 'invalid_handle',
+    })
+    expect(result.successMessage).toBeNull()
+    expect(result.errorMessage).toBe(FLASH_ERROR_MESSAGES.invalid_handle)
+  })
+
+  it('returns null on both sides when the query is empty', () => {
+    expect(resolveAccountFlashFromQuery({})).toEqual({
+      successMessage: null,
+      errorMessage: null,
+    })
+  })
+
+  it('returns null on both sides for unknown codes (safety against URL-injection of attacker text)', () => {
+    expect(
+      resolveAccountFlashFromQuery({
+        success: 'attacker_chosen_text',
+        error: '<script>alert(1)</script>',
+      }),
+    ).toEqual({ successMessage: null, errorMessage: null })
+  })
+
+  it('ignores non-string query values gracefully (e.g. ?success=foo&success=bar arrays)', () => {
+    expect(
+      resolveAccountFlashFromQuery({
+        success: ['backup_added', 'backup_removed'],
+        error: 12345,
+      }),
+    ).toEqual({ successMessage: null, errorMessage: null })
   })
 })

--- a/packages/auth-service/src/__tests__/account-settings-flash.test.ts
+++ b/packages/auth-service/src/__tests__/account-settings-flash.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FLASH_SUCCESS_MESSAGES,
+  FLASH_ERROR_MESSAGES,
+} from '../routes/account-settings.js'
+
+describe('account-settings flash messages', () => {
+  // Every code referenced in a redirect from a POST handler needs an
+  // entry in the matching lookup, otherwise the user lands on the
+  // settings page with no acknowledgement of the action they took.
+  // These tests guard against drift — adding a new code without a
+  // corresponding entry would mean the redirect silently dropped.
+
+  it('has a success message for each code redirected to from a POST handler', () => {
+    const expectedSuccessCodes = [
+      'backup_added',
+      'backup_verified',
+      'backup_removed',
+      'handle_updated',
+      'session_revoked',
+    ]
+    for (const code of expectedSuccessCodes) {
+      expect(
+        FLASH_SUCCESS_MESSAGES[code],
+        `missing FLASH_SUCCESS_MESSAGES["${code}"]`,
+      ).toBeTruthy()
+    }
+  })
+
+  it('has an error message for each code redirected to from a POST handler', () => {
+    const expectedErrorCodes = [
+      'invalid_email',
+      'already_primary',
+      'account_not_found',
+      'send_failed',
+      'verify_failed',
+      'invalid_handle',
+      'handle_failed',
+      'handle_taken',
+      'delete_failed',
+      'confirm_delete',
+    ]
+    for (const code of expectedErrorCodes) {
+      expect(
+        FLASH_ERROR_MESSAGES[code],
+        `missing FLASH_ERROR_MESSAGES["${code}"]`,
+      ).toBeTruthy()
+    }
+  })
+
+  it('returns undefined for unknown codes — the GET handler treats this as "no banner"', () => {
+    expect(FLASH_SUCCESS_MESSAGES['attacker_injected_text']).toBeUndefined()
+    expect(FLASH_ERROR_MESSAGES['<script>alert(1)</script>']).toBeUndefined()
+  })
+
+  it('all messages are plain text, no HTML', () => {
+    // The renderer escapeHtml's the lookup result anyway (defence in
+    // depth) but the values themselves shouldn't carry markup.
+    for (const msg of Object.values(FLASH_SUCCESS_MESSAGES)) {
+      expect(msg).not.toMatch(/<[a-z]/i)
+    }
+    for (const msg of Object.values(FLASH_ERROR_MESSAGES)) {
+      expect(msg).not.toMatch(/<[a-z]/i)
+    }
+  })
+})

--- a/packages/auth-service/src/__tests__/account-settings-flash.test.ts
+++ b/packages/auth-service/src/__tests__/account-settings-flash.test.ts
@@ -3,6 +3,7 @@ import {
   FLASH_SUCCESS_MESSAGES,
   FLASH_ERROR_MESSAGES,
   resolveAccountFlashFromQuery,
+  renderSettingsPage,
 } from '../routes/account-settings.js'
 
 describe('account-settings flash messages', () => {
@@ -65,6 +66,39 @@ describe('account-settings flash messages', () => {
     for (const msg of Object.values(FLASH_ERROR_MESSAGES)) {
       expect(msg).not.toMatch(/<[a-z]/i)
     }
+  })
+})
+
+describe('account-settings flash rendering', () => {
+  const renderPage = (messages: {
+    successMessage?: string
+    errorMessage?: string
+  }) =>
+    renderSettingsPage({
+      did: 'did:plc:test',
+      email: 'primary@example.com',
+      handleDomain: 'example.com',
+      currentHandle: null,
+      backupEmails: [],
+      sessions: [],
+      currentSessionToken: 'current-session',
+      csrfToken: 'csrf-token',
+      ...messages,
+    })
+
+  it('renders successful actions as an accessible status', () => {
+    const html = renderPage({ successMessage: 'Backup email removed.' })
+    expect(html).toContain(
+      '<div class="flash flash-success" role="status">Backup email removed.</div>',
+    )
+  })
+
+  it('renders escaped failures as an alert', () => {
+    const html = renderPage({ errorMessage: '<script>failed</script>' })
+    expect(html).toContain(
+      '<div class="flash flash-error" role="alert">&lt;script&gt;failed&lt;/script&gt;</div>',
+    )
+    expect(html).not.toContain('<script>failed</script>')
   })
 })
 

--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -57,6 +57,27 @@ export const FLASH_ERROR_MESSAGES: Record<string, string> = {
 }
 
 /**
+ * Resolve the success / error message pair from a /account request's
+ * query params. Whitelist the keys via the FLASH_*_MESSAGES tables so
+ * an attacker can't craft a URL like
+ * `/account?error=Some+raw+text` to inject arbitrary copy.
+ *
+ * Exported so the route handler can stay declarative AND be unit-
+ * tested without needing a fake express request.
+ */
+export function resolveAccountFlashFromQuery(query: {
+  success?: unknown
+  error?: unknown
+}): { successMessage: string | null; errorMessage: string | null } {
+  const successCode = typeof query.success === 'string' ? query.success : ''
+  const errorCode = typeof query.error === 'string' ? query.error : ''
+  return {
+    successMessage: FLASH_SUCCESS_MESSAGES[successCode] ?? null,
+    errorMessage: FLASH_ERROR_MESSAGES[errorCode] ?? null,
+  }
+}
+
+/**
  * Middleware that validates a better-auth session and injects it into res.locals.
  * If not authenticated, redirects to /account/login.
  */
@@ -122,15 +143,11 @@ export function createAccountSettingsRouter(
 
     // The POST handlers below redirect back to /account with a
     // ?success=… or ?error=… query param to confirm the action.
-    // Plumb those through so the user actually sees the result
-    // ("Backup email added", "Handle changed", …) instead of being
-    // silently bounced back to the same form. Whitelist the
-    // recognised codes via FLASH_*_MESSAGES so an attacker can't
-    // craft a URL that injects arbitrary text into the page.
-    const successCode = (req.query.success as string | undefined) ?? ''
-    const errorCode = (req.query.error as string | undefined) ?? ''
-    const successMessage = FLASH_SUCCESS_MESSAGES[successCode] ?? null
-    const errorMessage = FLASH_ERROR_MESSAGES[errorCode] ?? null
+    // resolveAccountFlashFromQuery whitelists the recognised codes
+    // so an attacker can't craft a URL that injects arbitrary text.
+    const { successMessage, errorMessage } = resolveAccountFlashFromQuery(
+      req.query as { success?: unknown; error?: unknown },
+    )
 
     res.type('html').send(
       renderSettingsPage({

--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -17,6 +17,46 @@ import { POWERED_BY_CSS, POWERED_BY_HTML } from '../lib/page-helpers.js'
 const logger = createLogger('auth:account-settings')
 
 /**
+ * User-visible flash-message lookup tables for the GET /account
+ * page. The POST handlers redirect back with `?success=<code>` or
+ * `?error=<code>` and the GET handler renders the matching message.
+ *
+ * Whitelisted lookup (not `?success=Some+raw+text`) so attackers
+ * can't inject arbitrary text into the settings page via a crafted
+ * URL.
+ *
+ * Exported for unit testing.
+ */
+export const FLASH_SUCCESS_MESSAGES: Record<string, string> = {
+  backup_added:
+    'Backup email added. Click the verification link we sent to confirm.',
+  backup_verified: 'Backup email verified.',
+  backup_removed: 'Backup email removed.',
+  handle_updated: 'Handle updated.',
+  session_revoked: 'Session revoked.',
+}
+
+export const FLASH_ERROR_MESSAGES: Record<string, string> = {
+  invalid_email: 'That email address is not valid.',
+  already_primary:
+    'That email is already your primary — you can sign in with it directly.',
+  account_not_found: "We couldn't find an account for your sign-in.",
+  send_failed:
+    "We couldn't send the verification email. Please try again in a moment.",
+  verify_failed:
+    'That verification link is no longer valid. Add the backup email again to receive a fresh link.',
+  invalid_handle:
+    "That handle isn't valid. Use 5–20 characters: letters, numbers, or hyphens.",
+  handle_failed:
+    "We couldn't change your handle. It may be reserved or already taken.",
+  delete_failed:
+    "We couldn't delete your account right now. Please try again in a moment.",
+  handle_taken: 'That handle is not available — please choose another.',
+  confirm_delete:
+    'Type DELETE in the confirmation box to permanently delete your account.',
+}
+
+/**
  * Middleware that validates a better-auth session and injects it into res.locals.
  * If not authenticated, redirects to /account/login.
  */
@@ -80,6 +120,18 @@ export function createAccountSettingsRouter(
       logger.warn({ err }, 'Failed to list sessions')
     }
 
+    // The POST handlers below redirect back to /account with a
+    // ?success=… or ?error=… query param to confirm the action.
+    // Plumb those through so the user actually sees the result
+    // ("Backup email added", "Handle changed", …) instead of being
+    // silently bounced back to the same form. Whitelist the
+    // recognised codes via FLASH_*_MESSAGES so an attacker can't
+    // craft a URL that injects arbitrary text into the page.
+    const successCode = (req.query.success as string | undefined) ?? ''
+    const errorCode = (req.query.error as string | undefined) ?? ''
+    const successMessage = FLASH_SUCCESS_MESSAGES[successCode] ?? null
+    const errorMessage = FLASH_ERROR_MESSAGES[errorCode] ?? null
+
     res.type('html').send(
       renderSettingsPage({
         did: did ?? '(unknown)',
@@ -90,6 +142,8 @@ export function createAccountSettingsRouter(
         sessions,
         currentSessionToken: session.session.token,
         csrfToken: res.locals.csrfToken,
+        successMessage,
+        errorMessage,
       }),
     )
   })
@@ -217,7 +271,7 @@ export function createAccountSettingsRouter(
       if (did && email) {
         ctx.db.removeBackupEmail(did, email)
       }
-      res.redirect(303, '/account')
+      res.redirect(303, '/account?success=backup_removed')
     },
   )
 
@@ -237,7 +291,7 @@ export function createAccountSettingsRouter(
           logger.warn({ err }, 'Failed to revoke session')
         }
       }
-      res.redirect(303, '/account')
+      res.redirect(303, '/account?success=session_revoked')
     },
   )
 
@@ -427,7 +481,21 @@ function renderSettingsPage(opts: {
   }>
   currentSessionToken: string
   csrfToken: string
+  successMessage?: string | null
+  errorMessage?: string | null
 }): string {
+  // Prepend any flash banners INSIDE the existing page-wrap so they
+  // sit above the settings content. Both go through escapeHtml even
+  // though the source dictionary is whitelisted — defence-in-depth
+  // against a future maintainer accidentally widening the lookup.
+  const flashHtml = [
+    opts.successMessage
+      ? `<div class="flash flash-success" role="status">${escapeHtml(opts.successMessage)}</div>`
+      : '',
+    opts.errorMessage
+      ? `<div class="flash flash-error" role="alert">${escapeHtml(opts.errorMessage)}</div>`
+      : '',
+  ].join('')
   const backupRows = opts.backupEmails
     .map(
       (be) => `
@@ -488,6 +556,8 @@ function renderSettingsPage(opts: {
         <button type="submit" class="btn-secondary">Sign out</button>
       </form>
     </div>
+
+    ${flashHtml}
 
     <section class="section">
       <h2>Account</h2>
@@ -589,6 +659,9 @@ const SETTINGS_CSS = `
   .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; border-bottom: 1px solid #eee; padding-bottom: 16px; }
   h1 { font-size: 24px; color: #111; }
   h2 { font-size: 18px; color: #333; margin-bottom: 12px; }
+  .flash { padding: 12px 16px; border-radius: 8px; margin-bottom: 20px; font-size: 14px; }
+  .flash-success { background: #f0fff4; color: #28a745; border: 1px solid #c3e6cb; }
+  .flash-error { background: #fdf0f0; color: #dc3545; border: 1px solid #f5c6cb; }
   .section { margin-bottom: 28px; padding-bottom: 20px; border-bottom: 1px solid #f0f0f0; }
   .section:last-child { border-bottom: none; margin-bottom: 0; }
   .setting-row { display: flex; justify-content: space-between; align-items: center; padding: 8px 0; font-size: 14px; color: #333; }

--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -43,6 +43,10 @@ export const FLASH_ERROR_MESSAGES: Record<string, string> = {
   account_not_found: "We couldn't find an account for your sign-in.",
   send_failed:
     "We couldn't send the verification email. Please try again in a moment.",
+  backup_remove_failed:
+    "We couldn't remove that backup email. Please try again in a moment.",
+  revoke_failed:
+    "We couldn't revoke that session. Please try again in a moment.",
   verify_failed:
     'That verification link is no longer valid. Add the backup email again to receive a fresh link.',
   invalid_handle:
@@ -280,15 +284,26 @@ export function createAccountSettingsRouter(
     async (req: Request, res: Response) => {
       const session = res.locals.betterAuthSession
       const email = ((req.body.email as string) || '').trim().toLowerCase()
+      if (!email) {
+        res.redirect(303, '/account?error=invalid_email')
+        return
+      }
       const did = await getDidByEmail(
         session.user.email,
         pdsUrl,
         internalSecret,
       )
-      if (did && email) {
-        ctx.db.removeBackupEmail(did, email)
+      if (!did) {
+        res.redirect(303, '/account?error=account_not_found')
+        return
       }
-      res.redirect(303, '/account?success=backup_removed')
+      try {
+        ctx.db.removeBackupEmail(did, email)
+        res.redirect(303, '/account?success=backup_removed')
+      } catch (err) {
+        logger.error({ err }, 'Failed to remove backup email')
+        res.redirect(303, '/account?error=backup_remove_failed')
+      }
     },
   )
 
@@ -298,17 +313,20 @@ export function createAccountSettingsRouter(
     requireAuth,
     async (req: Request, res: Response) => {
       const tokenToRevoke = req.body.session_token as string
-      if (tokenToRevoke) {
-        try {
-          await auth.api.revokeSession({
-            body: { token: tokenToRevoke },
-            headers: fromNodeHeaders(req.headers),
-          })
-        } catch (err) {
-          logger.warn({ err }, 'Failed to revoke session')
-        }
+      if (!tokenToRevoke) {
+        res.redirect(303, '/account?error=revoke_failed')
+        return
       }
-      res.redirect(303, '/account?success=session_revoked')
+      try {
+        await auth.api.revokeSession({
+          body: { token: tokenToRevoke },
+          headers: fromNodeHeaders(req.headers),
+        })
+        res.redirect(303, '/account?success=session_revoked')
+      } catch (err) {
+        logger.warn({ err }, 'Failed to revoke session')
+        res.redirect(303, '/account?error=revoke_failed')
+      }
     },
   )
 

--- a/packages/auth-service/src/routes/account-settings.ts
+++ b/packages/auth-service/src/routes/account-settings.ts
@@ -502,7 +502,7 @@ export function createAccountSettingsRouter(
   return router
 }
 
-function renderSettingsPage(opts: {
+export function renderSettingsPage(opts: {
   did: string
   email: string
   handleDomain: string

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
       // See AGENTS.md for the ratcheting policy.
       thresholds: {
         statements: 58,
-        branches: 57,
+        branches: 58,
         functions: 71,
         lines: 57,
       },


### PR DESCRIPTION
## Summary

Show accessible success and error banners after account-settings actions so users know whether backup-email removal, handle changes, and session revocation actually completed.

## Changes

- Resolve only whitelisted flash codes into visible messages
- Report success only after the requested operation completes
- Add dedicated failure messages and focused tests
- Document the end-user change with a changeset

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:coverage`


## Screenshots

**Before:** returning to account settings after an action showed no result feedback.

![Before: no account action feedback](https://github.com/user-attachments/assets/6411e34c-56e8-4c79-ad08-4166101ff9a8)

**After:** a clear success banner confirms the completed action.

![After: account-settings success banner](https://github.com/user-attachments/assets/2c14a56e-ffb3-4ddf-8cae-07f2c3bb49d6)

## Notes

- Focused extraction and review of work originally proposed in #165.
- The retained renderer assertions intentionally verify server-rendered accessibility roles and HTML escaping. They are contract/security tests, not checks for client-side implementation fragments.



