### PR TITLE
[HYPER-545] suggest corrections for mistyped email domains

### DIFF
--- a/.changeset/suggest-mistyped-email-domains.md
+++ b/.changeset/suggest-mistyped-email-domains.md
@@ -1,0 +1,9 @@
+---
+'ePDS': minor
+---
+
+Catch likely email-domain typos before sending a sign-in code.
+
+**Affects:** End users
+
+**End users:** addresses one edit away from Gmail, Hotmail, Outlook, Yahoo, or iCloud now show a “Did you mean…?” prompt as soon as they are typed. Accepting replaces the address in the email field; dismissing keeps the original. The prompt never changes or blocks an address silently.

--- a/e2e/step-definitions/email-typo-guard.steps.ts
+++ b/e2e/step-definitions/email-typo-guard.steps.ts
@@ -1,0 +1,193 @@
+import { randomBytes } from 'node:crypto'
+import { Then, When } from '@cucumber/cucumber'
+import { expect, type Request } from '@playwright/test'
+import { testEnv } from '../support/env.js'
+import { getPage } from '../support/utils.js'
+import type { EpdsWorld } from '../support/world.js'
+
+function isOtpSendRequest(request: Request): boolean {
+  const pathname = new URL(request.url()).pathname
+  return (
+    pathname.endsWith('/email-otp/send-verification-otp') ||
+    pathname === '/account/send-otp'
+  )
+}
+
+function requestEmail(request: Request): string | undefined {
+  const body = request.postData()
+  if (!body) return undefined
+
+  try {
+    const parsed = JSON.parse(body) as { email?: unknown }
+    if (typeof parsed.email === 'string') return parsed.email.toLowerCase()
+  } catch {
+    const email = new URLSearchParams(body).get('email')
+    if (email) return email.toLowerCase()
+  }
+  return undefined
+}
+
+function watchOtpSendRequests(world: EpdsWorld): void {
+  const page = getPage(world)
+  world.otpSendRequestCount = 0
+  world.lastOtpRequestEmail = undefined
+  page.on('request', (request) => {
+    if (!isOtpSendRequest(request)) return
+    world.otpSendRequestCount = (world.otpSendRequestCount ?? 0) + 1
+    world.lastOtpRequestEmail = requestEmail(request)
+  })
+}
+
+When(
+  'the user enters an email at {string} that should be {string}',
+  async function (this: EpdsWorld, typoDomain: string, correctDomain: string) {
+    const localPart = `typo-${Date.now()}-${randomBytes(3).toString('hex')}`
+    this.emailTypoOriginal = `${localPart}@${typoDomain}`
+    this.emailTypoSuggestion = `${localPart}@${correctDomain}`
+    watchOtpSendRequests(this)
+
+    const page = getPage(this)
+    await page.locator('#email').fill(this.emailTypoOriginal)
+  },
+)
+
+Then(
+  'the corrected-address suggestion appears before any code request',
+  async function (this: EpdsWorld) {
+    if (!this.emailTypoOriginal || !this.emailTypoSuggestion) {
+      throw new Error('No typo email is available — submit a typo first')
+    }
+
+    const page = getPage(this)
+    const prompt = page.locator('.email-typo-suggestion')
+    await expect(prompt).toBeVisible()
+    await expect(prompt.locator('[role="status"]')).toHaveText(
+      `Did you mean ${this.emailTypoSuggestion}?`,
+    )
+    await expect(prompt).not.toContainText(this.emailTypoOriginal)
+    await expect(prompt.locator('.email-typo-accept')).toHaveText('Yes, fix it')
+    await expect(prompt.locator('.email-typo-action')).toHaveCount(1)
+    await expect(prompt.locator('.email-typo-dismiss')).toHaveAccessibleName(
+      'Dismiss email correction suggestion',
+    )
+    await expect(page.locator('#email')).toHaveValue(this.emailTypoOriginal)
+    expect(this.otpSendRequestCount).toBe(0)
+  },
+)
+
+Then(
+  'the form cannot continue until the user resolves the suggestion',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    const submitButton = page.locator('form:has(#email) button[type="submit"]')
+    await expect(submitButton).toBeDisabled()
+
+    // The disabled button covers pointer users; the capture-phase guard must
+    // also stop implicit keyboard submission while the choice is unresolved.
+    await page.locator('#email').press('Enter')
+    expect(this.otpSendRequestCount).toBe(0)
+    await expect(page.locator('.email-typo-suggestion')).toBeVisible()
+  },
+)
+
+When(
+  'the user accepts the corrected email suggestion',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await page.locator('.email-typo-accept').click()
+  },
+)
+
+When(
+  'the user dismisses the email correction suggestion',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await page.locator('.email-typo-dismiss').click()
+  },
+)
+
+Then(
+  'the corrected address replaces the email and Continue is re-enabled',
+  async function (this: EpdsWorld) {
+    if (!this.emailTypoSuggestion) {
+      throw new Error('No corrected email is available — submit a typo first')
+    }
+    const page = getPage(this)
+    await expect(page.locator('#email')).toHaveValue(this.emailTypoSuggestion)
+    await expect(page.locator('.email-typo-suggestion')).toBeHidden()
+    await expect(
+      page.locator('form:has(#email) button[type="submit"]'),
+    ).toBeEnabled()
+    expect(this.otpSendRequestCount).toBe(0)
+  },
+)
+
+Then(
+  'the original address remains and Continue is re-enabled',
+  async function (this: EpdsWorld) {
+    if (!this.emailTypoOriginal) {
+      throw new Error('No original email is available — submit a typo first')
+    }
+    const page = getPage(this)
+    await expect(page.locator('#email')).toHaveValue(this.emailTypoOriginal)
+    await expect(page.locator('.email-typo-suggestion')).toBeHidden()
+    await expect(
+      page.locator('form:has(#email) button[type="submit"]'),
+    ).toBeEnabled()
+    expect(this.otpSendRequestCount).toBe(0)
+  },
+)
+
+When(
+  'the user continues from the email form',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await page.locator('form:has(#email) button[type="submit"]').click()
+  },
+)
+
+Then(
+  'one code request targets the corrected email address',
+  async function (this: EpdsWorld) {
+    if (!this.emailTypoSuggestion) {
+      throw new Error('No corrected email is available — submit a typo first')
+    }
+    await expect.poll(() => this.otpSendRequestCount).toBe(1)
+    expect(this.lastOtpRequestEmail).toBe(
+      this.emailTypoSuggestion.toLowerCase(),
+    )
+  },
+)
+
+Then(
+  'one code request targets the original email address',
+  async function (this: EpdsWorld) {
+    if (!this.emailTypoOriginal) {
+      throw new Error('No original email is available — submit a typo first')
+    }
+    await expect.poll(() => this.otpSendRequestCount).toBe(1)
+    expect(this.lastOtpRequestEmail).toBe(this.emailTypoOriginal.toLowerCase())
+  },
+)
+
+Then('the email code form is shown', async function (this: EpdsWorld) {
+  const page = getPage(this)
+  const oauthCodeForm = page.locator('#step-otp.active')
+  const accountCodeForm = page.locator('#otp')
+  await expect
+    .poll(
+      async () =>
+        (await oauthCodeForm.isVisible()) ||
+        (await accountCodeForm.isVisible()),
+    )
+    .toBe(true)
+})
+
+When(
+  'the user opens the account settings email sign-in page',
+  async function (this: EpdsWorld) {
+    const page = getPage(this)
+    await page.goto(`${testEnv.authUrl}/account/login`)
+    await expect(page.locator('#email')).toBeVisible()
+  },
+)

