### PR TITLE
ci(coveralls): add delta tolerance and absolute floor

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_decreased_threshold: 0.05
+coverage_threshold_for_failure: 32.3


### PR DESCRIPTION
Split out of #80, which bundled this CI-policy change with an unrelated one-line security fix (redacting `request_uri` from a warn log). That fix has been waiting since April; separating them lets it land while this is settled on its own merits.

## What it does

Adds `.coveralls.yml`:

```yaml
coverage_decreased_threshold: 0.05
coverage_threshold_for_failure: 32.3
```

Intent: absorb measurement jitter with a 0.05% per-PR drop tolerance, and set a 32.3% absolute floor to stop unbounded ratchet drift.

## ⚠️ These key names are probably wrong

Raised by CodeRabbit on #80. Investigating it produced a more nuanced answer than either of us started with:

**Thresholds *can* be set in `coveralls.yml`.** A Coveralls maintainer says so in [lemurheavy/coveralls-public#1455](https://github.com/lemurheavy/coveralls-public/issues/1455) — so "these are web-UI-only settings" is not correct. But under a **nested** structure:

```yaml
status:
  change_threshold: 5
  api:
    fail_threshold: 90
```

**The keys here match neither that shape nor the API field names** (`commit_status_fail_threshold`, `commit_status_fail_change_threshold`). A GitHub code search finds **zero** other repositories using `coverage_threshold_for_failure` in a `.coveralls.yml`, against a real hit for the nested `change_threshold` form.

The upstream evidence is itself weak: the maintainer offered that snippet untested, and the reporter closed the loop with *"my co-worker just changed the values in the web UI. So I never tested this, sorry"*. The issue was closed on an unverified suggestion.

**Not confirmed either way.** `GET /api/repos/github/hypercerts-org/ePDS` returns 403 without a Coveralls token, and the public `.json` endpoint exposes build data only — no threshold settings. Anyone with the token can settle it by comparing the configured thresholds against this file.

## Before merging

Either confirm the flat keys work, or switch to the nested form and verify. As it stands this file may configure nothing while appearing to set policy — which is worse than not having it, since it invites the belief that thresholds are version-controlled when they are still whatever the web UI says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)