### PR TITLE
fix(auth): gate email sign-in until its handlers are installed

### DIFF
--- a/.changeset/sign-in-button-readiness.md
+++ b/.changeset/sign-in-button-readiness.md
@@ -1,0 +1,9 @@
+---
+'ePDS': patch
+---
+
+The email sign-in button now waits until the page is ready before accepting clicks.
+
+**Affects:** End users
+
+**End users:** tapping Continue before the sign-in page finished loading could start a broken sign-in attempt that silently did nothing. The button is now disabled until the page is ready. Browsers with JavaScript disabled see a message explaining that JavaScript is required to sign in with email, instead of a button that never responds.

--- a/packages/auth-service/src/__tests__/login-page.test.ts
+++ b/packages/auth-service/src/__tests__/login-page.test.ts
@@ -561,6 +561,59 @@ describe('renderLoginPage sign-in error copy', () => {
   })
 })
 
+describe('renderLoginPage email form readiness gate', () => {
+  it('renders the email OTP form without a readiness dataset marker', () => {
+    const html = renderDefault()
+    expect(html).toContain('<form id="form-send-otp">')
+    expect(html).not.toContain('data-epds-login-ready')
+    expect(html).not.toContain('epdsLoginReady')
+  })
+
+  it('renders the email submit button disabled with the existing label', () => {
+    const html = renderDefault()
+    expect(html).toMatch(
+      /<button type="submit" class="btn-primary" disabled>Continue<\/button>/,
+    )
+  })
+
+  it('enables the button after handler setup', () => {
+    const html = renderDefault()
+    // The submit binding is the handler the button actually depends on,
+    // so assert against it directly — anchoring only on the last click
+    // handler would still pass if the submit binding moved below the
+    // enable. The click check stays as a second assertion so the enable
+    // is also pinned as the last thing handler setup does.
+    const submitHandlerIdx = html.indexOf(
+      "sendOtpForm.addEventListener('submit'",
+    )
+    const lastClickHandlerIdx = html.lastIndexOf("addEventListener('click'")
+    const enableIdx = html.indexOf('sendOtpBtn.disabled = false;')
+
+    expect(submitHandlerIdx).toBeGreaterThan(0)
+    expect(lastClickHandlerIdx).toBeGreaterThan(0)
+    expect(enableIdx).toBeGreaterThan(submitHandlerIdx)
+    expect(enableIdx).toBeGreaterThan(lastClickHandlerIdx)
+  })
+
+  it('does not use a blind timer for readiness', () => {
+    const html = renderDefault()
+    // Scoped to the gap between the submit binding and the enable,
+    // rather than the whole page: the page legitimately uses setInterval
+    // elsewhere for the PAR heartbeat. What matters is that the enable is
+    // driven by handler setup completing, not by a timer.
+    const submitHandlerIdx = html.indexOf(
+      "sendOtpForm.addEventListener('submit'",
+    )
+    const enableIdx = html.indexOf('sendOtpBtn.disabled = false;')
+
+    expect(submitHandlerIdx).toBeGreaterThan(0)
+    expect(enableIdx).toBeGreaterThan(submitHandlerIdx)
+    expect(html.slice(submitHandlerIdx, enableIdx)).not.toMatch(
+      /set(?:Timeout|Interval)\s*\(/,
+    )
+  })
+})
+
 describe('renderLoginPage OTP verify-form double-submit latch (regression)', () => {
   it('declares the verifying flag at IIFE scope so input/paste/submit handlers share it', () => {
     const html = renderDefault()

--- a/packages/auth-service/src/routes/login-page.ts
+++ b/packages/auth-service/src/routes/login-page.ts
@@ -708,10 +708,12 @@ export function renderLoginPage(opts: {
              directly under the field that caused it rather than above
              the heading. -->
         <div id="flash-slot-email">${opts.initialStep === 'otp' ? '' : flashRegionHtml}</div>
-        <button type="submit" class="btn-primary">Continue</button>
+        <button type="submit" class="btn-primary" disabled>Continue</button>
       </form>
       ${handleLoginButtonHtml}
     </div>
+
+    <noscript><div class="flash-msg error">JavaScript is required to sign in with email.</div></noscript>
 
     <!-- Step 2: OTP entry (calls better-auth verifyOtp) -->
     <div id="step-otp" class="step-otp${opts.initialStep === 'otp' ? ' active' : ''}">
@@ -775,6 +777,7 @@ export function renderLoginPage(opts: {
       var otpSubtitle = document.getElementById('otp-subtitle');
       var otpEmailInput = document.getElementById('otp-email');
       var atprotoBtn = document.querySelector('.btn-atproto');
+      var sendOtpForm = document.getElementById('form-send-otp');
       var emailInput = document.getElementById('email');
       var emailLabel = document.querySelector('label[for="email"]');
       var sendOtpBtn = document.querySelector('#form-send-otp button[type=submit]');
@@ -1304,7 +1307,7 @@ export function renderLoginPage(opts: {
       }
 
       // Form: send OTP (email mode) or hand off to client (handle mode)
-      document.getElementById('form-send-otp').addEventListener('submit', async function(e) {
+      sendOtpForm.addEventListener('submit', async function(e) {
         e.preventDefault();
         clearError();
         var raw = emailInput.value.trim();
@@ -1489,6 +1492,10 @@ export function renderLoginPage(opts: {
         showEmailStep();
         clearOtpBoxes();
       });
+
+      // Enable only after the submit handler is installed. This avoids a race mostly
+      // seen in fast e2e runs where the button is clicked before JS is ready.
+      sendOtpBtn.disabled = false;
 
       // Pillar 1: If login_hint was provided, the OTP step is already visible
       // server-side — no DOM transition needed.


### PR DESCRIPTION
Split 2 of 4 from #148. Independent of the other three — based directly on `main`, mergeable in any order.

## The bug

The Continue button on the email sign-in form was clickable from first paint, but its submit handler is installed at the end of a long inline script. A click landing in that window did nothing at all: the form had no handler yet, so the sign-in attempt was silently dropped.

Fast e2e runs hit this routinely. Real users on slow connections can too.

## The fix

Ship the button `disabled` and enable it as the last step of handler setup, so it becomes clickable exactly when it starts working.

Also adds a `<noscript>` warning: with scripting off the button would otherwise never respond and never explain why.

## Tests

The tests pin the ordering rather than the mechanism — the enable must follow the submit binding, and must not be driven by a `setTimeout`/`setInterval`. Anchoring on a timer would pass for the wrong reason, and the page legitimately uses `setInterval` elsewhere for the PAR heartbeat, so the timer check is scoped to the gap between binding and enable.

## Verification

`typecheck`, `lint`, `format` clean; 73 test files / 1124 tests pass.

## Series

1. #241 — extract OAuth client-id resolution
2. **#242 ← this PR** — gate email sign-in until handlers are installed
3. #243 — sign `epds_handle_mode` through the callback hop
4. #244 — identify generated-handle accounts by email

🤖 Generated with [Claude Code](https://claude.com/claude-code)