--- a/e2e/support/world.ts
+++ b/e2e/support/world.ts
@@ -19,6 +19,18 @@ export class EpdsWorld extends World {
   /** Generated unique email for the current scenario — set by "unique test email" steps. */
   testEmail?: string
 
+  /** Mistyped address entered by an email-domain suggestion scenario. */
+  emailTypoOriginal?: string
+
+  /** Corrected address offered by the email-domain suggestion. */
+  emailTypoSuggestion?: string
+
+  /** Number of code-send requests observed after the typo guard was armed. */
+  otpSendRequestCount?: number
+
+  /** Email in the most recent observed code-send request. */
+  lastOtpRequestEmail?: string
+
   /** Generated unique backup email for backup-email scenarios — set by "unique backup email" steps. */
   backupEmail?: string
 

--- a/features/email-typo-guard.feature
+++ b/features/email-typo-guard.feature
@@ -1,0 +1,46 @@
+Feature: Email-domain typo suggestions
+  A mistyped email domain prevents a user from receiving their sign-in code.
+  Before sending a code, ePDS should suggest an obvious correction while
+  still allowing the user to dismiss the suggestion and keep their address.
+
+  Background:
+    Given the ePDS test environment is running
+    And the demo OAuth client's metadata is discoverable
+
+  @email @email-typo-guard
+  Scenario: OAuth login uses the suggested correction
+    When the demo client initiates an OAuth login via flow 2
+    Then the browser is redirected to the auth service login page
+    When the user enters an email at "gmial.com" that should be "gmail.com"
+    Then the corrected-address suggestion appears before any code request
+    And the form cannot continue until the user resolves the suggestion
+    When the user accepts the corrected email suggestion
+    Then the corrected address replaces the email and Continue is re-enabled
+    When the user continues from the email form
+    Then one code request targets the corrected email address
+    And the email code form is shown
+
+  @email @email-typo-guard
+  Scenario: OAuth login can dismiss the suggestion and keep the original address
+    When the demo client initiates an OAuth login via flow 2
+    Then the browser is redirected to the auth service login page
+    When the user enters an email at "gnail.com" that should be "gmail.com"
+    Then the corrected-address suggestion appears before any code request
+    And the form cannot continue until the user resolves the suggestion
+    When the user dismisses the email correction suggestion
+    Then the original address remains and Continue is re-enabled
+    When the user continues from the email form
+    Then one code request targets the original email address
+    And the email code form is shown
+
+  @account-settings @email-typo-guard
+  Scenario: Account settings login uses the suggested correction
+    When the user opens the account settings email sign-in page
+    And the user enters an email at "hotmal.com" that should be "hotmail.com"
+    Then the corrected-address suggestion appears before any code request
+    And the form cannot continue until the user resolves the suggestion
+    When the user accepts the corrected email suggestion
+    Then the corrected address replaces the email and Continue is re-enabled
+    When the user continues from the email form
+    Then one code request targets the corrected email address
+    And the email code form is shown

--- a/packages/auth-service/src/__tests__/email-typo-guard.test.ts
+++ b/packages/auth-service/src/__tests__/email-typo-guard.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { suggestEmailAddress } from '../lib/email-typo-guard.js'
+
+describe('suggestEmailAddress', () => {
+  it.each([
+    ['person@gnail.com', 'person@gmail.com'],
+    ['person@gmial.com', 'person@gmail.com'],
+    ['person@gmail.coml', 'person@gmail.com'],
+    ['person@hotmal.com', 'person@hotmail.com'],
+    ['person@outlok.com', 'person@outlook.com'],
+    ['person@yaho.com', 'person@yahoo.com'],
+    ['person@iclod.com', 'person@icloud.com'],
+  ])('suggests %s as %s', (email, expected) => {
+    expect(suggestEmailAddress(email)).toBe(expected)
+  })
+
+  it('preserves the local part while normalising the suggested domain', () => {
+    expect(suggestEmailAddress(' First.Last+tag@GMIAL.COM ')).toBe(
+      'First.Last+tag@gmail.com',
+    )
+  })
+
+  it.each([
+    'person@gmail.com',
+    'person@GMAIL.COM',
+    'person@example.com',
+    'person@proton.me',
+    'person@gmx.com',
+    'not-an-email',
+    '@gmial.com',
+    'person@',
+    'person@@gmial.com',
+  ])('does not guess a correction for %s', (email) => {
+    expect(suggestEmailAddress(email)).toBeNull()
+  })
+})

--- a/packages/auth-service/src/lib/email-typo-guard.ts
+++ b/packages/auth-service/src/lib/email-typo-guard.ts
@@ -1,0 +1,251 @@
+const COMMON_EMAIL_DOMAINS = [
+  'gmail.com',
+  'hotmail.com',
+  'outlook.com',
+  'yahoo.com',
+  'icloud.com',
+] as const
+
+/**
+ * Return the optimal-string-alignment distance between two strings.
+ *
+ * Unlike plain Levenshtein distance, one adjacent transposition counts as one
+ * edit, so common mistakes such as `gmial.com` are recognised conservatively.
+ */
+function editDistance(left: string, right: string): number {
+  const rows = left.length + 1
+  const columns = right.length + 1
+  const distance = Array.from({ length: rows }, () =>
+    Array<number>(columns).fill(0),
+  )
+
+  for (let row = 0; row < rows; row += 1) distance[row][0] = row
+  for (let column = 0; column < columns; column += 1) {
+    distance[0][column] = column
+  }
+
+  for (let row = 1; row < rows; row += 1) {
+    for (let column = 1; column < columns; column += 1) {
+      const substitutionCost = left[row - 1] === right[column - 1] ? 0 : 1
+      distance[row][column] = Math.min(
+        distance[row - 1][column] + 1,
+        distance[row][column - 1] + 1,
+        distance[row - 1][column - 1] + substitutionCost,
+      )
+
+      if (
+        row > 1 &&
+        column > 1 &&
+        left[row - 1] === right[column - 2] &&
+        left[row - 2] === right[column - 1]
+      ) {
+        distance[row][column] = Math.min(
+          distance[row][column],
+          distance[row - 2][column - 2] + 1,
+        )
+      }
+    }
+  }
+
+  return distance[left.length][right.length]
+}
+
+/**
+ * Suggest a corrected address when its domain is exactly one edit away from a
+ * common provider. Exact domains and less-certain matches are left untouched.
+ */
+export function suggestEmailAddress(email: string): string | null {
+  const trimmed = email.trim()
+  const at = trimmed.lastIndexOf('@')
+  if (at <= 0 || at !== trimmed.indexOf('@') || at === trimmed.length - 1) {
+    return null
+  }
+
+  const localPart = trimmed.slice(0, at)
+  const domain = trimmed.slice(at + 1).toLowerCase()
+  if (COMMON_EMAIL_DOMAINS.some((candidate) => candidate === domain)) {
+    return null
+  }
+
+  const suggestion = COMMON_EMAIL_DOMAINS.find(
+    (candidate) => editDistance(domain, candidate) === 1,
+  )
+  return suggestion ? `${localPart}@${suggestion}` : null
+}
+
+export const EMAIL_TYPO_GUARD_CSS = `
+.email-typo-suggestion { position: relative; margin: -10px 0 20px; padding: 12px 34px 12px 12px; border: 1px solid var(--email-typo-border, #e4c86a); border-radius: 8px; background: var(--email-typo-bg, #fff8dc); color: var(--email-typo-foreground, #4a3b00); font-size: 14px; line-height: 1.5; text-align: left; }
+.email-typo-suggestion[hidden] { display: none; }
+.email-typo-suggestion p { margin: 0; }
+.email-typo-action { border: 1px solid var(--email-typo-action-border, currentColor); border-radius: 6px; padding: 3px 8px; background: var(--email-typo-action-bg, rgba(255, 255, 255, 0.65)); color: inherit; font: inherit; font-size: 13px; font-weight: 600; line-height: 1.3; cursor: pointer; }
+.email-typo-action:hover { background: var(--email-typo-action-hover-bg, rgba(255, 255, 255, 0.9)); }
+.email-typo-action:focus-visible, .email-typo-dismiss:focus-visible { outline: 2px solid currentColor; outline-offset: 2px; }
+.email-typo-accept { display: inline-block; margin-top: 8px; }
+.email-typo-dismiss { position: absolute; top: 4px; right: 4px; display: flex; width: 24px; height: 24px; align-items: center; justify-content: center; border: 0; border-radius: 3px; padding: 0; background: transparent; color: inherit; font: inherit; font-size: 18px; line-height: 1; opacity: 0.55; cursor: pointer; }
+.email-typo-dismiss:hover { opacity: 0.85; }
+.email-typo-suggestion ~ button[type="submit"]:disabled { opacity: 0.55; cursor: not-allowed; }
+`
+
+export function renderEmailTypoGuardMarkup(): string {
+  return `<div class="email-typo-suggestion" hidden>
+  <button type="button" class="email-typo-dismiss" aria-label="Dismiss email correction suggestion" title="Dismiss">&times;</button>
+  <p role="status" aria-live="polite">Did you mean <strong class="email-typo-correction"></strong>?</p>
+  <button type="button" class="email-typo-action email-typo-accept">Yes, fix it</button>
+</div>`
+}
+
+/**
+ * Render a dependency-free browser guard for one email form.
+ *
+ * Input changes reveal likely corrections immediately. The capture-phase
+ * submit listener remains as defence in depth, so a typo cannot fire an OTP
+ * request until the user accepts or dismisses the suggestion.
+ */
+export function renderEmailTypoGuardScript(
+  formId: string,
+  inputId: string,
+): string {
+  return `<script>
+(function() {
+  var form = document.getElementById(${JSON.stringify(formId)});
+  var input = document.getElementById(${JSON.stringify(inputId)});
+  if (!form || !input) return;
+
+  var commonDomains = ${JSON.stringify(COMMON_EMAIL_DOMAINS)};
+  var prompt = form.querySelector('.email-typo-suggestion');
+  var correctionText = form.querySelector('.email-typo-correction');
+  var acceptButton = form.querySelector('.email-typo-accept');
+  var dismissButton = form.querySelector('.email-typo-dismiss');
+  var submitButton = form.querySelector('button[type="submit"]');
+  if (!prompt || !correctionText || !acceptButton || !dismissButton || !submitButton) return;
+
+  var originalEmail = '';
+  var suggestedEmail = '';
+  var bypassEmail = null;
+  var promptActive = false;
+
+  function editDistance(left, right) {
+    var distance = [];
+    var row;
+    var column;
+    for (row = 0; row <= left.length; row += 1) {
+      distance[row] = [];
+      distance[row][0] = row;
+    }
+    for (column = 0; column <= right.length; column += 1) {
+      distance[0][column] = column;
+    }
+    for (row = 1; row <= left.length; row += 1) {
+      for (column = 1; column <= right.length; column += 1) {
+        var substitutionCost = left.charAt(row - 1) === right.charAt(column - 1) ? 0 : 1;
+        distance[row][column] = Math.min(
+          distance[row - 1][column] + 1,
+          distance[row][column - 1] + 1,
+          distance[row - 1][column - 1] + substitutionCost
+        );
+        if (
+          row > 1 &&
+          column > 1 &&
+          left.charAt(row - 1) === right.charAt(column - 2) &&
+          left.charAt(row - 2) === right.charAt(column - 1)
+        ) {
+          distance[row][column] = Math.min(
+            distance[row][column],
+            distance[row - 2][column - 2] + 1
+          );
+        }
+      }
+    }
+    return distance[left.length][right.length];
+  }
+
+  function suggest(email) {
+    var trimmed = email.trim();
+    var at = trimmed.lastIndexOf('@');
+    if (at <= 0 || at !== trimmed.indexOf('@') || at === trimmed.length - 1) return null;
+    var localPart = trimmed.slice(0, at);
+    var domain = trimmed.slice(at + 1).toLowerCase();
+    for (var i = 0; i < commonDomains.length; i += 1) {
+      if (domain === commonDomains[i]) return null;
+    }
+    for (var j = 0; j < commonDomains.length; j += 1) {
+      if (editDistance(domain, commonDomains[j]) === 1) {
+        return localPart + '@' + commonDomains[j];
+      }
+    }
+    return null;
+  }
+
+  function hidePrompt() {
+    prompt.hidden = true;
+    if (promptActive) submitButton.disabled = false;
+    promptActive = false;
+    correctionText.textContent = '';
+    originalEmail = '';
+    suggestedEmail = '';
+  }
+
+  function showPrompt(email, correction) {
+    originalEmail = email;
+    suggestedEmail = correction;
+    // Reveal the live region before changing its content so assistive
+    // technology can observe and announce the suggestion mutation.
+    prompt.hidden = false;
+    promptActive = true;
+    submitButton.disabled = true;
+    correctionText.textContent = suggestedEmail;
+  }
+
+  function refreshPrompt() {
+    var email = input.value.trim();
+    var correction = suggest(email);
+    if (correction) {
+      showPrompt(email, correction);
+    } else {
+      hidePrompt();
+    }
+  }
+
+  input.addEventListener('input', function() {
+    bypassEmail = null;
+    refreshPrompt();
+  });
+
+  form.addEventListener('submit', function(event) {
+    var email = input.value.trim();
+    if (bypassEmail !== null && email.toLowerCase() === bypassEmail.toLowerCase()) {
+      bypassEmail = null;
+      hidePrompt();
+      return;
+    }
+
+    var correction = suggest(email);
+    if (!correction) {
+      hidePrompt();
+      return;
+    }
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    showPrompt(email, correction);
+    acceptButton.focus();
+  }, true);
+
+  acceptButton.addEventListener('click', function() {
+    var correction = suggestedEmail;
+    input.value = correction;
+    bypassEmail = correction;
+    hidePrompt();
+    input.focus();
+  });
+
+  dismissButton.addEventListener('click', function() {
+    bypassEmail = originalEmail;
+    hidePrompt();
+    input.focus();
+  });
+
+  refreshPrompt();
+})();
+</script>`
+}

--- a/packages/auth-service/src/routes/account-login.ts
+++ b/packages/auth-service/src/routes/account-login.ts
@@ -20,6 +20,11 @@ import type { AuthServiceContext } from '../context.js'
 import { buildOtpInputProps } from '../otp-input.js'
 import type { BetterAuthInstance } from '../better-auth.js'
 import { POWERED_BY_CSS, POWERED_BY_HTML } from '../lib/page-helpers.js'
+import {
+  EMAIL_TYPO_GUARD_CSS,
+  renderEmailTypoGuardMarkup,
+  renderEmailTypoGuardScript,
+} from '../lib/email-typo-guard.js'
 
 const logger = createLogger('auth:account-login')
 
@@ -152,7 +157,7 @@ function renderLoginForm(opts: { csrfToken: string; error?: string }): string {
       <h1>Account Settings</h1>
       <p class="subtitle">Sign in to manage your account</p>
       ${opts.error ? '<p class="error" role="alert">' + escapeHtml(opts.error) + '</p>' : ''}
-      <form method="POST" action="/account/send-otp">
+      <form id="form-account-send-otp" method="POST" action="/account/send-otp">
         <input type="hidden" name="csrf" value="${escapeHtml(opts.csrfToken)}">
         <div class="field">
           <label for="email">Email address</label>
@@ -160,11 +165,13 @@ function renderLoginForm(opts: { csrfToken: string; error?: string }): string {
                  autocomplete="email"
                  placeholder="you@example.com">
         </div>
+        ${renderEmailTypoGuardMarkup()}
         <button type="submit" class="btn-primary">Continue with email</button>
       </form>
     </div>
     ${POWERED_BY_HTML}
   </div>
+  ${renderEmailTypoGuardScript('form-account-send-otp', 'email')}
 </body>
 </html>`
 }
@@ -237,6 +244,7 @@ const CSS = `
   .field label { display: block; font-size: 14px; font-weight: 500; color: #333; margin-bottom: 6px; }
   .field input { width: 100%; padding: 10px 12px; border: 1px solid #ddd; border-radius: 8px; font-size: 16px; outline: none; }
   .field input:focus { border-color: #0f1828; }
+  ${EMAIL_TYPO_GUARD_CSS}
   .otp-input { font-size: 28px !important; text-align: center; font-family: 'SF Mono', Menlo, Consolas, monospace !important; padding: 14px !important; }
   .btn-primary { width: 100%; padding: 12px; background: #0f1828; color: white; border: none; border-radius: 8px; font-size: 16px; font-weight: 500; cursor: pointer; }
   .btn-primary:hover { background: #1a2a40; }

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -54,6 +54,11 @@ import {
 } from '../lib/page-helpers.js'
 import { renderError } from '../lib/render-error.js'
 import {
+  EMAIL_TYPO_GUARD_CSS,
+  renderEmailTypoGuardMarkup,
+  renderEmailTypoGuardScript,
+} from '../lib/email-typo-guard.js'
+import {
   appendOrphanDeviceCookieClearHeaders,
   buildPdsAuthorizeRedirect,
   deriveSharedCookieDomain,
@@ -609,6 +614,7 @@ export function renderLoginPage(opts: {
     .field label { display: block; font-size: 16px; line-height: 24px; font-weight: 600; color: #1A130F; margin-bottom: 8px; }
     .field input { width: 100%; padding: 14px 20px; border: 1px solid var(--input-border); border-radius: 8px; font-size: 16px; outline: none; background: var(--input-bg); transition: border-color 0.15s; }
     .field input:focus { border-color: var(--focus-border); }
+    ${EMAIL_TYPO_GUARD_CSS}
     .otp-boxes { display: flex; gap: 10px; justify-content: center; margin-bottom: 24px; }
     .otp-box { width: 48px; height: 56px; padding: 0; text-align: center; font-size: 24px; font-family: 'SF Mono', Menlo, Consolas, monospace; border: 1px solid var(--input-border); border-radius: 8px; background: var(--input-bg); color: #1A130F; outline: none; transition: border-color 0.15s; }
     .otp-box::placeholder { color: #d4d4d4; }
@@ -670,6 +676,7 @@ export function renderLoginPage(opts: {
                  placeholder="you@example.com"
                  value="${escapeHtml(opts.loginHint)}">
         </div>
+        ${renderEmailTypoGuardMarkup()}
         <button type="submit" class="btn-primary">Continue</button>
       </form>
       ${handleLoginButtonHtml}
@@ -716,6 +723,7 @@ export function renderLoginPage(opts: {
     </a>
   </div>
 
+  ${renderEmailTypoGuardScript('form-send-otp', 'email')}
   <script>
     (function() {
       var authBasePath = ${JSON.stringify(opts.authBasePath)};


### PR DESCRIPTION
## Summary

Prevent obvious email-domain typos from silently sending sign-in codes to unreachable addresses. Before either the OAuth login form or account-settings login sends a code, ePDS now offers a conservative, non-blocking correction for near-misses of Gmail, Hotmail, Outlook, Yahoo, and iCloud.

## Changes

- add a one-edit domain matcher with adjacent-transposition support for cases such as `gmial.com`
- share one dependency-free client-side guard across both email entry points, reacting immediately to input changes
- show only “Did you mean <corrected address>?” with a single “Yes, fix it” action and a subtle dismiss icon; disable Continue until the user accepts, dismisses, or edits
- preserve custom theming through semantic `--email-typo-*` CSS variables
- add unit coverage for observed and representative provider typos
- add behavioral E2E scenarios proving the prompt appears before Continue is pressed, neither submits nor repeats the typo, accepting only updates the field, and dismissing preserves the original address
- add an end-user changeset

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` — 1,084 tests pass
- `pnpm test:coverage` — thresholds pass; the new helper has 100% statement/branch/function/line coverage
- full Cucumber definition dry-run — 61 scenarios / 391 steps defined
- local browser verification of the compact prompt, correction acceptance, dismiss behavior, input values, and Continue state
- deployed Railway E2E — 74 scenarios / 506 steps pass on current SHA `fe3b15c` in [run 30666552929](https://github.com/hypercerts-org/ePDS/actions/runs/30666552929)


## Before and after

The screenshots are embedded in this PR description only; no screenshot binaries are committed to the repository.

### Before

Submitting the plain email form immediately attempted to send a code, even for an obvious provider-domain typo.

![Before: email form without a typo decision](https://files.catbox.moe/hkpnhk.png)

### After

The prompt appears immediately when the typed domain matches, shows only the corrected address, offers one compact **Yes, fix it** mini button, and provides a subtle × to dismiss it and keep the original input. Either action hides the prompt and re-enables **Continue** without submitting.

![After: compact email correction suggestion with a mini fix button and dismiss icon](https://files.catbox.moe/o025ut.png)

## Notes

- Linear: [HYPER-545](https://linear.app/hypercerts/issue/HYPER-545/add-email-typo-guard-at-signup-to-cut-hard-bounces-gmialcom-gnailcom)
- Matching is intentionally limited to one insertion, deletion, substitution, or adjacent transposition from the five configured common domains. Less-certain guesses are ignored.












<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email-domain typo detection for account and OAuth sign-in flows.
  * Users can review suggested corrections, accept them, or dismiss them to keep the original address.
  * Sign-in code requests are blocked until a detected typo is resolved.

* **Bug Fixes**
  * Prevented one-time codes from being sent to mistyped email addresses.
  * Added support for common provider-domain misspellings, including transposed characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





