### PR TITLE
docs(agents): record the Coveralls thresholds and why they can't be in-repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,30 @@ thresholds: {
 **Never lower thresholds.** If a change removes tested code (e.g. deleting
 a feature), add tests for other code to compensate.
 
+### Coveralls Thresholds (Not Version-Controlled)
+
+Coverage is gated twice: by `vitest.config.ts` above, and by Coveralls.
+The two measure different things, so a PR can pass one and fail the other.
+
+Coveralls' thresholds **cannot** be set from a file in this repo. They live
+only on the Coveralls repo Settings page, under "Status Updates":
+
+| Setting                                 | Value | Rationale                                                    |
+| --------------------------------------- | ----- | ------------------------------------------------------------ |
+| Coverage threshold for failure          | 55%   | Backstop below the vitest floors, so vitest trips first      |
+| Coverage decrease threshold for failure | 0.5%  | Catches drift; tolerates rounding noise and honest refactors |
+
+The decrease threshold is the one thing vitest cannot express: vitest checks
+absolute floors only, so nothing else catches a series of small drops.
+
+Do **not** add a `.coveralls.yml` with keys such as
+`coverage_threshold_for_failure` or `coverage_decreased_threshold`. They are
+silently ignored — the docs list no such keys, `coveralls-ruby` parses only
+`repo_token` / `repo_secret_token` / `service_name`, and the
+`coverallsapp/github-action@v2` used in `.github/workflows/ci.yml` neither
+reads the file nor exposes a threshold input. Such a file looks like
+version-controlled policy while configuring nothing.
+
 ## Docker
 
 ```bash


### PR DESCRIPTION
## Why

Coverage is gated twice in this repo — by `vitest.config.ts` and by Coveralls — and only the first is version-controlled. The Coveralls floor and decrease thresholds exist solely on the repo's Coveralls Settings page, so nothing in the tree records what they are, why they were chosen, or how they relate to the vitest floors.

This documents both values next to the ratcheting policy they complement.

## Configured values

| Setting | Value | Rationale |
| --- | --- | --- |
| Coverage threshold for failure | 55% | Backstop below the vitest floors (58/57/71/57), so vitest trips first |
| Coverage decrease threshold for failure | 0.5% | Catches drift; tolerates rounding noise and honest refactors |

The decrease threshold is the one thing vitest cannot express — vitest checks absolute floors only, so nothing else catches a series of small drops.

## Supersedes #240

#240 tried to version-control these as a `.coveralls.yml`. Those keys are silently ignored:

- The Coveralls docs list no such keys — the only documented `.coveralls.yml` key anywhere is `repo_token`.
- `coveralls-ruby`'s `configuration.rb` parses exactly `repo_token`, `repo_secret_token`, and `service_name`.
- Decisively: `.github/workflows/ci.yml` uses `coverallsapp/github-action@v2`, whose documented inputs include no threshold option and no `.coveralls.yml` reading. Its only failure input, `fail-on-error`, governs upload failures, not coverage metrics — so the file never reaches Coveralls at all.

Such a file looks like version-controlled policy while configuring nothing, which is worse than no file. Credit to Copilot for flagging this on #240.

## Testing

Docs-only; no runtime or user-visible change, so no changeset. `prettier --check AGENTS.md` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)